### PR TITLE
fix: increase commons-lang3 transitive dependency version for checkstyle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,9 @@ dependencies {
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }
+        checkstyle ('org.apache.commons:commons-lang3:3.18.0') {
+            because("previous versions have vulnerabilities")
+        }
     }
 }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Increased `org.apache.commons:commons-lang3` transitive dependency version from `3.8.1` to `3.18.0` for checkstyle plugin

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.