### PR TITLE
fix: adjust error message when upstream endpoint is missing

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpoint.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpoint.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Pattern(regexp = "https?://[-a-zA-Z0-9@:%._\\+~#=]{1,256}(\\.[a-zA-Z0-9()]{1,6})?\\b(:[0-9]{1,5})?([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)", message = "Invalid upstream endpoint")
 @Documented
 @Retention(RUNTIME)
-@NotNull
+@NotNull(message = "Upstream endpoint must not be null.")
 @Target(FIELD)
 public @interface UpstreamEndpoint {
 

--- a/src/test/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpointTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dto/validation/annotation/UpstreamEndpointTest.java
@@ -6,6 +6,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,6 +39,15 @@ class UpstreamEndpointTest {
         TestClass testClass = new TestClass(endpoint);
         Set<ConstraintViolation<TestClass>> violations = validator.validate(testClass);
         Assertions.assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    void testIsValid_violationHasCorrectMessageWhenEndpointIsNull() {
+        TestClass testClass = new TestClass(null);
+        Set<ConstraintViolation<TestClass>> violations = validator.validate(testClass);
+        Assertions.assertThat(violations).isNotEmpty();
+        ConstraintViolation<TestClass> violation = violations.iterator().next();
+        Assertions.assertThat(violation.getMessage()).isEqualTo("Upstream endpoint must not be null.");
     }
 
     private static Stream<Arguments> validEndpoints() {

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ModelControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ModelControllerTest.java
@@ -117,4 +117,16 @@ class ModelControllerTest extends AbstractControllerNoneSecureTest {
                 .andExpect(jsonPath("$.message").value("roleLimits: The role limits cannot contain the default role name."));
     }
 
+    @Test
+    void testCreateModel_MissingUpstreamEndpoint_ValidationException() throws Exception {
+        var dtoJson = ResourceUtils.readResource("/model_dto_without_upstream_endpoint.json");
+
+        mockMvc.perform(post("/api/v1/models")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(dtoJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.message").value("JSON parse error: endpoint: Upstream endpoint must not be null."));
+    }
+
 }

--- a/src/test/resources/model_dto_without_upstream_endpoint.json
+++ b/src/test/resources/model_dto_without_upstream_endpoint.json
@@ -1,0 +1,61 @@
+{
+  "type": "embedding",
+  "tokenizerModel": "testTokenizerModel",
+  "limits": {
+    "maxPromptTokens": 8192
+  },
+  "pricing": {
+    "unit": "token",
+    "prompt": "0.00000013",
+    "completion": "0.00000001"
+  },
+  "upstreams": [
+    {
+      "key": "test key"
+    },
+    {
+      "endpoint": "https://upstream2.endpoint.test.com/embeddings"
+    }
+  ],
+  "name": "test_model",
+  "adapter": "adapter1",
+  "displayName": "Test Model",
+  "description": "It is a test model",
+  "displayVersion": "1.0.0",
+  "reference": "test_reference",
+  "forwardAuthToken": true,
+  "features": {
+    "rateEndpoint": "https://endpoint.test.com/rate",
+    "tokenizeEndpoint": "https://endpoint.test.com/tokenize",
+    "truncatePromptEndpoint": "https://endpoint.test.com/truncate",
+    "configurationEndpoint": "https://endpoint.test.com/configuration",
+    "systemPromptSupported": true,
+    "toolsSupported": true,
+    "seedSupported": true,
+    "urlAttachmentsSupported": true,
+    "folderAttachmentsSupported": true,
+    "allowResume": true,
+    "accessibleByPerRequestKey": true,
+    "contentPartsSupported": true
+  },
+  "inputAttachmentTypes": [
+    "application/json"
+  ],
+  "maxInputAttachments": 10,
+  "defaults": {
+    "test_key": "test_value"
+  },
+  "interceptors": [
+    "test_interceptor"
+  ],
+  "topics": [
+    "Test Topic"
+  ],
+  "maxRetryAttempts": 10,
+  "roleLimits": {
+    "testRole1": {
+      "minute": "128000",
+      "day": "2000000"
+    }
+  }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #22 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Adjusted validation message when upstream endpoint is missing

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.