### PR TITLE
fix: add 'org.apache.commons:commons-lang3:3.18.0' dependency constraint for buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    dependencies {
+        constraints {
+            classpath ('org.apache.commons:commons-lang3:3.18.0') {
+                because("previous versions have vulnerabilities")
+            }
+        }
+    }
+}
+
 plugins {
     id "java"
     id 'checkstyle'


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added org.apache.commons:commons-lang3:3.18.0 dependency constraint for buildscript

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.