### PR TITLE
fix: increase commons-lang3 transitive dependency version in expressions-parser module

### DIFF
--- a/expressions-parser/build.gradle
+++ b/expressions-parser/build.gradle
@@ -29,6 +29,12 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.36'
 
     testImplementation 'junit:junit:4.13.2'
+
+    constraints {
+        implementation ('org.apache.commons:commons-lang3:3.18.0') {
+            because("previous versions have vulnerabilities")
+        }
+    }
 }
 
 generateGrammarSource {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Increased `org.apache.commons:commons-lang3` transitive dependency version from `3.17.0` to `3.18.0` in `expressions-parser` module

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.