### PR TITLE
fix!: remove default configMap and kubeSecret export names

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,10 +13,10 @@ config.export.storageType=LOCAL_FILE
 ## LOCAL_FILE output type props
 config.export.outputFile.path=data/export/out.json
 ## CONFIG_MAP output type props
-config.export.configMap.name=core-config-git
+config.export.configMap.name=
 config.export.configMap.key=env.config.json
 ## KUBE_SECRET output type props
-config.export.kubeSecret.name=kube-secret-name
+config.export.kubeSecret.name=
 config.export.kubeSecret.key=kube-secret-key
 ## AIDIAL Config Secret Values File Exporter
 config.export.keyvault.type=${CONFIG_EXPORT_KEYVAULT_TYPE:none}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #25 

### Description of changes

Remove default values for the following properties:

- config.export.configMap.name
- config.export.kubeSecret.name
so that they do not conflict with the following env variables:

- CONFIG_EXPORT_CONFIGMAP_NAMES
- CONFIG_EXPORT_KUBESECRET_NAMES
correspondingly



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.