### PR TITLE
fix: make tomcat maxPartCount property configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ Additional Kubernetes client configuration options are available from the [Fabri
 | server.port | SERVER_PORT | 8080 | Port number for the web server |
 | server.tomcat.accesslog.pattern | SERVER_TOMCAT_ACCESSLOG_PATTERN | "request: method=%m uri=\"%U\" response: statuscode=%s bytes=%b duration=%D(ms) client: remoteip=%a user=%u useragent=\"%{User-Agent}i\"" | Pattern for Tomcat access logs |
 | server.tomcat.accesslog.enabled | TOMCAT_ACCESSLOG_ENABLED | false | Enable or disable Tomcat access logging |
-| server.tomcat.maxPartCount | SERVER_TOMCAT_MAX_PART_COUNT | -1 | Maximum total number of parts permitted in a multipart/form-data request. Requests that exceed this limit will be rejected. A value of less than 0 means no limit. |
+| server.tomcat.maxPartCount | SERVER_TOMCAT_MAX_PART_COUNT | 64 | Maximum total number of parts permitted in a multipart/form-data request. Requests that exceed this limit will be rejected. A value of less than 0 means no limit. |
 
 ## Security Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ Additional Kubernetes client configuration options are available from the [Fabri
 | server.port | SERVER_PORT | 8080 | Port number for the web server |
 | server.tomcat.accesslog.pattern | SERVER_TOMCAT_ACCESSLOG_PATTERN | "request: method=%m uri=\"%U\" response: statuscode=%s bytes=%b duration=%D(ms) client: remoteip=%a user=%u useragent=\"%{User-Agent}i\"" | Pattern for Tomcat access logs |
 | server.tomcat.accesslog.enabled | TOMCAT_ACCESSLOG_ENABLED | false | Enable or disable Tomcat access logging |
+| server.tomcat.maxPartCount | SERVER_TOMCAT_MAX_PART_COUNT | -1 | Maximum total number of parts permitted in a multipart/form-data request. Requests that exceed this limit will be rejected. A value of less than 0 means no limit. |
 
 ## Security Configuration
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,7 @@ kubernetes-config.client.withWatchReconnectLimit=16
 
 # Web-Server
 server.port=8080
+server.tomcat.maxPartCount=${SERVER_TOMCAT_MAX_PART_COUNT:-1}
 
 # Security
 config.rest.security.mode=${CONFIG_REST_SECURITY_MODE:none}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,7 +46,7 @@ kubernetes-config.client.withWatchReconnectLimit=16
 
 # Web-Server
 server.port=8080
-server.tomcat.maxPartCount=${SERVER_TOMCAT_MAX_PART_COUNT:-1}
+server.tomcat.maxPartCount=${SERVER_TOMCAT_MAX_PART_COUNT:64}
 
 # Security
 config.rest.security.mode=${CONFIG_REST_SECURITY_MODE:none}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #59

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Tomcat `maxPartCount` property becomes configurable with 64 by default.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.