### PR TITLE
fix: increase commons-fileupload transitive dependency version and increase shadow gradle plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,9 @@ dependencies {
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:10.1.42') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('commons-fileupload:commons-fileupload:1.6.0') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }

--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -4,14 +4,14 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+        classpath "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
     }
 }
 
 plugins {
     id 'java'
     id 'io.freefair.lombok' version '8.0.1'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '8.3.8'
 }
 
 group 'com.epam.aidial'


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->

- Increased commons-fileupload transitive dependency version from 1.5 to 1.6.0
- Increased shadow gradle plugin version from 7.1.2 to 8.3.8

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.