### PR TITLE
fix: allow internal service names in upstream endpoint [#9]

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpoint.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpoint.java
@@ -12,7 +12,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Constraint(validatedBy = {})
-@Pattern(regexp = "https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)", message = "Invalid upstream endpoint")
+@Pattern(regexp = "https?://[-a-zA-Z0-9@:%._\\+~#=]{1,256}(\\.[a-zA-Z0-9()]{1,6})?\\b(:[0-9]{1,5})?([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)", message = "Invalid upstream endpoint")
 @Documented
 @Retention(RUNTIME)
 @NotNull

--- a/src/test/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpointTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpointTest.java
@@ -1,0 +1,67 @@
+package com.epam.aidial.cfg.dto.validation.annotation;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+class UpstreamEndpointTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void init() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validEndpoints")
+    void testIsValid_Success(String endpoint) {
+        TestClass testClass = new TestClass(endpoint);
+        Set<ConstraintViolation<TestClass>> violations = validator.validate(testClass);
+        Assertions.assertThat(violations).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidEndpoints")
+    void testIsValid_IsNotValid(String endpoint) {
+        TestClass testClass = new TestClass(endpoint);
+        Set<ConstraintViolation<TestClass>> violations = validator.validate(testClass);
+        Assertions.assertThat(violations).isNotEmpty();
+    }
+
+    private static Stream<Arguments> validEndpoints() {
+        return Stream.of(
+                Arguments.of("http://example.com"),
+                Arguments.of("https://example.com"),
+                Arguments.of("http://localhost:8080"),
+                Arguments.of("http://127.0.0.1:8080"),
+                Arguments.of("http://ai-test:50/"),
+                Arguments.of("http://ai-test:50/api"),
+                Arguments.of("http://ai-test:50/api?param=value"),
+                Arguments.of("http://ai-test/api")
+        );
+    }
+
+    private static Stream<Arguments> invalidEndpoints() {
+        return Stream.of(
+                Arguments.of(""),
+                Arguments.of((String) null),
+                Arguments.of("ftp://example.com"),
+                Arguments.of("example.com"),
+                Arguments.of("http://")
+        );
+    }
+
+    private record TestClass(@UpstreamEndpoint String endpoint) { }
+}


### PR DESCRIPTION
### Applicable issues

- fixes #9 

### Description of changes

1. Made the TLD part optional
2. Added explicit support for port numbers
3. Removed the requirement for "www." prefix
4. Simplified the hostname pattern to allow internal service names

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.