### PR TITLE
fix: update shadow gradle plugin dependency

### DIFF
--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -4,14 +4,14 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+        classpath "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
     }
 }
 
 plugins {
     id 'java'
     id 'io.freefair.lombok' version '8.0.1'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '8.3.8'
 }
 
 group 'com.epam.aidial'


### PR DESCRIPTION
### Description of changes

There was a security vulnerability related to commons-io:commons-io@2.11.0, which is a transitive dependency from gradle shadow plugin. Updated it's version & id (ref: https://gradleup.com/shadow/)

Original PR: https://github.com/epam/ai-dial-admin-backend/pull/28

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.