### PR TITLE
fix: add configurable default limit for DIAL Core prompts metadata request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,9 @@ dependencies {
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:10.1.42') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('commons-fileupload:commons-fileupload:1.6.0') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,9 +118,10 @@ config.export.keyvault.type=vault
 
 ## DIAL Core Configuration
 
-| Setting | Environment Variable | Default | Description |
-|---------|---------------------|---------|-------------|
+| Setting | Environment Variable | Default        | Description |
+|---------|---------------------|----------------|-------------|
 | core.client.url | CORE_CLIENT_URL | localhost:8081 | URL of the DIAL Core service |
+| core.prompts.metadata.default.limit | CORE_PROMPTS_METADATA_DEFAULT_LIMIT | 256 | Default limit on the number of items in the prompts metadata response from DIAL Core |
 
 ## OpenTelemetry Configuration
 

--- a/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
@@ -31,7 +31,8 @@ public interface PromptClient {
     PromptMetadataDto getPromptsMetadata(
             @PathVariable String path,
             @RequestParam boolean recursive,
-            @RequestParam String token
+            @RequestParam String token,
+            @RequestParam int limit
     );
 
     /**

--- a/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
@@ -12,4 +12,5 @@ public class ResourceMetadataRequestDto {
     private String path;
     @Nullable
     private String nextToken;
+    private Integer limit;
 }

--- a/src/main/java/com/epam/aidial/cfg/mapper/ResourceMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/mapper/ResourceMapper.java
@@ -36,6 +36,7 @@ public interface ResourceMapper {
                 .path(dto.getPath())
                 .recursive(dto.isRecursive())
                 .nextToken(dto.getNextToken())
+                .limit(dto.getLimit())
                 .build();
     }
 

--- a/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
+++ b/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
@@ -13,4 +13,5 @@ public class ResourceMetadataRequest {
     private boolean recursive;
     private String path;
     private String nextToken;
+    private Integer limit;
 }

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
@@ -17,6 +17,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
     private final PromptClient promptClient;
     private final String path;
     private final boolean recursive;
+    private final int limit;
 
     private List<PromptMetadataDto> items = Collections.emptyList();
     private String nextToken = null;
@@ -31,7 +32,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
         }
         firstRequest = false;
 
-        var data = promptClient.getPromptsMetadata(path, recursive, nextToken);
+        var data = promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
         log.debug("New batch of prompt metadata is fetched in iterator: data={}", data);
         items = data.getItems() != null ? data.getItems() : Collections.emptyList();
         nextToken = data.getNextToken();

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
@@ -14,9 +14,9 @@ import com.epam.aidial.cfg.model.PromptNodeInfo;
 import com.epam.aidial.cfg.model.ResourceMetadataRequest;
 import com.epam.aidial.cfg.service.ResourceService;
 import feign.FeignException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,7 +31,6 @@ import static com.epam.aidial.cfg.client.mapper.PromptClientMapper.PROMPTS_PREFI
 @Slf4j
 @Service
 @LogExecution
-@RequiredArgsConstructor
 public class PromptService implements ResourceService {
 
     private static final String BASE_PATH = "public/";
@@ -40,6 +39,20 @@ public class PromptService implements ResourceService {
     private final PromptClientMapper promptClientMapper;
     private final ResourceClient resourceClient;
     private final ResourceClientMapper resourceClientMapper;
+
+    private final int promptsMetadataDefaultLimit;
+
+    public PromptService(PromptClient promptClient,
+                         PromptClientMapper promptClientMapper,
+                         ResourceClient resourceClient,
+                         ResourceClientMapper resourceClientMapper,
+                         @Value("${core.prompts.metadata.default.limit}") int promptsMetadataDefaultLimit) {
+        this.promptClient = promptClient;
+        this.promptClientMapper = promptClientMapper;
+        this.resourceClient = resourceClient;
+        this.resourceClientMapper = resourceClientMapper;
+        this.promptsMetadataDefaultLimit = promptsMetadataDefaultLimit;
+    }
 
     public PromptNodeInfo getPrompts(ResourceMetadataRequest request) {
         var promptsMetadataResponse = getMetadata(request);
@@ -59,12 +72,13 @@ public class PromptService implements ResourceService {
         var recursive = request.isRecursive();
         var nextToken = request.getNextToken();
         var path = request.getPath() != null ? request.getPath() : BASE_PATH;
-        return promptClient.getPromptsMetadata(path, recursive, nextToken);
+        var limit = request.getLimit() != null ? request.getLimit() : promptsMetadataDefaultLimit;
+        return promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
     }
 
     public Prompt getPrompt(String path) {
         var promptDto = promptClient.getPrompt(path);
-        var promptMetadata = promptClient.getPromptsMetadata(path, false, null);
+        var promptMetadata = promptClient.getPromptsMetadata(path, false, null, promptsMetadataDefaultLimit);
         return promptClientMapper.toPrompt(promptDto, promptMetadata);
     }
 
@@ -106,7 +120,7 @@ public class PromptService implements ResourceService {
     }
 
     private Stream<PromptMetadataDto> createStream(String path, boolean recursive) {
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, promptsMetadataDefaultLimit);
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,6 +70,7 @@ gcp.keyvault.projectId: ${GCP_KEY_VAULT_PROJECT_ID}
 
 # DIAL Core
 core.client.url=${CORE_CLIENT_URL:localhost:8081}
+core.prompts.metadata.default.limit=${CORE_PROMPTS_METADATA_DEFAULT_LIMIT:256}
 
 #Opentelemetry
 otel.sdk.disabled=${OTEL_SDK_DISABLED:true}

--- a/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
@@ -24,6 +24,7 @@ class PromptMetadataIteratorTest {
     void testIteration_SinglePage_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var item1 = new PromptMetadataDto();
         item1.setName("item1");
@@ -34,9 +35,9 @@ class PromptMetadataIteratorTest {
         response.setItems(List.of(item1, item2));
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -49,6 +50,7 @@ class PromptMetadataIteratorTest {
     void testIteration_MultiplePages_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 2;
 
         var item1 = new PromptMetadataDto();
         item1.setName("item1");
@@ -64,10 +66,10 @@ class PromptMetadataIteratorTest {
         secondResponse.setItems(List.of(item3));
         secondResponse.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(firstResponse);
-        when(promptClient.getPromptsMetadata(path, recursive, "next-token")).thenReturn(secondResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(firstResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, "next-token", limit)).thenReturn(secondResponse);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -82,14 +84,15 @@ class PromptMetadataIteratorTest {
     void testHasNext_EmptyData_ReturnsFalse() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isFalse();
     }
@@ -98,14 +101,15 @@ class PromptMetadataIteratorTest {
     void testNext_NoMoreElements_ThrowsException() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isFalse();
         assertThatThrownBy(iterator::next)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #34 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added configurable (via `CORE_PROMPTS_METADATA_DEFAULT_LIMIT` env var) default limit for DIAL Core prompts metadata request.
Added `limit` property into `ResourceMetadataRequestDto` so that limit can also be passed from FE. If it's passed, it will be used for DIAL Core prompts metadata request, otherwise default limit will be used.

Original PR: https://github.com/epam/ai-dial-admin-backend/pull/35

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.