### PR TITLE
fix: fix import preview for non-existing adapters, add "createAdapterIfAbsent" request param to import preview endpoint to align with import endpoint

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
@@ -139,16 +139,16 @@ public class ConfigTransfer {
 
     @Transactional(readOnly = true)
     public ImportConfigPreview importPreview(List<MultipartFile> files,
-                                             ConflictResolutionPolicy resolutionPolicy) {
+                                             ConfigImportOptions importOptions) {
         try {
+            ConflictResolutionPolicy resolutionPolicy = importOptions.conflictResolutionPolicy();
             Config config = readAndMergeConfig(files);
             var roles = roleImporter.preview(config.getRoles(), resolutionPolicy);
             var keys = keyImporter.importKeys(config.getKeys(), resolutionPolicy, true);
             var interceptors = interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, true);
             var applicationRunners = applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, true);
-            ConfigImportOptions importOptions = createConfigImportOptions(resolutionPolicy);
             var adapters = adapterImporter.importAdapters(config.getModels(), importOptions, true);
-            var models = modelImporter.importModels(config.getModels(), config.getRoles(), importOptions, true);
+            var models = modelImporter.importModels(config.getModels(), config.getRoles(), importOptions, adapters, true);
             var addons = addonTransfer.importAddons(config.getAddons(), config.getRoles(), importOptions, true);
             var applications = applicationImporter.importApplications(config.getApplications(), config.getRoles(), importOptions, true);
             var routes = routeImporter.importRoutes(config.getRoutes(), config.getRoles(), importOptions, true);
@@ -166,7 +166,7 @@ public class ConfigTransfer {
                     .assistants(assistants)
                     .build();
         } catch (Exception exception) {
-            log.warn("Failed to import config. Conflict resolution policy: {}. Error: {}", resolutionPolicy, exception);
+            log.warn("Failed to import config. Config import options: {}. Error: {}", importOptions, exception);
             throw exception;
         }
 
@@ -240,7 +240,7 @@ public class ConfigTransfer {
             interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, false);
             applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, false);
             adapterImporter.importAdapters(config.getModels(), importOptions, false);
