### PR TITLE
fix: use correct model name mapping when import core config

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
@@ -41,10 +41,10 @@ public class AdapterImporter {
             for (Adapter adapter : adapterService.getAll()) {
                 adapterByEndpoint.put(adapter.getBaseEndpoint(), adapter);
             }
-            Set<String> coreEndpoints = coreModels.values()
+            Set<String> coreEndpoints = coreModels.entrySet()
                     .stream()
-                    .filter(coreModel -> coreModel.getEndpoint() != null)
-                    .map(this::mapToAdapterBaseEndpoint)
+                    .filter(e -> e.getValue().getEndpoint() != null)
+                    .map(e -> mapToAdapterBaseEndpoint(e.getKey(), e.getValue()))
                     .collect(Collectors.toSet());
             boolean createAdapterIfAbsent = importOptions.createAdapterIfAbsent();
             List<ImportComponent<Adapter>> result = new ArrayList<>();
@@ -67,9 +67,8 @@ public class AdapterImporter {
         return Collections.emptyList();
     }
 
-    private String mapToAdapterBaseEndpoint(CoreModel coreModel) {
+    private String mapToAdapterBaseEndpoint(String name, CoreModel coreModel) {
         String modelEndpoint = coreModel.getEndpoint();
-        String name = coreModel.getName();
         ModelType type = coreModel.getType();
         return modelEndpointUtils.extractAdapterEndpoint(modelEndpoint, name, type);
     }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
@@ -114,15 +114,15 @@ public class ModelImporter extends RoleBasedImporter {
 
     private Model map(String modelName, CoreModel model, Map<String, CoreRole> roles) {
         model.setName(modelName);
-        Adapter adapter = getAdapterByEndpoint(model);
+        Adapter adapter = getAdapterByEndpoint(modelName, model);
         return modelMapper.mapModel(model, roles, adapter);
     }
 
-    private Adapter getAdapterByEndpoint(CoreModel coreModel) {
+    private Adapter getAdapterByEndpoint(String name, CoreModel coreModel) {
         if (coreModel == null || coreModel.getEndpoint() == null) {
             return null;
         }
-        String adapterEndpoint = modelEndpointUtils.extractAdapterEndpoint(coreModel.getEndpoint(), coreModel.getName(), coreModel.getType());
+        String adapterEndpoint = modelEndpointUtils.extractAdapterEndpoint(coreModel.getEndpoint(), name, coreModel.getType());
         return adapterService.getByEndpoint(adapterEndpoint);
     }
 


### PR DESCRIPTION
### Description of changes

Core config doesn't use field name, name stored as key in models map

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.