### PR TITLE
feat: name pattern validation for domain models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ This document provides a comprehensive list of all configurable properties in th
 - [Metrics Configuration](#metrics-configuration)
 - [Logging Configuration](#logging-configuration)
 - [Retry Configuration](#retry-configuration)
+- [Validation Configuration](#validation-configuration)
 
 ## AIDIAL Config File Exporter
 
@@ -220,3 +221,9 @@ When using MS_SQL_SERVER we recommend to set case-sensitive, accept-sensitive da
 | Setting | Environment Variable | Default | Description |
 |---------|---------------------|---------|-------------|
 | config.env.tokenizers.json | CONFIG_ENV_TOKENIZERS_JSON | - | Preconfigured DIAL tokenizers list in JSON format |
+
+## Validation Configuration
+
+| Setting | Environment Variable | Default | Description                       |
+|---------|---------------------|---------|-----------------------------------|
+| validation.role.name | ROLE_NAME_VALIDATION_PATTERN | - | Validation pattern for Role name  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,16 @@ When using MS_SQL_SERVER we recommend to set case-sensitive, accept-sensitive da
 
 ## Validation Configuration
 
-| Setting | Environment Variable | Default | Description                       |
-|---------|---------------------|---------|-----------------------------------|
-| validation.role.name | ROLE_NAME_VALIDATION_PATTERN | - | Validation pattern for Role name  |
+| Setting                             | Environment Variable | Default | Description |
+|-------------------------------------|---------------------|---------|-------------|
+| validation.role.name                | ROLE_NAME_VALIDATION_PATTERN | - | Validation pattern for Role name |
+| validation.adapter.name             | ADAPTER_NAME_VALIDATION_PATTERN | - | Validation pattern for Adapter name |
+| validation.addon.name               | ADDON_NAME_VALIDATION_PATTERN | - | Validation pattern for Addon name |
+| validation.application.name         | APPLICATION_NAME_VALIDATION_PATTERN | - | Validation pattern for Application name |
+| validation.assistant.name           | ASSISTANT_NAME_VALIDATION_PATTERN | - | Validation pattern for Assistant name |
+| validation.interceptor.name         | INTERCEPTOR_NAME_VALIDATION_PATTERN | - | Validation pattern for Interceptor name |
+| validation.interceptorRunner.name   | INTERCEPTOR_RUNNER_NAME_VALIDATION_PATTERN | - | Validation pattern for InterceptorRunner name |
+| validation.key.name                 | KEY_NAME_VALIDATION_PATTERN | - | Validation pattern for Key name |
+| validation.model.name               | MODEL_NAME_VALIDATION_PATTERN | - | Validation pattern for Model name |
+| validation.route.name               | ROUTE_NAME_VALIDATION_PATTERN | - | Validation pattern for Route name |
+| validation.applicationTypeSchema.id | APPLICATION_TYPE_SCHEMA_ID_VALIDATION_PATTERN | - | Validation pattern for ApplicationTypeSchema id |

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
@@ -54,6 +54,7 @@ public class AdapterService {
 
     @Transactional
     public void create(Adapter adapter) {
+        adapterValidator.validateAdapterCreation(adapter);
         assertNotExists(adapter.getName());
         Optional.of(adapter)
                 .map(domainModel -> mapper.toEntity(domainModel, new AdapterEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
@@ -3,9 +3,7 @@ package com.epam.aidial.cfg.domain.service;
 import com.epam.aidial.cfg.dao.jpa.AddonJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AddonEntityMapper;
 import com.epam.aidial.cfg.dao.model.AddonEntity;
-import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Addon;
-import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.domain.validator.AddonValidator;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
@@ -48,6 +46,7 @@ public class AddonService {
     @FeatureFlagGate(featureFlag = "addonsSupported")
     @Transactional
     public void createAddon(Addon addon) {
+        addonValidator.validateAddonCreation(addon);
         deploymentService.assertDeploymentNotExists(addon.getDeployment().getName());
         Optional.of(addon)
                 .map(domainAddon -> mapper.toEntity(domainAddon, new AddonEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationTypeSchemaService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationTypeSchemaService.java
@@ -5,9 +5,7 @@ import com.epam.aidial.cfg.dao.jpa.ApplicationTypeSchemaJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.ApplicationTypeSchemaEntityMapper;
 import com.epam.aidial.cfg.dao.model.ApplicationEntity;
 import com.epam.aidial.cfg.dao.model.ApplicationTypeSchemaEntity;
-import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
-import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.domain.validator.ApplicationTypeSchemaValidator;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
@@ -51,6 +49,7 @@ public class ApplicationTypeSchemaService {
 
     @Transactional
     public void create(ApplicationTypeSchema applicationTypeSchema) {
+        applicationTypeSchemaValidator.validateCreation(applicationTypeSchema);
         assertNotExists(applicationTypeSchema.getSchemaId());
         Optional.of(applicationTypeSchema)
                 .map(domainModel -> mapper.toEntity(domainModel, new ApplicationTypeSchemaEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
@@ -2,11 +2,8 @@ package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.AssistantJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AssistantEntityMapper;
-import com.epam.aidial.cfg.dao.model.ApplicationTypeSchemaEntity;
 import com.epam.aidial.cfg.dao.model.AssistantEntity;
-import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Assistant;
-import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.domain.validator.AssistantValidator;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
@@ -49,6 +46,7 @@ public class AssistantService {
     @FeatureFlagGate(featureFlag = "assistantsSupported")
     @Transactional
     public void createAssistant(Assistant assistant) {
+        assistantValidator.validateAssistantCreation(assistant);
         deploymentService.assertDeploymentNotExists(assistant.getDeployment().getName());
         Optional.of(assistant)
                 .map(domainModel -> mapper.toEntity(domainModel, new AssistantEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RoleService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RoleService.java
@@ -50,8 +50,8 @@ public class RoleService {
 
     @Transactional
     public void createRole(Role role) {
-        assertNotExists(role.getName());
         roleValidator.validateRoleCreation(role);
+        assertNotExists(role.getName());
         Optional.of(role)
                 .map(domainModel -> mapper.toEntity(domainModel, new RoleEntity()))
                 .ifPresent(roleJpaRepository::save);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RoleService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RoleService.java
@@ -51,6 +51,7 @@ public class RoleService {
     @Transactional
     public void createRole(Role role) {
         assertNotExists(role.getName());
+        roleValidator.validateRoleCreation(role);
         Optional.of(role)
                 .map(domainModel -> mapper.toEntity(domainModel, new RoleEntity()))
                 .ifPresent(roleJpaRepository::save);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
@@ -2,10 +2,7 @@ package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.RouteJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.RouteEntityMapper;
-import com.epam.aidial.cfg.dao.model.ModelEntity;
-import com.epam.aidial.cfg.dao.model.RoleEntity;
 import com.epam.aidial.cfg.dao.model.RouteEntity;
-import com.epam.aidial.cfg.domain.model.Model;
 import com.epam.aidial.cfg.domain.model.Route;
 import com.epam.aidial.cfg.domain.validator.RouteValidator;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
@@ -47,6 +44,7 @@ public class RouteService {
 
     @Transactional
     public void create(Route route) {
+        routeValidator.validateRouteCreation(route);
         deploymentService.assertDeploymentNotExists(route.getDeployment().getName());
         Optional.of(route)
                 .map(domainModel -> mapper.toEntity(domainModel, new RouteEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
@@ -1,18 +1,36 @@
 package com.epam.aidial.cfg.domain.validator;
 
-import com.epam.aidial.cfg.dao.model.AdapterEntity;
-import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Adapter;
-import com.epam.aidial.cfg.domain.model.Key;
-import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AdapterValidator {
+
+    @Value("${validation.adapter.name:}")
+    private String adapterNameValidationPattern;
+
+    public void validateAdapterCreation(Adapter adapter) {
+        final String adapterName = adapter.getName();
+
+        if (StringUtils.isEmpty(adapterNameValidationPattern)) {
+            log.debug("Adapter name validation pattern is empty, skipping validation for adapter: {}", adapterName);
+            return;
+        }
+
+        if (!Pattern.matches(adapterNameValidationPattern, adapterName)) {
+            throw new IllegalArgumentException("Adapter name '" + adapterName
+                + "' does not match the required pattern: " + adapterNameValidationPattern);
+        }
+    }
 
     public void validateUpdate(String adapterName, Adapter adapter) {
         if (!Objects.equals(adapterName, adapter.getName())) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
@@ -2,13 +2,36 @@ package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Addon;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.regex.Pattern;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AddonValidator {
 
     private final DeploymentValidator deploymentValidator;
+
+    @Value("${validation.addon.name:}")
+    private String addonNameValidationPattern;
+
+    public void validateAddonCreation(Addon addon) {
+        final String addonName = addon.getDeployment().getName();
+
+        if (StringUtils.isEmpty(addonNameValidationPattern)) {
+            log.debug("Addon name validation pattern is empty, skipping validation for addon: {}", addonName);
+            return;
+        }
+
+        if (!Pattern.matches(addonNameValidationPattern, addonName)) {
+            throw new IllegalArgumentException("Addon name '" + addonName
+                + "' does not match the required pattern: " + addonNameValidationPattern);
+        }
+    }
 
     public void validateUpdate(String addonName, Addon addon) {
         deploymentValidator.validateUpdate(addonName, addon.getDeployment(), "Addon");

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
@@ -1,12 +1,34 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 public class ApplicationTypeSchemaValidator {
+
+    @Value("${validation.applicationTypeSchema.id:}")
+    private String applicationTypeSchemaIdValidationPattern;
+
+    public void validateCreation(ApplicationTypeSchema applicationTypeSchema) {
+        final String schemaId = applicationTypeSchema.getSchemaId();
+
+        if (StringUtils.isEmpty(applicationTypeSchemaIdValidationPattern)) {
+            log.debug("ApplicationTypeSchema id validation pattern is empty, skipping validation for schema id: {}", schemaId);
+            return;
+        }
+
+        if (!Pattern.matches(applicationTypeSchemaIdValidationPattern, schemaId)) {
+            throw new IllegalArgumentException("ApplicationTypeSchema ID '" + schemaId
+                + "' does not match the required pattern: " + applicationTypeSchemaIdValidationPattern);
+        }
+    }
 
     public void validateUpdate(String schemaId, ApplicationTypeSchema applicationTypeSchema) {
         if (!Objects.equals(schemaId, applicationTypeSchema.getSchemaId())) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
@@ -2,11 +2,15 @@ package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Application;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ApplicationValidator {
@@ -14,7 +18,11 @@ public class ApplicationValidator {
     private final DisplayFieldsValidator displayFieldsValidator;
     private final DeploymentValidator deploymentValidator;
 
+    @Value("${validation.application.name:}")
+    private String applicationNameValidationPattern;
+
     public void validateCreation(Application application) {
+        validateApplicationName(application);
         displayFieldsValidator.validateDisplayNameDisplayVersion(application.getDisplayName(), application.getDisplayVersion());
         validateEndpointAndApplicationTypeSchemaId(application.getEndpoint(), application.getApplicationTypeSchemaId());
     }
@@ -23,6 +31,20 @@ public class ApplicationValidator {
         deploymentValidator.validateUpdate(applicationName, application.getDeployment(), "Application");
         displayFieldsValidator.validateDisplayNameDisplayVersion(application.getDisplayName(), application.getDisplayVersion());
         validateEndpointAndApplicationTypeSchemaId(application.getEndpoint(), application.getApplicationTypeSchemaId());
+    }
+
+    private void validateApplicationName(Application application) {
+        final String applicationName = application.getDeployment().getName();
+
+        if (StringUtils.isEmpty(applicationNameValidationPattern)) {
+            log.debug("Application name validation pattern is empty, skipping validation for application: {}", applicationName);
+            return;
+        }
+
+        if (!Pattern.matches(applicationNameValidationPattern, applicationName)) {
+            throw new IllegalArgumentException("Application name '" + applicationName
+                + "' does not match the required pattern: " + applicationNameValidationPattern);
+        }
     }
 
     private void validateEndpointAndApplicationTypeSchemaId(String endpoint, URI applicationTypeSchemaId) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
@@ -2,13 +2,36 @@ package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Assistant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.regex.Pattern;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AssistantValidator {
 
     private final DeploymentValidator deploymentValidator;
+
+    @Value("${validation.assistant.name:}")
+    private String assistantNameValidationPattern;
+
+    public void validateAssistantCreation(Assistant assistant) {
+        final String assistantName = assistant.getDeployment().getName();
+
+        if (StringUtils.isEmpty(assistantNameValidationPattern)) {
+            log.debug("Assistant name validation pattern is empty, skipping validation for assistant: {}", assistantName);
+            return;
+        }
+
+        if (!Pattern.matches(assistantNameValidationPattern, assistantName)) {
+            throw new IllegalArgumentException("Assistant name '" + assistantName
+                + "' does not match the required pattern: " + assistantNameValidationPattern);
+        }
+    }
 
     public void validateUpdate(String assistantName, Assistant assistant) {
         deploymentValidator.validateUpdate(assistantName, assistant.getDeployment(), "Assistant");

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
@@ -1,14 +1,23 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.InterceptorRunner;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 public class InterceptorRunnerValidator {
 
+    @Value("${validation.interceptorRunner.name:}")
+    private String interceptorRunnerNameValidationPattern;
+
     public void validateCreation(InterceptorRunner interceptorRunner) {
+        validateInterceptorRunnerName(interceptorRunner);
         validateEndpoints(interceptorRunner.getCompletionEndpoint(), interceptorRunner.getConfigurationEndpoint());
     }
 
@@ -18,6 +27,20 @@ public class InterceptorRunnerValidator {
                 .formatted(interceptorRunnerName, interceptorRunner.getName()));
         }
         validateEndpoints(interceptorRunner.getCompletionEndpoint(), interceptorRunner.getConfigurationEndpoint());
+    }
+    
+    private void validateInterceptorRunnerName(InterceptorRunner interceptorRunner) {
+        final String interceptorRunnerName = interceptorRunner.getName();
+
+        if (StringUtils.isEmpty(interceptorRunnerNameValidationPattern)) {
+            log.debug("InterceptorRunner name validation pattern is empty, skipping validation for interceptor runner: {}", interceptorRunnerName);
+            return;
+        }
+
+        if (!Pattern.matches(interceptorRunnerNameValidationPattern, interceptorRunnerName)) {
+            throw new IllegalArgumentException("InterceptorRunner name '" + interceptorRunnerName
+                + "' does not match the required pattern: " + interceptorRunnerNameValidationPattern);
+        }
     }
 
     private void validateEndpoints(String completionEndpoint, String configurationEndpoint) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
@@ -1,15 +1,23 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Interceptor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 public class InterceptorValidator {
 
+    @Value("${validation.interceptor.name:}")
+    private String interceptorNameValidationPattern;
+
     public void validateCreation(Interceptor interceptor) {
+        validateInterceptorName(interceptor);
         validateInterceptorRunnerAndEndpoint(interceptor);
     }
 
@@ -19,6 +27,20 @@ public class InterceptorValidator {
                 .formatted(interceptorName, interceptor.getName()));
         }
         validateInterceptorRunnerAndEndpoint(interceptor);
+    }
+    
+    private void validateInterceptorName(Interceptor interceptor) {
+        final String interceptorName = interceptor.getName();
+
+        if (StringUtils.isEmpty(interceptorNameValidationPattern)) {
+            log.debug("Interceptor name validation pattern is empty, skipping validation for interceptor: {}", interceptorName);
+            return;
+        }
+
+        if (!Pattern.matches(interceptorNameValidationPattern, interceptorName)) {
+            throw new IllegalArgumentException("Interceptor name '" + interceptorName
+                + "' does not match the required pattern: " + interceptorNameValidationPattern);
+        }
     }
 
     private void validateInterceptorRunnerAndEndpoint(Interceptor interceptor) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
@@ -4,21 +4,45 @@ import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KeyValidator {
 
     private final TransactionTimestampContext transactionTimestampContext;
 
+    @Value("${validation.key.name:}")
+    private String keyNameValidationPattern;
+
     public void validateCreation(Key key) {
+        validateKeyName(key);
+        
         long now = transactionTimestampContext.getTimestamp();
         Long expiresAt = key.getExpiresAt();
         if (expiresAt != null && expiresAt <= now) {
             throw new IllegalArgumentException("Key expiresAt ms: '" + expiresAt + "' should be greater than current epoch ms: '" + now + "'");
+        }
+    }
+
+    private void validateKeyName(Key key) {
+        final String keyName = key.getName();
+
+        if (StringUtils.isEmpty(keyNameValidationPattern)) {
+            log.debug("Key name validation pattern is empty, skipping validation for key: {}", keyName);
+            return;
+        }
+
+        if (!Pattern.matches(keyNameValidationPattern, keyName)) {
+            throw new IllegalArgumentException("Key name '" + keyName
+                + "' does not match the required pattern: " + keyNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
@@ -2,8 +2,14 @@ package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Model;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.regex.Pattern;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ModelValidator {
@@ -11,12 +17,30 @@ public class ModelValidator {
     private final DisplayFieldsValidator displayFieldsValidator;
     private final DeploymentValidator deploymentValidator;
 
+    @Value("${validation.model.name:}")
+    private String modelNameValidationPattern;
+
     public void validateCreation(Model model) {
+        validateModelName(model);
         displayFieldsValidator.validateDisplayNameDisplayVersion(model.getDisplayName(), model.getDisplayVersion());
     }
 
     public void validateUpdate(String modelName, Model model) {
         deploymentValidator.validateUpdate(modelName, model.getDeployment(), "Model");
         displayFieldsValidator.validateDisplayNameDisplayVersion(model.getDisplayName(), model.getDisplayVersion());
+    }
+
+    private void validateModelName(Model model) {
+        final String modelName = model.getDeployment().getName();
+
+        if (StringUtils.isEmpty(modelNameValidationPattern)) {
+            log.debug("Model name validation pattern is empty, skipping validation for model: {}", modelName);
+            return;
+        }
+
+        if (!Pattern.matches(modelNameValidationPattern, modelName)) {
+            throw new IllegalArgumentException("Model name '" + modelName
+                + "' does not match the required pattern: " + modelNameValidationPattern);
+        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
@@ -1,24 +1,46 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Role;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static com.epam.aidial.core.config.CoreRole.DEFAULT_ROLE_NAME;
 
 @Component
+@Slf4j
 public class RoleValidator {
 
-    public void validateRoleDeletion(String roleName) {
-        if (Objects.equals(roleName, DEFAULT_ROLE_NAME)) {
-            throw new IllegalArgumentException(DEFAULT_ROLE_NAME + " role can not be deleted");
+    @Value("${validation.role.name:}")
+    private String roleNameValidationPattern;
+
+    public void validateRoleCreation(Role role) {
+        final String roleName = role.getName();
+
+        if (StringUtils.isEmpty(roleNameValidationPattern)) {
+            log.debug("Role name validation pattern is empty, skipping validation for role: {}", roleName);
+            return;
+        }
+
+        if (!Pattern.matches(roleNameValidationPattern, roleName)) {
+            throw new IllegalArgumentException("Role name '" + roleName
+                + "' does not match the required pattern: " + roleNameValidationPattern);
         }
     }
 
     public void validateRoleUpdate(String roleName, Role role) {
         if (!Objects.equals(roleName, role.getName())) {
             throw new IllegalArgumentException("Role with name: '" + roleName + "' can not be renamed. New role name: '" + role.getName() + "'");
+        }
+    }
+
+    public void validateRoleDeletion(String roleName) {
+        if (Objects.equals(roleName, DEFAULT_ROLE_NAME)) {
+            throw new IllegalArgumentException(DEFAULT_ROLE_NAME + " role can not be deleted");
         }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
@@ -2,13 +2,36 @@ package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Route;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.regex.Pattern;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RouteValidator {
 
     private final DeploymentValidator deploymentValidator;
+    
+    @Value("${validation.route.name:}")
+    private String routeNameValidationPattern;
+    
+    public void validateRouteCreation(Route route) {
+        final String routeName = route.getDeployment().getName();
+
+        if (StringUtils.isEmpty(routeNameValidationPattern)) {
+            log.debug("Route name validation pattern is empty, skipping validation for route: {}", routeName);
+            return;
+        }
+
+        if (!Pattern.matches(routeNameValidationPattern, routeName)) {
+            throw new IllegalArgumentException("Route name '" + routeName
+                + "' does not match the required pattern: " + routeNameValidationPattern);
+        }
+    }
 
     public void validateUpdate(String routeName, Route route) {
         deploymentValidator.validateUpdate(routeName, route.getDeployment(), "Route");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -157,3 +157,13 @@ features.flags.assistantsSupported=${ASSISTANTS_SUPPORTED:false}
 
 # Validation
 validation.role.name=${ROLE_NAME_VALIDATION_PATTERN:}
+validation.adapter.name=${ADAPTER_NAME_VALIDATION_PATTERN:}
+validation.addon.name=${ADDON_NAME_VALIDATION_PATTERN:}
+validation.application.name=${APPLICATION_NAME_VALIDATION_PATTERN:}
+validation.assistant.name=${ASSISTANT_NAME_VALIDATION_PATTERN:}
+validation.interceptor.name=${INTERCEPTOR_NAME_VALIDATION_PATTERN:}
+validation.interceptorRunner.name=${INTERCEPTOR_RUNNER_NAME_VALIDATION_PATTERN:}
+validation.key.name=${KEY_NAME_VALIDATION_PATTERN:}
+validation.model.name=${MODEL_NAME_VALIDATION_PATTERN:}
+validation.route.name=${ROUTE_NAME_VALIDATION_PATTERN:}
+validation.applicationTypeSchema.id=${APPLICATION_TYPE_SCHEMA_ID_VALIDATION_PATTERN:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -154,3 +154,6 @@ config.import.configsMaxCount=${IMPORT_CONFIGS_MAX_COUNT:64}
 
 features.flags.addonsSupported=${ADDONS_SUPPORTED:false}
 features.flags.assistantsSupported=${ASSISTANTS_SUPPORTED:false}
+
+# Validation
+validation.role.name=${ROLE_NAME_VALIDATION_PATTERN:}

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/AddonValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/AddonValidatorTest.java
@@ -4,16 +4,22 @@ import com.epam.aidial.cfg.domain.model.Addon;
 import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.validator.AddonValidator;
 import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AddonValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     @Mock
     private DeploymentValidator deploymentValidator;
@@ -36,6 +42,37 @@ class AddonValidatorTest {
 
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Addon");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateAddonCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(addonValidator, "addonNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Addon addon = new Addon();
+        addon.setDeployment(deployment);
+
+        // when/then
+        Assertions.assertThatNoException().isThrownBy(() -> addonValidator.validateAddonCreation(addon));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateAddonCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(addonValidator, "addonNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Addon addon = new Addon();
+        addon.setDeployment(deployment);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> addonValidator.validateAddonCreation(addon))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationTypeSchemaValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationTypeSchemaValidatorTest.java
@@ -4,11 +4,16 @@ import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
 import com.epam.aidial.cfg.domain.validator.ApplicationTypeSchemaValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ApplicationTypeSchemaValidatorTest {
+
+    private static final String ID_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     private ApplicationTypeSchemaValidator applicationTypeSchemaValidator;
 
@@ -33,6 +38,35 @@ class ApplicationTypeSchemaValidatorTest {
         applicationTypeSchema.setSchemaId("schema_id");
 
         assertThatNoException().isThrownBy(() -> applicationTypeSchemaValidator.validateUpdate("schema_id", applicationTypeSchema));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-id", "valid_id", "ValidId123", "id-123_456", "id.with.dots"})
+    void validateCreation_shouldNotThrowExceptionForValidId(String id) {
+        // given
+        ReflectionTestUtils.setField(applicationTypeSchemaValidator, "applicationTypeSchemaIdValidationPattern", ID_VALIDATION_PATTERN);
+
+        ApplicationTypeSchema schema = new ApplicationTypeSchema();
+        schema.setSchemaId(id);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> applicationTypeSchemaValidator.validateCreation(schema));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid id with spaces", "invalid@id", "invalid#id", "invalid$id", 
+            "id-that-is-way-too-long-for-validation-pattern"})
+    void validateCreation_shouldThrowExceptionForInvalidId(String id) {
+        // given
+        ReflectionTestUtils.setField(applicationTypeSchemaValidator, "applicationTypeSchemaIdValidationPattern", ID_VALIDATION_PATTERN);
+
+        ApplicationTypeSchema schema = new ApplicationTypeSchema();
+        schema.setSchemaId(id);
+
+        // when/then
+        assertThatThrownBy(() -> applicationTypeSchemaValidator.validateCreation(schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationValidatorTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.net.URI;
 
@@ -20,6 +22,8 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     @Mock
     private DisplayFieldsValidator displayFieldsValidator;
@@ -179,5 +183,38 @@ class ApplicationValidatorTest {
         Assertions.assertThatThrownBy(() -> applicationValidator.validateUpdate(deploymentName, application))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Both endpoint: 'test' and application type schema id: 'https://test.com' are specified. Only one of them should be specified");
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(applicationValidator, "applicationNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Application application = new Application();
+        application.setDeployment(deployment);
+        application.setEndpoint("test"); // To avoid other validation errors
+
+        // when/then
+        Assertions.assertThatNoException().isThrownBy(() -> applicationValidator.validateCreation(application));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(applicationValidator, "applicationNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Application application = new Application();
+        application.setDeployment(deployment);
+        application.setEndpoint("test"); // To avoid other validation errors
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/ApplicationValidatorTest.java
@@ -36,6 +36,8 @@ class ApplicationValidatorTest {
         application.setDisplayName("text");
         application.setDisplayVersion("1.0");
         application.setEndpoint("test");
+        Deployment deployment = new Deployment("text");
+        application.setDeployment(deployment);
 
         // when
         applicationValidator.validateCreation(application);
@@ -52,6 +54,8 @@ class ApplicationValidatorTest {
         application.setDisplayName("text");
         application.setDisplayVersion("1.0");
         application.setEndpoint(endpoint);
+        Deployment deployment = new Deployment("text");
+        application.setDeployment(deployment);
 
         // then
         Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))
@@ -73,6 +77,9 @@ class ApplicationValidatorTest {
         application.setEndpoint(endpoint);
         application.setApplicationTypeSchemaId(applicationTypeSchemaId);
 
+        Deployment deployment = new Deployment("text");
+        application.setDeployment(deployment);
+
         // then
         Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -89,6 +96,8 @@ class ApplicationValidatorTest {
         application.setDisplayVersion("1.0");
         application.setEndpoint("test");
         application.setApplicationTypeSchemaId(URI.create("https://test.com"));
+        Deployment deployment = new Deployment("text");
+        application.setDeployment(deployment);
 
         // then
         Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/InterceptorValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/InterceptorValidatorTest.java
@@ -4,11 +4,16 @@ import com.epam.aidial.cfg.domain.model.Interceptor;
 import com.epam.aidial.cfg.domain.validator.InterceptorValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class InterceptorValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     private InterceptorValidator interceptorValidator;
 
@@ -35,6 +40,37 @@ class InterceptorValidatorTest {
         interceptor.setEndpoint("https://test.endpoint.com");
 
         assertThatNoException().isThrownBy(() -> interceptorValidator.validateUpdate("interceptor_name", interceptor));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(interceptorValidator, "interceptorNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName(name);
+        interceptor.setEndpoint("https://test.endpoint.com");
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> interceptorValidator.validateCreation(interceptor));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(interceptorValidator, "interceptorNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName(name);
+        interceptor.setEndpoint("https://test.endpoint.com");
+
+        // when/then
+        assertThatThrownBy(() -> interceptorValidator.validateCreation(interceptor))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/KeyValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/KeyValidatorTest.java
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,6 +20,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class KeyValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     @Mock
     private TransactionTimestampContext transactionTimestampContext;
@@ -85,6 +89,38 @@ class KeyValidatorTest {
         keyEntity.setCreatedAt(2);
 
         assertThatNoException().isThrownBy(() -> keyValidator.validateUpdate("key_name", key, keyEntity));
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(keyValidator, "keyNameValidationPattern", NAME_VALIDATION_PATTERN);
+        when(transactionTimestampContext.getTimestamp()).thenReturn(2L);
+
+        Key key = new Key();
+        key.setName(name);
+        key.setExpiresAt(3L);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> keyValidator.validateCreation(key));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(keyValidator, "keyNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Key key = new Key();
+        key.setName(name);
+        key.setExpiresAt(3L);
+
+        // when/then
+        assertThatThrownBy(() -> keyValidator.validateCreation(key))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/ModelValidatorTest.java
@@ -30,6 +30,8 @@ class ModelValidatorTest {
         Model model = new Model();
         model.setDisplayName("text");
         model.setDisplayVersion("1.0");
+        Deployment deployment = new Deployment("text");
+        model.setDeployment(deployment);
 
         // when
         modelValidator.validateCreation(model);

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/ModelValidatorTest.java
@@ -7,14 +7,21 @@ import com.epam.aidial.cfg.domain.validator.DisplayFieldsValidator;
 import com.epam.aidial.cfg.domain.validator.ModelValidator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ModelValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     @Mock
     private DisplayFieldsValidator displayFieldsValidator;
@@ -58,6 +65,37 @@ class ModelValidatorTest {
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Model");
         verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(modelValidator, "modelNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Model model = new Model();
+        model.setDeployment(deployment);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> modelValidator.validateCreation(model));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(modelValidator, "modelNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Model model = new Model();
+        model.setDeployment(deployment);
+
+        // when/then
+        assertThatThrownBy(() -> modelValidator.validateCreation(model))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/RoleValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/RoleValidatorTest.java
@@ -4,11 +4,16 @@ import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.domain.validator.RoleValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RoleValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     private RoleValidator roleValidator;
 
@@ -45,5 +50,34 @@ class RoleValidatorTest {
         role.setName("role_name");
 
         assertThatNoException().isThrownBy(() -> roleValidator.validateRoleUpdate("role_name", role));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateRoleCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(roleValidator, "roleNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Role role = new Role();
+        role.setName(name);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> roleValidator.validateRoleCreation(role));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateRoleCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(roleValidator, "roleNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Role role = new Role();
+        role.setName(name);
+
+        // when/then
+        assertThatThrownBy(() -> roleValidator.validateRoleCreation(role))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/dao/validator/RouteValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/validator/RouteValidatorTest.java
@@ -6,14 +6,21 @@ import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
 import com.epam.aidial.cfg.domain.validator.RouteValidator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class RouteValidatorTest {
+
+    private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     @Mock
     private DeploymentValidator deploymentValidator;
@@ -36,6 +43,37 @@ class RouteValidatorTest {
 
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Route");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
+    void validateRouteCreation_shouldNotThrowExceptionForValidName(String name) {
+        // given
+        ReflectionTestUtils.setField(routeValidator, "routeNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Route route = new Route();
+        route.setDeployment(deployment);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> routeValidator.validateRouteCreation(route));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+            "name-that-is-way-too-long-for-validation-pattern"})
+    void validateRouteCreation_shouldThrowExceptionForInvalidName(String name) {
+        // given
+        ReflectionTestUtils.setField(routeValidator, "routeNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        Deployment deployment = new Deployment(name);
+        Route route = new Route();
+        route.setDeployment(deployment);
+
+        // when/then
+        assertThatThrownBy(() -> routeValidator.validateRouteCreation(route))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern");
     }
 
 }


### PR DESCRIPTION
### Description of changes

#24 Added pattern validations for name. Patterns are specified as env variables and are absent by default.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.