### PR TITLE
fix: log that multiple adapters with same endpoint are found only when multiple are really found

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
@@ -122,7 +122,10 @@ public class AdapterService {
             return null;
         }
 
-        log.warn("Found several adapters with same base endpoint: {}. Will use the first one", adapters);
+        if (IterableUtils.size(adapters) != 1) {
+            log.warn("Found multiple adapters with same base endpoint: {}. Will use the first one", adapters);
+        }
+
         return IterableUtils.first(adapters);
     }
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #36

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Minor adjustment of logging message
- Log now printed only in case when multiple adapters with same endpoint are found, not at least one found as it was before

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.