-            modelImporter.importModels(config.getModels(), config.getRoles(), importOptions, false);
+            modelImporter.importModels(config.getModels(), config.getRoles(), importOptions, List.of(), false);
             addonTransfer.importAddons(config.getAddons(), config.getRoles(), importOptions, false);
             applicationImporter.importApplications(config.getApplications(), config.getRoles(), importOptions, false);
             routeImporter.importRoutes(config.getRoutes(), config.getRoles(), importOptions, false);

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
@@ -52,10 +52,12 @@ public class AdapterImporter {
                 if (!adapterByEndpoint.containsKey(endpoint)) {
                     if (createAdapterIfAbsent) {
                         Adapter adapter = new Adapter();
-                        adapter.setName(UUID.randomUUID().toString());
                         adapter.setBaseEndpoint(endpoint);
                         if (!isPreview) {
+                            adapter.setName(UUID.randomUUID().toString());
                             adapterService.create(adapter);
+                        } else {
+                            adapter.setName("<will be defined during import>");
                         }
                         result.add(new ImportComponent<>(ImportAction.CREATE, adapter));
                     } else {

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
@@ -17,12 +17,12 @@ import com.epam.aidial.core.config.CoreModel;
 import com.epam.aidial.core.config.CoreRole;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.epam.aidial.cfg.domain.model.ImportAction.CREATE;
@@ -151,13 +151,12 @@ public class ModelImporter extends RoleBasedImporter {
             return adapterService.getByEndpoint(adapterEndpoint);
         }
 
-        Map<String, Adapter> adaptersToCreateByBaseEndpoint = adaptersForPreview.stream()
+        return adaptersForPreview.stream()
                 .filter(importComponent -> importComponent.getImportAction() == CREATE)
                 .map(ImportComponent::getValue)
-                .collect(Collectors.toMap(Adapter::getBaseEndpoint, Function.identity()));
-
-        Adapter adapter = adaptersToCreateByBaseEndpoint.get(adapterEndpoint);
-        return adapter != null ? adapter : adapterService.getByEndpoint(adapterEndpoint);
+                .filter(adapter -> Strings.CS.equals(adapter.getBaseEndpoint(), adapterEndpoint))
+                .findFirst()
+                .orElseGet(() -> adapterService.getByEndpoint(adapterEndpoint));
     }
 
     private String resolveEndpointDeploymentName(ModelEndpointComponents modelEndpointComponents) {

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.epam.aidial.cfg.domain.model.ImportAction.CREATE;
@@ -49,11 +50,16 @@ public class ModelImporter extends RoleBasedImporter {
     public Collection<ImportComponent<Model>> importModels(Map<String, CoreModel> coreModels,
                                                            Map<String, CoreRole> roles,
                                                            ConfigImportOptions importOptions,
+                                                           Collection<ImportComponent<Adapter>> adaptersForPreview,
                                                            boolean isPreview) {
         if (MapUtils.isNotEmpty(coreModels)) {
             Map<String, Model> models = coreModels.entrySet()
                     .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> map(entry.getKey(), entry.getValue(), roles)));
+                    .collect(Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    entry -> map(entry.getKey(), entry.getValue(), roles, adaptersForPreview, isPreview)
+                            )
+                    );
             return importAdminModels(models, importOptions, isPreview);
         }
         return Collections.emptyList();
@@ -113,15 +119,15 @@ public class ModelImporter extends RoleBasedImporter {
         return CREATE;
     }
 
-    private Model map(String modelName, CoreModel model, Map<String, CoreRole> roles) {
+    private Model map(String modelName,
+                      CoreModel model,
+                      Map<String, CoreRole> roles,
+                      Collection<ImportComponent<Adapter>> adaptersForPreview,
+                      boolean isPreview) {
         model.setName(modelName);
         ModelEndpointComponents modelEndpointComponents = getModelEndpointComponents(model);
-        Adapter adapter = modelEndpointComponents != null
-                ? adapterService.getByEndpoint(modelEndpointComponents.adapterEndpoint())
-                : null;
-        String endpointDeploymentName = modelEndpointComponents != null
-                ? modelEndpointComponents.endpointDeploymentName()
-                : null;
+        Adapter adapter = resolveAdapter(adaptersForPreview, isPreview, modelEndpointComponents);
+        String endpointDeploymentName = resolveEndpointDeploymentName(modelEndpointComponents);
         return modelMapper.mapModel(model, roles, adapter, endpointDeploymentName);
     }
 
@@ -130,6 +136,32 @@ public class ModelImporter extends RoleBasedImporter {
             return null;
         }
         return modelEndpointUtils.parseModelEndpoint(coreModel.getEndpoint(), coreModel.getType());
+    }
+
+    private Adapter resolveAdapter(Collection<ImportComponent<Adapter>> adaptersForPreview,
+                                   boolean isPreview,
+                                   ModelEndpointComponents modelEndpointComponents) {
+        if (modelEndpointComponents == null) {
+            return null;
+        }
+
+        String adapterEndpoint = modelEndpointComponents.adapterEndpoint();
+
+        if (!isPreview) {
+            return adapterService.getByEndpoint(adapterEndpoint);
+        }
+
+        Map<String, Adapter> adaptersToCreateByBaseEndpoint = adaptersForPreview.stream()
+                .filter(importComponent -> importComponent.getImportAction() == CREATE)
+                .map(ImportComponent::getValue)
+                .collect(Collectors.toMap(Adapter::getBaseEndpoint, Function.identity()));
+
+        Adapter adapter = adaptersToCreateByBaseEndpoint.get(adapterEndpoint);
+        return adapter != null ? adapter : adapterService.getByEndpoint(adapterEndpoint);
+    }
+
+    private String resolveEndpointDeploymentName(ModelEndpointComponents modelEndpointComponents) {
+        return modelEndpointComponents != null ? modelEndpointComponents.endpointDeploymentName() : null;
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/ConfigController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/ConfigController.java
@@ -131,13 +131,16 @@ public class ConfigController {
 
     @PostMapping(path = "/import/preview", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ImportConfigPreviewDto importConfigPreview(@RequestPart("file") @Valid @Size(min = 1) List<MultipartFile> files,
-                                                      @RequestParam("resolutionPolicy") ConflictResolutionPolicy resolutionPolicy) {
+                                                      @RequestParam("resolutionPolicy") ConflictResolutionPolicy resolutionPolicy,
+                                                      @RequestParam(value = "createAdapterIfAbsent", required = false, defaultValue = "true") boolean createAdapterIfAbsent) {
         int filesSize = CollectionUtils.size(files);
         if (filesSize > importConfigsMaxCount) {
             throw new IllegalArgumentException(String.format("Exceeded maximum file upload limit. Can upload up to %d files, but found %d.",
                     importConfigsMaxCount, filesSize));
         }
-        var importConfigPreview = configTransfer.importPreview(files, resolutionPolicy);
+
+        var configImportOptions = new ConfigImportOptions(resolutionPolicy, false, createAdapterIfAbsent);
+        var importConfigPreview = configTransfer.importPreview(files, configImportOptions);
         return importConfigMapper.toImportConfigPreviewDto(importConfigPreview);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -1107,9 +1107,10 @@ public abstract class ConfigTransferFunctionalTest {
                 "application/json",
                 config.getBytes()
         );
+        ConfigImportOptions configImportOptions = new ConfigImportOptions(ConflictResolutionPolicy.OVERRIDE, false, true);
 
         // when
-        var importConfigPreview = configTransfer.importPreview(List.of(mockFile), ConflictResolutionPolicy.OVERRIDE);
+        var importConfigPreview = configTransfer.importPreview(List.of(mockFile), configImportOptions);
         // then
         var expected = ResourceUtils.readResource("/import/import_preview.json");
         var expectedPreview = jsonMapper.readValue(expected, ImportConfigPreview.class);
@@ -1125,6 +1126,32 @@ public abstract class ConfigTransferFunctionalTest {
         var importConfigPreview = configTransfer.importPreviewZip(zipFile, ConflictResolutionPolicy.OVERRIDE);
         // then
         var expected = ResourceUtils.readResource("/import/import_zip_preview.json");
+        var expectedPreview = jsonMapper.readValue(expected, ImportConfigPreview.class);
+        Assertions.assertThat(importConfigPreview).usingRecursiveAssertion().isEqualTo(expectedPreview);
+    }
+
+    @Test
+    void testImportPreview_ImportModelWithAdapter() throws IOException {
+        // given
+        AdapterDto adapterDto = new AdapterDto();
+        adapterDto.setName("adapter1");
+        adapterDto.setBaseEndpoint("http://endpoint1/");
+        adapterFacade.createAdapter(adapterDto);
+
+        String config = FileUtils.readFileToString(new File("src/test/resources/import/import_modelWithAdapter.json"), StandardCharsets.UTF_8);
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.json",
+                "application/json",
+                config.getBytes()
+        );
+        ConfigImportOptions configImportOptions = new ConfigImportOptions(ConflictResolutionPolicy.OVERRIDE, false, true);
+
+        // when
+        var importConfigPreview = configTransfer.importPreview(List.of(mockFile), configImportOptions);
+
+        // then
+        var expected = ResourceUtils.readResource("/import/import_modelWithAdapter_preview.json");
         var expectedPreview = jsonMapper.readValue(expected, ImportConfigPreview.class);
         Assertions.assertThat(importConfigPreview).usingRecursiveAssertion().isEqualTo(expectedPreview);
     }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -171,7 +171,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
                 .models(List.of(new ImportComponent<>(CREATE, model)))
                 .build();
 
-        when(configTransfer.importPreview(List.of(mockFile), ConflictResolutionPolicy.SKIP)).thenReturn(importConfigPreview);
+        var configImportOptions = new ConfigImportOptions(ConflictResolutionPolicy.SKIP, false, true);
+        when(configTransfer.importPreview(List.of(mockFile), configImportOptions)).thenReturn(importConfigPreview);
         String expected = ResourceUtils.readResource("/import/import_preview_model.json");
         // when
         mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/configs/import/preview")
@@ -181,7 +182,7 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
                 // then
                 .andExpect(status().isOk())
                 .andExpect(content().json(expected, JsonCompareMode.LENIENT));
-        verify(configTransfer).importPreview(List.of(mockFile), ConflictResolutionPolicy.SKIP);
+        verify(configTransfer).importPreview(List.of(mockFile), configImportOptions);
     }
 
     @Test

--- a/src/test/resources/import/import_modelWithAdapter_preview.json
+++ b/src/test/resources/import/import_modelWithAdapter_preview.json
@@ -1,0 +1,120 @@
+{
+  "roles": [],
+  "keys": [],
+  "interceptors": [],
+  "applicationRunners": [],
+  "routes": [],
+  "adapters": [
+    {
+      "importAction": "create",
+      "value": {
+        "name": "<will be defined during import>",
+        "baseEndpoint": "http://endpoint2/",
+        "models": []
+      }
+    }
+  ],
+  "models": [
+    {
+      "importAction": "create",
+      "value": {
+        "deployment": {
+          "name": "testModel2",
+          "isPublic": true,
+          "defaultRoleLimit": {}
+        },
+        "adapter": {
+          "name": "<will be defined during import>",
+          "baseEndpoint": "http://endpoint2/",
+          "models": []
+        },
+        "displayName": "Test Model2",
+        "displayVersion": "2.0.0",
+        "forwardAuthToken": false,
+        "features": {
+          "systemPromptSupported": true,
+          "toolsSupported": false,
+          "seedSupported": false,
+          "urlAttachmentsSupported": false,
+          "folderAttachmentsSupported": false,
+          "allowResume": false,
+          "accessibleByPerRequestKey": true,
+          "contentPartsSupported": false,
+          "temperatureSupported": true,
+          "addonsSupported": false,
+          "cacheSupported": true,
+          "autoCachingSupported": false,
+          "consentRequired": false,
+          "parallelToolCallsSupported": true
+        },
+        "defaults": {},
+        "interceptors": [],
+        "topics": [],
+        "maxRetryAttempts": 5,
+        "author": "test-author",
+        "createdAt": 12345,
+        "updatedAt": 12345,
+        "dependencies": [],
+        "type": "embedding",
+        "upstreams": [],
+        "fieldsHashingOrder": [],
+        "endpointDeploymentName": "testModel2"
+      }
+    },
+    {
+      "importAction": "create",
+      "value": {
+        "deployment": {
+          "name": "testModel1",
+          "isPublic": true,
+          "defaultRoleLimit": {}
+        },
+        "adapter": {
+          "name": "adapter1",
+          "baseEndpoint": "http://endpoint1/",
+          "models": []
+        },
+        "displayName": "Test Model1",
+        "displayVersion": "2.0.0",
+        "forwardAuthToken": false,
+        "features": {
+          "systemPromptSupported": true,
+          "toolsSupported": false,
+          "seedSupported": false,
+          "urlAttachmentsSupported": false,
+          "folderAttachmentsSupported": false,
+          "allowResume": false,
+          "accessibleByPerRequestKey": true,
+          "contentPartsSupported": false,
+          "temperatureSupported": true,
+          "addonsSupported": false,
+          "cacheSupported": true,
+          "autoCachingSupported": false,
+          "consentRequired": false,
+          "parallelToolCallsSupported": true
+        },
+        "defaults": {},
+        "interceptors": [],
+        "topics": [],
+        "maxRetryAttempts": 5,
+        "author": "test-author",
+        "createdAt": 12345,
+        "updatedAt": 12345,
+        "dependencies": [
+          "dep1",
+          "dep2"
+        ],
+        "type": "embedding",
+        "upstreams": [],
+        "fieldsHashingOrder": [
+          "prompt",
+          "temperature"
+        ],
+        "endpointDeploymentName": "testModel1"
+      }
+    }
+  ],
+  "applications": [],
+  "addons": [],
+  "assistants": []
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #70 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Fixed import preview for non-existing adapters
- Added `createAdapterIfAbsent` request param to import preview endpoint to align with import endpoint

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.