### PR TITLE
fix: increase nimbus-jose-jwt transitive dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,9 @@ dependencies {
         implementation ('commons-fileupload:commons-fileupload:1.6.0') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('com.nimbusds:nimbus-jose-jwt:10.3.1') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Increased `com.nimbusds:nimbus-jose-jwt` transitive dependency version from `9.40` to `10.3.1`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.