### PR TITLE
fix: resolve adapter from adapters with same base endpoint

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/jpa/AdapterJpaRepository.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/jpa/AdapterJpaRepository.java
@@ -7,11 +7,10 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface AdapterJpaRepository extends CrudRepository<AdapterEntity, String> {
 
-    Optional<AdapterEntity> findByBaseEndpoint(String endpoint);
+    Iterable<AdapterEntity> findByBaseEndpointOrderByNameAsc(String endpoint);
 
     @Query("DELETE FROM AdapterEntity a WHERE a.name NOT IN :names")
     @Modifying

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
@@ -10,6 +10,8 @@ import com.epam.aidial.cfg.domain.validator.AdapterValidator;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.IterableUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ import java.util.stream.StreamSupport;
 @Service("coreAdapterService")
 @RequiredArgsConstructor
 @LogExecution
+@Slf4j
 public class AdapterService {
 
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Adapter with name %s does not exist";
@@ -47,7 +50,8 @@ public class AdapterService {
     @Transactional(readOnly = true)
     public Adapter getByEndpoint(String adapterEndpoint) {
         return Optional.ofNullable(adapterEndpoint)
-                .flatMap(adapterJpaRepository::findByBaseEndpoint)
+                .map(adapterJpaRepository::findByBaseEndpointOrderByNameAsc)
+                .map(this::resolveAdapterFromAdaptersWithSameBaseEndpoint)
                 .map(mapper::toDomain)
                 .orElseThrow(() -> new EntityNotFoundException("Adapter with endpoint %s does not exist".formatted(adapterEndpoint)));
     }
@@ -109,5 +113,16 @@ public class AdapterService {
         if (adapterJpaRepository.existsById(name)) {
             throw new EntityAlreadyExistsException("Adapter with name " + name + " already exists");
         }
+    }
+
+    // Such resolution is temporary and will be removed once there is an option for user to resolve
+    // conflict on UI
+    private AdapterEntity resolveAdapterFromAdaptersWithSameBaseEndpoint(Iterable<AdapterEntity> adapters) {
+        if (IterableUtils.isEmpty(adapters)) {
+            return null;
+        }
+
+        log.warn("Found several adapters with same base endpoint: {}. Will use the first one", adapters);
+        return IterableUtils.first(adapters);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -693,6 +693,45 @@ public abstract class ConfigTransferFunctionalTest {
         Assertions.assertThat(adapterNames).containsAll(Set.of(models.get("testModel1").getAdapter(), models.get("testModel2").getAdapter()));
     }
 
+    @Test
+    void testImport_ImportModelWithAdapterConflictingByBaseEndpoint() throws IOException {
+        // given
+        AdapterDto adapterDto1 = new AdapterDto();
+        adapterDto1.setName("adapter1");
+        adapterDto1.setBaseEndpoint("http://endpoint1/");
+
+        AdapterDto adapterDto2 = new AdapterDto();
+        adapterDto2.setName("adapter2");
+        adapterDto2.setBaseEndpoint("http://endpoint1/");
+
+        AdapterDto adapterDto3 = new AdapterDto();
+        adapterDto3.setName("adapter3");
+        adapterDto3.setBaseEndpoint("http://endpoint2/");
+
+        adapterFacade.createAdapter(adapterDto1);
+        adapterFacade.createAdapter(adapterDto2);
+        adapterFacade.createAdapter(adapterDto3);
+
+        String config = FileUtils.readFileToString(new File("src/test/resources/import/import_modelWithAdapter.json"), StandardCharsets.UTF_8);
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.json",
+                "application/json",
+                config.getBytes()
+        );
+
+        // when
+        configTransfer.importConfig(List.of(mockFile), overrideAndCreateRoleAndCreateNew());
+
+        // then
+        Map<String, ModelDto> models = modelFacade.getAll().stream()
+                .collect(Collectors.toMap(ModelDto::getName, Function.identity()));
+        String model1AdapterName = models.get("testModel1").getAdapter();
+        String model2AdapterName = models.get("testModel2").getAdapter();
+        Assertions.assertThat(model1AdapterName).isEqualTo("adapter1");
+        Assertions.assertThat(model2AdapterName).isEqualTo("adapter3");
+    }
+
     private static Stream<Arguments> addSecrets() {
         return Stream.of(
                 Arguments.of(false, null),


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #36

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added adapter resolution for adapters which have the same `base_endpoint`: namely the first one from the adapters ordered by name in ascending order will be used.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.