### PR TITLE
hotfix!: patch in rls-0.4. increase dependencies versions, add prompts limits, improve default app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Complete list of configuration properties can be found [here](docs/configuration
 
 ### Authentication
 
+**Security is disabled for default configuration. It's highly not recommended to use default configuration 
+for production environment.** 
+
+For production environment:
+- Set `CONFIG_REST_SECURITY_MODE` environment variable with either `oidc` or `basic` value
+- (optional) Set `MS_SQL_SERVER_OPS` environment variable with `encrypt=true;` value if application is launched with sql server.
+
 The system supports two authentication methods:
 
 1. **Basic Authentication** (Default)
@@ -74,7 +81,7 @@ The system supports two authentication methods:
      ```
    - Enable with:
      ```properties
-     config.rest.security=basic
+     config.rest.security.mode=basic
      com.c4-soft.springaddons.oidc.resourceserver.enabled=false
      ```
 
@@ -89,7 +96,7 @@ The system supports two authentication methods:
      ```
    - Enable with:
      ```properties
-     config.rest.security=oidc
+     config.rest.security.mode=oidc
      com.c4-soft.springaddons.oidc.resourceserver.enabled=true
      ```
 
@@ -108,8 +115,58 @@ The system creates an empty configuration. To utilize existing Dial Core configu
 
 ### Run Application with Gradle
 
+#### Run with H2 database
+
 From the project's root directory:
 
+Execute 
+```bash
+python secrets-utils/keys_generator.py
+```
+to get values for 
+- `H2_DATASOURCE_PASSWORD`, 
+- `H2_DATASOURCE_MASTER_KEY`, 
+- `H2_DATASOURCE_ENCRYPTED_FILE_KEY` 
+
+environment variables.
+
+Set those environment variables and execute
+```bash
+./gradlew bootRun
+```
+
+#### Run with POSTGRES database
+
+From the project's root directory:
+
+Execute
+```bash
+cd local_env
+docker-compose up postgres
+```
+to start postgres container.
+
+Set `DATASOURCE_VENDOR=POSTGRES` environment variable to run application with postgres database.
+
+Execute
+```bash
+./gradlew bootRun
+```
+
+#### Run with MS_SQL_SERVER database
+
+From the project's root directory:
+
+Execute
+```bash
+cd local_env
+docker-compose up sqlserver
+```
+to start sqlserver container.
+
+Set `DATASOURCE_VENDOR=MS_SQL_SERVER` environment variable to run application with sql server database.
+
+Execute
 ```bash
 ./gradlew bootRun
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,9 @@ dependencies {
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:10.1.42') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('commons-fileupload:commons-fileupload:1.6.0') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,9 +118,10 @@ config.export.keyvault.type=vault
 
 ## DIAL Core Configuration
 
-| Setting | Environment Variable | Default | Description |
-|---------|---------------------|---------|-------------|
+| Setting | Environment Variable | Default        | Description |
+|---------|---------------------|----------------|-------------|
 | core.client.url | CORE_CLIENT_URL | localhost:8081 | URL of the DIAL Core service |
+| core.prompts.metadata.default.limit | CORE_PROMPTS_METADATA_DEFAULT_LIMIT | 256 | Default limit on the number of items in the prompts metadata response from DIAL Core |
 
 ## OpenTelemetry Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ Additional Kubernetes client configuration options are available from the [Fabri
 
 | Setting | Environment Variable | Default | Description                                                                                 |
 |---------|---------------------|---------|---------------------------------------------------------------------------------------------|
-| config.rest.security.mode | CONFIG_REST_SECURITY_MODE | oidc | Authentication mode (oidc, basic, or none)                                                  |
+| config.rest.security.mode | CONFIG_REST_SECURITY_MODE | none | Authentication mode (oidc, basic, or none)                                                  |
 | config.rest.security.allowedRoles | SECURITY_ALLOWED_ROLES | ConfigAdmin,admin | Comma-separated list of roles with access permissions                                       |
 | config.rest.security.principal-claim | SECURITY_USER_CLAIM | oid | JWT claim name for user identification                                                      |
 | config.rest.security.roles-claim | SECURITY_ROLES_CLAIM | roles | JWT claim name for user roles                                                               |
@@ -166,7 +166,7 @@ config.export.keyvault.type=vault
 |                                | MS_SQL_SERVER_HOST                | localhost                                           | MSSQL Server database host                                                                                                                             |
 |                                | MS_SQL_SERVER_PORT                | 1433                                                | MSSQL Server database port                                                                                                                             |
 |                                | MS_SQL_SERVER_DATABASE            | testdb                                              | MSSQL Server database name                                                                                                                             |
-|                                | MS_SQL_SERVER_OPS                 | encrypt=true;                                       | MSSQL Server database connection options                                                                                                               |
+|                                | MS_SQL_SERVER_OPS                 | encrypt=false;                                      | MSSQL Server database connection options                                                                                                               |
 | sqlserver.datasource.username  | MS_SQL_SERVER_DATASOURCE_USERNAME | sa                                                  | Username for MSSQL Server database access                                                                                                              |
 | sqlserver.datasource.password  | MS_SQL_SERVER_DATASOURCE_PASSWORD | SQLServerPassword1                                  | Password for MSSQL Server database access                                                                                                              |
 | spring.jpa.hibernate.ddl-auto  | SPRING_JPA_HIBERNATE_DDL_AUTO     | validate                                            | Hibernate schema generation strategy                                                                                                                   |

--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -4,14 +4,14 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+        classpath "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
     }
 }
 
 plugins {
     id 'java'
     id 'io.freefair.lombok' version '8.0.1'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '8.3.8'
 }
 
 group 'com.epam.aidial'

--- a/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
@@ -31,7 +31,8 @@ public interface PromptClient {
     PromptMetadataDto getPromptsMetadata(
             @PathVariable String path,
             @RequestParam boolean recursive,
-            @RequestParam String token
+            @RequestParam String token,
+            @RequestParam int limit
     );
 
     /**

--- a/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
@@ -12,4 +12,5 @@ public class ResourceMetadataRequestDto {
     private String path;
     @Nullable
     private String nextToken;
+    private Integer limit;
 }

--- a/src/main/java/com/epam/aidial/cfg/mapper/ResourceMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/mapper/ResourceMapper.java
@@ -36,6 +36,7 @@ public interface ResourceMapper {
                 .path(dto.getPath())
                 .recursive(dto.isRecursive())
                 .nextToken(dto.getNextToken())
+                .limit(dto.getLimit())
                 .build();
     }
 

--- a/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
+++ b/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
@@ -13,4 +13,5 @@ public class ResourceMetadataRequest {
     private boolean recursive;
     private String path;
     private String nextToken;
+    private Integer limit;
 }

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
@@ -17,6 +17,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
     private final PromptClient promptClient;
     private final String path;
     private final boolean recursive;
+    private final int limit;
 
     private List<PromptMetadataDto> items = Collections.emptyList();
     private String nextToken = null;
@@ -31,7 +32,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
         }
         firstRequest = false;
 
-        var data = promptClient.getPromptsMetadata(path, recursive, nextToken);
+        var data = promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
         log.debug("New batch of prompt metadata is fetched in iterator: data={}", data);
         items = data.getItems() != null ? data.getItems() : Collections.emptyList();
         nextToken = data.getNextToken();

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
@@ -14,9 +14,9 @@ import com.epam.aidial.cfg.model.PromptNodeInfo;
 import com.epam.aidial.cfg.model.ResourceMetadataRequest;
 import com.epam.aidial.cfg.service.ResourceService;
 import feign.FeignException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,7 +31,6 @@ import static com.epam.aidial.cfg.client.mapper.PromptClientMapper.PROMPTS_PREFI
 @Slf4j
 @Service
 @LogExecution
-@RequiredArgsConstructor
 public class PromptService implements ResourceService {
 
     private static final String BASE_PATH = "public/";
@@ -40,6 +39,20 @@ public class PromptService implements ResourceService {
     private final PromptClientMapper promptClientMapper;
     private final ResourceClient resourceClient;
     private final ResourceClientMapper resourceClientMapper;
+
+    private final int promptsMetadataDefaultLimit;
+
+    public PromptService(PromptClient promptClient,
+                         PromptClientMapper promptClientMapper,
+                         ResourceClient resourceClient,
+                         ResourceClientMapper resourceClientMapper,
+                         @Value("${core.prompts.metadata.default.limit}") int promptsMetadataDefaultLimit) {
+        this.promptClient = promptClient;
+        this.promptClientMapper = promptClientMapper;
+        this.resourceClient = resourceClient;
+        this.resourceClientMapper = resourceClientMapper;
+        this.promptsMetadataDefaultLimit = promptsMetadataDefaultLimit;
+    }
 
     public PromptNodeInfo getPrompts(ResourceMetadataRequest request) {
         var promptsMetadataResponse = getMetadata(request);
@@ -59,12 +72,13 @@ public class PromptService implements ResourceService {
         var recursive = request.isRecursive();
         var nextToken = request.getNextToken();
         var path = request.getPath() != null ? request.getPath() : BASE_PATH;
-        return promptClient.getPromptsMetadata(path, recursive, nextToken);
+        var limit = request.getLimit() != null ? request.getLimit() : promptsMetadataDefaultLimit;
+        return promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
     }
 
     public Prompt getPrompt(String path) {
         var promptDto = promptClient.getPrompt(path);
-        var promptMetadata = promptClient.getPromptsMetadata(path, false, null);
+        var promptMetadata = promptClient.getPromptsMetadata(path, false, null, promptsMetadataDefaultLimit);
         return promptClientMapper.toPrompt(promptDto, promptMetadata);
     }
 
@@ -106,7 +120,7 @@ public class PromptService implements ResourceService {
     }
 
     private Stream<PromptMetadataDto> createStream(String path, boolean recursive) {
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, promptsMetadataDefaultLimit);
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/web/security/IssuerToDecoderMapFactory.java
+++ b/src/main/java/com/epam/aidial/cfg/web/security/IssuerToDecoderMapFactory.java
@@ -1,12 +1,11 @@
 package com.epam.aidial.cfg.web.security;
 
 import jakarta.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import org.springframework.stereotype.Component;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -15,21 +14,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-@Component
+@RequiredArgsConstructor
 public class IssuerToDecoderMapFactory {
 
     private static final String AUDIENCE_PREFIX = "api://";
     private static final String V1_ISSUER_FORMAT = "https://%s/%s/";
     private static final String V2_ISSUER_FORMAT = "https://%s/%s/v2.0/";
 
-    @Value("${config.rest.security.accepted-issuers}")
-    protected String[] acceptedIssuers;
-
-    @Value("${config.rest.security.accepted-audiences}")
-    protected String[] acceptedAudiences;
-
-    @Value("${config.rest.security.accepted-issuers-aliases}")
-    private String[] acceptedIssuersAliases;
+    private final String[] acceptedIssuers;
+    private final String[] acceptedAudiences;
+    private final String[] acceptedIssuersAliases;
 
     @NotNull
     public Map<String, JwtDecoder> createIssuerToDecoderMap(final NimbusJwtDecoder jwtDecoder) {

--- a/src/main/java/com/epam/aidial/cfg/web/security/JwtAuthenticationConverterFactory.java
+++ b/src/main/java/com/epam/aidial/cfg/web/security/JwtAuthenticationConverterFactory.java
@@ -1,18 +1,14 @@
 package com.epam.aidial.cfg.web.security;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
-import org.springframework.stereotype.Component;
 
-@Component
+@RequiredArgsConstructor
 public class JwtAuthenticationConverterFactory {
 
-    @Value("${config.rest.security.roles-claim}")
-    private String rolesClaim;
-
-    @Value("${config.rest.security.principal-claim}")
-    private String principalClaim;
+    private final String rolesClaim;
+    private final String principalClaim;
 
     public JwtAuthenticationConverter create() {
         final var grantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();

--- a/src/main/java/com/epam/aidial/cfg/web/security/SecurityConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/web/security/SecurityConfiguration.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.web.security;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +15,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true)
 @ConditionalOnProperty(value = "config.rest.security.mode", havingValue = "oidc", matchIfMissing = true)
@@ -28,14 +27,29 @@ public class SecurityConfiguration {
     @Value("${config.rest.security.disable-swagger-authorization}")
     protected boolean disableSwaggerAuthorization;
 
-    @Autowired
-    private TokenDecoderFactory tokenDecoderFactory;
-
-    @Autowired
-    private JwtAuthenticationConverterFactory jwtAuthenticationConverterFactory;
+    @Bean
+    public JwtAuthenticationConverterFactory jwtAuthenticationConverterFactory(@Value("${config.rest.security.roles-claim}") String rolesClaim,
+                                                                               @Value("${config.rest.security.principal-claim}") String principalClaim) {
+        return new JwtAuthenticationConverterFactory(rolesClaim, principalClaim);
+    }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public IssuerToDecoderMapFactory issuerToDecoderMapFactory(@Value("${config.rest.security.accepted-issuers}") String[] acceptedIssuers,
+                                                               @Value("${config.rest.security.accepted-audiences}") String[] acceptedAudiences,
+                                                               @Value("${config.rest.security.accepted-issuers-aliases}") String[] acceptedIssuersAliases) {
+        return new IssuerToDecoderMapFactory(acceptedIssuers, acceptedAudiences, acceptedIssuersAliases);
+    }
+
+    @Bean
+    public TokenDecoderFactory tokenDecoderFactory(@Value("${config.rest.security.jwk-key-uris}") String[] keySetUris,
+                                                   IssuerToDecoderMapFactory issuerToDecoderMapFactory) {
+        return new TokenDecoderFactoryImpl(keySetUris, issuerToDecoderMapFactory);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   TokenDecoderFactory tokenDecoderFactory,
+                                                   JwtAuthenticationConverterFactory jwtAuthenticationConverterFactory) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(publicPathPatterns()).permitAll()

--- a/src/main/java/com/epam/aidial/cfg/web/security/TokenDecoderFactoryImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/web/security/TokenDecoderFactoryImpl.java
@@ -1,21 +1,16 @@
 package com.epam.aidial.cfg.web.security;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 
-@Component
+@RequiredArgsConstructor
 public class TokenDecoderFactoryImpl implements TokenDecoderFactory {
 
-    @Value("${config.rest.security.jwk-key-uris}")
-    protected String[] keySetUris;
-
-    @Autowired
-    private IssuerToDecoderMapFactory issuerToDecoderMapFactory;
+    private final String[] keySetUris;
+    private final IssuerToDecoderMapFactory issuerToDecoderMapFactory;
 
     public JwtDecoder createJwtDecoder() {
         final var issuerToDecoderMap = new HashMap<String, JwtDecoder>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,7 +48,7 @@ kubernetes-config.client.withWatchReconnectLimit=16
 server.port=8080
 
 # Security
-config.rest.security.mode=${CONFIG_REST_SECURITY_MODE:oidc}
+config.rest.security.mode=${CONFIG_REST_SECURITY_MODE:none}
 config.rest.security.allowedRoles=${SECURITY_ALLOWED_ROLES:ConfigAdmin,admin}
 config.rest.security.principal-claim=${SECURITY_USER_CLAIM:oid}
 config.rest.security.roles-claim=${SECURITY_ROLES_CLAIM:roles}
@@ -106,7 +106,7 @@ postgres.datasource.driver-class-name=org.postgresql.Driver
 postgres.datasource.username=${POSTGRES_DATASOURCE_USERNAME:postgres}
 postgres.datasource.password=${POSTGRES_DATASOURCE_PASSWORD:postgres}
 
-sqlserver.datasource.url=jdbc:sqlserver://${MS_SQL_SERVER_HOST:localhost}:${MS_SQL_SERVER_PORT:1433};database=${MS_SQL_SERVER_DATABASE:testdb};${MS_SQL_SERVER_OPS:encrypt=true;}
+sqlserver.datasource.url=jdbc:sqlserver://${MS_SQL_SERVER_HOST:localhost}:${MS_SQL_SERVER_PORT:1433};database=${MS_SQL_SERVER_DATABASE:testdb};${MS_SQL_SERVER_OPS:encrypt=false;}
 sqlserver.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 sqlserver.datasource.username=${MS_SQL_SERVER_DATASOURCE_USERNAME:sa}
 sqlserver.datasource.password=${MS_SQL_SERVER_DATASOURCE_PASSWORD:SQLServerPassword1}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,6 +70,7 @@ gcp.keyvault.projectId: ${GCP_KEY_VAULT_PROJECT_ID}
 
 # DIAL Core
 core.client.url=${CORE_CLIENT_URL:localhost:8081}
+core.prompts.metadata.default.limit=${CORE_PROMPTS_METADATA_DEFAULT_LIMIT:256}
 
 #Opentelemetry
 otel.sdk.disabled=${OTEL_SDK_DISABLED:true}

--- a/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
@@ -24,6 +24,7 @@ class PromptMetadataIteratorTest {
     void testIteration_SinglePage_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var item1 = new PromptMetadataDto();
         item1.setName("item1");
@@ -34,9 +35,9 @@ class PromptMetadataIteratorTest {
         response.setItems(List.of(item1, item2));
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -49,6 +50,7 @@ class PromptMetadataIteratorTest {
     void testIteration_MultiplePages_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 2;
 
         var item1 = new PromptMetadataDto();
         item1.setName("item1");
@@ -64,10 +66,10 @@ class PromptMetadataIteratorTest {
         secondResponse.setItems(List.of(item3));
         secondResponse.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(firstResponse);
-        when(promptClient.getPromptsMetadata(path, recursive, "next-token")).thenReturn(secondResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(firstResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, "next-token", limit)).thenReturn(secondResponse);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -82,14 +84,15 @@ class PromptMetadataIteratorTest {
     void testHasNext_EmptyData_ReturnsFalse() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isFalse();
     }
@@ -98,14 +101,15 @@ class PromptMetadataIteratorTest {
     void testNext_NoMoreElements_ThrowsException() {
         String path = "test-path";
         boolean recursive = true;
+        int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
 
         assertThat(iterator.hasNext()).isFalse();
         assertThatThrownBy(iterator::next)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #34 , #30

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Added configurable (via `CORE_PROMPTS_METADATA_DEFAULT_LIMIT` env var) default limit for DIAL Core prompts metadata request.
- Added `limit` property into `ResourceMetadataRequestDto` so that limit can also be passed from FE. If it's passed, it will be used for DIAL Core prompts metadata request, otherwise default limit will be used.
- Improved default application configuration, so that only few environment variables are required to be set.
- Refactored SecurityConfiguration in order to not create redundant beans in case security mode is `none`.
- Increased commons-fileupload transitive dependency version from 1.5 to 1.6.0
- Increased shadow gradle plugin version from 7.1.2 to 8.3.8

BREAKING CHANGES: 

- `CONFIG_REST_SECURITY_MODE` env var default value changed from `oidc` to `none`, 
- `MS_SQL_SERVER_OPS` env var default value changed from `encrypt=true;` to `encrypt=false;`

Original PRs: https://github.com/epam/ai-dial-admin-backend/pull/35, https://github.com/epam/ai-dial-admin-backend/pull/33, https://github.com/epam/ai-dial-admin-backend/pull/28

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.