### PR TITLE
hotfix: patch in rls-0.4. add model endpoint deployment name

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/model/ModelEntity.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/model/ModelEntity.java
@@ -68,6 +68,7 @@ public class ModelEntity extends AbstractEntity<String> {
     private String upstreams;
     private String overrideName;
     private List<String> fieldsHashingOrder;
+    private String endpointDeploymentName;
 
     @PreRemove
     public void preRemove() {

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/ModelCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/ModelCoreMapper.java
@@ -40,7 +40,7 @@ public abstract class ModelCoreMapper {
     @Mapping(target = "topics", source = "model.descriptionKeywords")
     @Mapping(target = "deployment", ignore = true)
     @Mapping(target = "features", source = "model.features", qualifiedByName = "toFeaturesDto")
-    public abstract Model mapModel(CoreModel model, Map<String, CoreRole> roles, Adapter adapter);
+    public abstract Model mapModel(CoreModel model, Map<String, CoreRole> roles, Adapter adapter, String endpointDeploymentName);
 
     @Mapping(target = "id", ignore = true)
     public abstract Upstream map(CoreUpstream upstream);

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Model.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Model.java
@@ -40,4 +40,5 @@ public class Model extends RoleBased {
     private List<Upstream> upstreams;
     private String overrideName;
     private List<String> fieldsHashingOrder;
+    private String endpointDeploymentName;
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.domain.utils;
 
 import com.epam.aidial.cfg.domain.model.Model;
 import com.epam.aidial.cfg.domain.model.ModelType;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
@@ -13,8 +14,8 @@ import java.util.regex.Pattern;
 @Component
 public class ModelEndpointUtils {
 
-    private static final Pattern CHAT_MODEL_ENDPOINT_PATTERN = Pattern.compile("^(.*/)(.*?)/chat/completions$");
-    private static final Pattern NON_CHAT_MODEL_ENDPOINT_PATTERN = Pattern.compile("^(.*/)(.*?)/embeddings$");
+    private static final Pattern CHAT_MODEL_ENDPOINT_PATTERN = Pattern.compile("^(https?://.+?)(?:/([^/]+))?/chat/completions$");
+    private static final Pattern NON_CHAT_MODEL_ENDPOINT_PATTERN = Pattern.compile("^(https?://.+?)(?:/([^/]+))?/embeddings$");
 
     private static final Map<Boolean, Pair<String, Pattern>> MODEL_PATTERN_MAP = Map.of(
             true, Pair.of("chat/completions", CHAT_MODEL_ENDPOINT_PATTERN),
@@ -27,27 +28,34 @@ public class ModelEndpointUtils {
             return null;
         }
         String baseEndpoint = adapter.getBaseEndpoint();
-        String modelName = model.getDeployment().getName();
-        return createEndpoint(baseEndpoint, modelName, model.getType());
+        String endpointDeploymentName = model.getEndpointDeploymentName();
+        return createEndpoint(baseEndpoint, endpointDeploymentName, model.getType());
     }
 
-    private String createEndpoint(String baseEndpoint, String modelName, ModelType type) {
-        String suffix = modelPath(modelName, type);
+    private String createEndpoint(String baseEndpoint, String endpointDeploymentName, ModelType type) {
+        String suffix = modelPath(endpointDeploymentName, type);
         return Strings.CS.appendIfMissing(baseEndpoint, "/") + suffix;
     }
 
-    public String extractAdapterEndpoint(String modelEndpoint, com.epam.aidial.core.config.ModelType type) {
+    public ModelEndpointComponents parseModelEndpoint(String modelEndpoint, com.epam.aidial.core.config.ModelType type) {
         boolean isChat = isChat(type);
+        String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
+        boolean isDirectOpenAiEndpoint = modelEndpoint.endsWith("v1/" + endpointEnding);
+
+        if (isDirectOpenAiEndpoint) {
+            String adapterEndpoint = Strings.CS.removeEnd(modelEndpoint, endpointEnding);
+            return new ModelEndpointComponents(adapterEndpoint, null);
+        }
+
         Pattern pattern = MODEL_PATTERN_MAP.get(isChat).getRight();
         Matcher matcher = pattern.matcher(modelEndpoint);
 
         if (!matcher.matches()) {
-            String modelEndpointPattern = "<adapter_base_endpoint>/any_string/" + getEndpointByType(isChat);
-            throw new IllegalArgumentException("Unable to extract adapter endpoint from invalid model endpoint: "
-                    + modelEndpoint + ". Model endpoint must satisfy the following pattern: " + modelEndpointPattern);
+            throw new IllegalArgumentException("Unable to extract adapter endpoint and endpoint deployment name "
+                    + "from invalid model endpoint: " + modelEndpoint);
         }
 
-        return matcher.group(1);
+        return new ModelEndpointComponents(matcher.group(1) + "/", matcher.group(2));
     }
 
     private boolean isChat(ModelType type) {
@@ -66,7 +74,12 @@ public class ModelEndpointUtils {
         return MODEL_PATTERN_MAP.get(chat).getLeft();
     }
 
-    private String modelPath(String modelName, ModelType type) {
-        return modelName + "/" + getEndpointByType(type);
+    private String modelPath(String endpointDeploymentName, ModelType type) {
+        return endpointDeploymentName != null
+                ? endpointDeploymentName + "/" + getEndpointByType(type)
+                : getEndpointByType(type);
+    }
+
+    public record ModelEndpointComponents(String adapterEndpoint, @Nullable String endpointDeploymentName) {
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ModelDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ModelDto.java
@@ -43,5 +43,6 @@ public class ModelDto extends RoleBasedDto {
     private List<UpstreamDto> upstreams = List.of();
     private String overrideName;
     private List<String> fieldsHashingOrder;
+    private String endpointDeploymentName;
 
 }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/AdapterImporter.java
@@ -72,7 +72,7 @@ public class AdapterImporter {
     private String mapToAdapterBaseEndpoint(CoreModel coreModel) {
         String modelEndpoint = coreModel.getEndpoint();
         ModelType type = coreModel.getType();
-        return modelEndpointUtils.extractAdapterEndpoint(modelEndpoint, type);
+        return modelEndpointUtils.parseModelEndpoint(modelEndpoint, type).adapterEndpoint();
     }
 
     public List<ImportComponent<Adapter>> importAdminAdapters(Map<String, Adapter> adapters,

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
@@ -10,6 +10,7 @@ import com.epam.aidial.cfg.domain.service.AdapterService;
 import com.epam.aidial.cfg.domain.service.ModelService;
 import com.epam.aidial.cfg.domain.service.RoleService;
 import com.epam.aidial.cfg.domain.utils.ModelEndpointUtils;
+import com.epam.aidial.cfg.domain.utils.ModelEndpointUtils.ModelEndpointComponents;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
 import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
 import com.epam.aidial.core.config.CoreModel;
@@ -114,16 +115,21 @@ public class ModelImporter extends RoleBasedImporter {
 
     private Model map(String modelName, CoreModel model, Map<String, CoreRole> roles) {
         model.setName(modelName);
-        Adapter adapter = getAdapterByEndpoint(model);
-        return modelMapper.mapModel(model, roles, adapter);
+        ModelEndpointComponents modelEndpointComponents = getModelEndpointComponents(model);
+        Adapter adapter = modelEndpointComponents != null
+                ? adapterService.getByEndpoint(modelEndpointComponents.adapterEndpoint())
+                : null;
+        String endpointDeploymentName = modelEndpointComponents != null
+                ? modelEndpointComponents.endpointDeploymentName()
+                : null;
+        return modelMapper.mapModel(model, roles, adapter, endpointDeploymentName);
     }
 
-    private Adapter getAdapterByEndpoint(CoreModel coreModel) {
+    private ModelEndpointComponents getModelEndpointComponents(CoreModel coreModel) {
         if (coreModel == null || coreModel.getEndpoint() == null) {
             return null;
         }
-        String adapterEndpoint = modelEndpointUtils.extractAdapterEndpoint(coreModel.getEndpoint(), coreModel.getType());
-        return adapterService.getByEndpoint(adapterEndpoint);
+        return modelEndpointUtils.parseModelEndpoint(coreModel.getEndpoint(), coreModel.getType());
     }
 
 }

--- a/src/main/resources/db/migration/H2/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
+++ b/src/main/resources/db/migration/H2/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
@@ -1,0 +1,2 @@
+alter table if exists model_entity add column if not exists endpoint_deployment_name varchar(255);
+alter table if exists model_entity_aud add column if not exists endpoint_deployment_name varchar(255);

--- a/src/main/resources/db/migration/H2/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
+++ b/src/main/resources/db/migration/H2/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint_deployment_name = deployment_name;
+update model_entity_aud set endpoint_deployment_name = deployment_name;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
@@ -1,0 +1,2 @@
+alter table model_entity add endpoint_deployment_name nvarchar(255);
+alter table model_entity_aud add endpoint_deployment_name nvarchar(255);

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint_deployment_name = deployment_name;
+update model_entity_aud set endpoint_deployment_name = deployment_name;

--- a/src/main/resources/db/migration/POSTGRES/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.43__AddEnpointDeploymentNameToModelEntityTable.sql
@@ -1,0 +1,2 @@
+alter table if exists model_entity add column if not exists endpoint_deployment_name varchar(255);
+alter table if exists model_entity_aud add column if not exists endpoint_deployment_name varchar(255);

--- a/src/main/resources/db/migration/POSTGRES/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.44__UpdateEnpointDeploymentNameInModelEntityTableToDeploymentName.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint_deployment_name = deployment_name;
+update model_entity_aud set endpoint_deployment_name = deployment_name;

--- a/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
@@ -1,5 +1,8 @@
 package com.epam.aidial.cfg.domain.utils;
 
+import com.epam.aidial.cfg.domain.model.Adapter;
+import com.epam.aidial.cfg.domain.model.Model;
+import com.epam.aidial.cfg.domain.utils.ModelEndpointUtils.ModelEndpointComponents;
 import com.epam.aidial.core.config.ModelType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,45 +24,114 @@ class ModelEndpointUtilsTest {
     }
 
     @ParameterizedTest
-    @MethodSource("extractAdapterEndpoint_shouldSuccessfullyExtractAdapterEndpointTestParams")
-    void extractAdapterEndpoint_shouldSuccessfullyExtractAdapterEndpoint(String modelEndpoint,
-                                                                         ModelType type,
-                                                                         String expected) {
+    @MethodSource("createEndpoint_shouldSuccessfullyCreateEndpointTestParams")
+    void createEndpoint_shouldSuccessfullyCreateEndpoint(Model model, String expected) {
         // when
-        String actual = modelEndpointUtils.extractAdapterEndpoint(modelEndpoint, type);
+        String actual = modelEndpointUtils.createEndpoint(model);
 
         // then
         assertThat(actual).isEqualTo(expected);
     }
 
     @ParameterizedTest
-    @MethodSource("extractAdapterEndpoint_shouldThrowExceptionWhenInvalidModelEndpointTestParams")
-    void extractAdapterEndpoint_shouldThrowExceptionWhenInvalidModelEndpoint(String modelEndpoint, ModelType type, String expectedExceptionMessageEnding) {
+    @MethodSource("parseModelEndpoint_shouldSuccessfullyReturnEndpointComponentsTestParams")
+    void parseModelEndpoint_shouldSuccessfullyReturnEndpointComponents(String modelEndpoint,
+                                                                       ModelType type,
+                                                                       ModelEndpointComponents expected) {
         // when
-        Assertions.assertThatThrownBy(() -> modelEndpointUtils.extractAdapterEndpoint(modelEndpoint, type))
-                // then
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Unable to extract adapter endpoint from invalid model endpoint: " + modelEndpoint
-                        + ". Model endpoint must satisfy the following pattern: "
-                        + "<adapter_base_endpoint>/any_string/" + expectedExceptionMessageEnding);
+        ModelEndpointComponents actual = modelEndpointUtils.parseModelEndpoint(modelEndpoint, type);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 
-    private static Stream<Arguments> extractAdapterEndpoint_shouldSuccessfullyExtractAdapterEndpointTestParams() {
+    @ParameterizedTest
+    @MethodSource("parseModelEndpoint_shouldThrowExceptionWhenInvalidModelEndpointTestParams")
+    void parseModelEndpoint_shouldThrowExceptionWhenInvalidModelEndpoint(String modelEndpoint, ModelType type, String expectedExceptionMessageEnding) {
+        // when
+        Assertions.assertThatThrownBy(() -> modelEndpointUtils.parseModelEndpoint(modelEndpoint, type))
+                // then
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unable to extract adapter endpoint and endpoint deployment name "
+                        + "from invalid model endpoint: " + modelEndpoint);
+    }
+
+    private static Stream<Arguments> createEndpoint_shouldSuccessfullyCreateEndpointTestParams() {
+        Model modelWithoutAdapter = new Model();
+
+        Adapter adapter = new Adapter();
+        adapter.setBaseEndpoint("http://host/openai/deployments");
+
+        Model modelWithAdapterAndEndpointDeploymentName = new Model();
+        modelWithAdapterAndEndpointDeploymentName.setAdapter(adapter);
+        modelWithAdapterAndEndpointDeploymentName.setEndpointDeploymentName("endpoint-deployment-name");
+
+        Model modelWithAdapter = new Model();
+        modelWithAdapter.setAdapter(adapter);
+
+        Model chatModelWithAdapterAndEndpointDeploymentName = new Model();
+        chatModelWithAdapterAndEndpointDeploymentName.setType(com.epam.aidial.cfg.domain.model.ModelType.CHAT);
+        chatModelWithAdapterAndEndpointDeploymentName.setAdapter(adapter);
+        chatModelWithAdapterAndEndpointDeploymentName.setEndpointDeploymentName("endpoint-deployment-name");
+
+        Model chatModelWithAdapter = new Model();
+        chatModelWithAdapter.setType(com.epam.aidial.cfg.domain.model.ModelType.CHAT);
+        chatModelWithAdapter.setAdapter(adapter);
+
+        Model nonChatModelWithAdapterAndEndpointDeploymentName = new Model();
+        nonChatModelWithAdapterAndEndpointDeploymentName.setType(com.epam.aidial.cfg.domain.model.ModelType.EMBEDDING);
+        nonChatModelWithAdapterAndEndpointDeploymentName.setAdapter(adapter);
+        nonChatModelWithAdapterAndEndpointDeploymentName.setEndpointDeploymentName("endpoint-deployment-name");
+
+        Model nonChatModelWithAdapter = new Model();
+        nonChatModelWithAdapter.setType(com.epam.aidial.cfg.domain.model.ModelType.EMBEDDING);
+        nonChatModelWithAdapter.setAdapter(adapter);
+
         return Stream.of(
-                Arguments.of("http://host/openai/deployments/model-name/chat/completions", ModelType.CHAT, "http://host/openai/deployments/"),
-                Arguments.of("http://host/openai/deployments/model-name/embeddings", ModelType.EMBEDDING, "http://host/openai/deployments/")
+                Arguments.of(modelWithoutAdapter, null),
+                Arguments.of(modelWithAdapterAndEndpointDeploymentName, "http://host/openai/deployments/endpoint-deployment-name/chat/completions"),
+                Arguments.of(modelWithAdapter, "http://host/openai/deployments/chat/completions"),
+                Arguments.of(chatModelWithAdapterAndEndpointDeploymentName, "http://host/openai/deployments/endpoint-deployment-name/chat/completions"),
+                Arguments.of(chatModelWithAdapter, "http://host/openai/deployments/chat/completions"),
+                Arguments.of(nonChatModelWithAdapterAndEndpointDeploymentName, "http://host/openai/deployments/endpoint-deployment-name/embeddings"),
+                Arguments.of(nonChatModelWithAdapter, "http://host/openai/deployments/embeddings")
         );
     }
 
-    private static Stream<Arguments> extractAdapterEndpoint_shouldThrowExceptionWhenInvalidModelEndpointTestParams() {
+    private static Stream<Arguments> parseModelEndpoint_shouldSuccessfullyReturnEndpointComponentsTestParams() {
         return Stream.of(
-                Arguments.of("http://host/openai/deployments/model-name/chat/completions/text", ModelType.CHAT, "chat/completions"),
-                Arguments.of("http://host/openai/deployments/model-name/chat", ModelType.CHAT, "chat/completions"),
-                Arguments.of("http://host/openai/deployments/model-name/", ModelType.CHAT, "chat/completions"),
-                Arguments.of("http://host/openai/deployments/model-name", ModelType.CHAT, "chat/completions"),
-                Arguments.of("http://host/openai/deployments/model-name/embeddings/text", ModelType.EMBEDDING, "embeddings"),
-                Arguments.of("http://host/openai/deployments/model-name/", ModelType.EMBEDDING, "embeddings"),
-                Arguments.of("http://host/openai/deployments/model-name", ModelType.EMBEDDING, "embeddings")
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name/chat/completions",
+                        ModelType.CHAT,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name")
+                ),
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name/embeddings",
+                        ModelType.EMBEDDING,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name")
+                ),
+                Arguments.of(
+                        "http://host/v1/chat/completions",
+                        ModelType.CHAT,
+                        new ModelEndpointComponents("http://host/v1/", null)
+                ),
+                Arguments.of(
+                        "http://host/v1/embeddings",
+                        ModelType.EMBEDDING,
+                        new ModelEndpointComponents("http://host/v1/", null)
+                )
+        );
+    }
+
+    private static Stream<Arguments> parseModelEndpoint_shouldThrowExceptionWhenInvalidModelEndpointTestParams() {
+        return Stream.of(
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name/chat/completions/text", ModelType.CHAT, "chat/completions"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name/chat", ModelType.CHAT, "chat/completions"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name/", ModelType.CHAT, "chat/completions"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name", ModelType.CHAT, "chat/completions"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name/embeddings/text", ModelType.EMBEDDING, "embeddings"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name/", ModelType.EMBEDDING, "embeddings"),
+                Arguments.of("http://host/openai/deployments/endpoint-deployment-name", ModelType.EMBEDDING, "embeddings")
         );
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/AdapterFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/AdapterFunctionalTest.java
@@ -109,6 +109,7 @@ public abstract class AdapterFunctionalTest {
         model1.setAdapter("adapter1");
         modelFacade.createModel(model1);
         model1.setAdapter("adapter2");
+        model1.setEndpointDeploymentName("model1");
         modelFacade.updateModel(model1.getName(), model1);
 
         AdapterDto actualAdapter1 = adapterFacade.getAdapter(adapterDto1.getName());
@@ -129,6 +130,7 @@ public abstract class AdapterFunctionalTest {
         expectedModel1.setDefaults(Map.of());
         expectedModel1.setRoleLimits(Map.of());
         expectedModel1.setDefaultRoleLimit(new LimitDto());
+        expectedModel1.setEndpointDeploymentName("model1");
         Assertions.assertEquals(expectedModel1, actualModel1);
     }
 
@@ -154,7 +156,7 @@ public abstract class AdapterFunctionalTest {
 
         ModelDto expectedModel1 = createModel("1");
         expectedModel1.setAdapter("adapter1");
-        expectedModel1.setEndpoint("endpoint1/model1/chat/completions");
+        expectedModel1.setEndpoint("endpoint1/chat/completions");
         expectedModel1.setDefaults(Map.of());
         expectedModel1.setRoleLimits(Map.of());
         expectedModel1.setDefaultRoleLimit(new LimitDto());

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -88,11 +88,12 @@ public abstract class ModelFunctionalTest {
         ModelDto modelDto = createDto("1");
         modelDto.setAdapter("adapter1");
         modelFacade.createModel(modelDto);
+
         ModelDto updatedModel = createDto("1");
         updatedModel.setAdapter("adapter2");
         updatedModel.setDescription("new model description");
         updatedModel.setDefaults(Map.of());
-
+        updatedModel.setEndpointDeploymentName("newEndpointDeploymentName");
         modelFacade.updateModel(modelDto.getName(), updatedModel);
 
         ModelDto actual = modelFacade.getModel(modelDto.getName());
@@ -102,7 +103,8 @@ public abstract class ModelFunctionalTest {
         expected.setDefaults(Map.of());
         expected.setDefaultRoleLimit(new LimitDto());
         expected.setAdapter("adapter2");
-        expected.setEndpoint("http://adapter.endpoint2/model1/chat/completions");
+        expected.setEndpoint("http://adapter.endpoint2/newEndpointDeploymentName/chat/completions");
+        expected.setEndpointDeploymentName("newEndpointDeploymentName");
         updatedModel.setDefaults(Map.of());
         updatedModel.setDefaultRoleLimit(new LimitDto());
         assertModel(actual, expected);
@@ -116,9 +118,12 @@ public abstract class ModelFunctionalTest {
         LimitDto limitDto = new LimitDto();
         limitDto.setDay(10L);
         updatedModel.setRoleLimits(Map.of("role3", limitDto));
+        updatedModel.setEndpointDeploymentName(null);
         modelFacade.updateModel(modelDto.getName(), updatedModel);
         actual = modelFacade.getModel(modelDto.getName());
         expected.setRoleLimits(Map.of("role3", limitDto));
+        expected.setEndpoint("http://adapter.endpoint2/chat/completions");
+        expected.setEndpointDeploymentName(null);
         assertModel(actual, expected);
 
         roleFacade.deleteRole("role3");

--- a/src/test/resources/domain/model/models.json
+++ b/src/test/resources/domain/model/models.json
@@ -120,6 +120,7 @@
           }
         }
       ]
-    }
+    },
+    "endpointDeploymentName": "sampleDeployment"
   }
 ]

--- a/src/test/resources/domain/model/models_public.json
+++ b/src/test/resources/domain/model/models_public.json
@@ -116,6 +116,7 @@
           }
         }
       ]
-    }
+    },
+    "endpointDeploymentName": "sampleDeployment"
   }
 ]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #89 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Added `endpointDeploymentName` to model entity and adjusted model `endpoint` parsing which extracts `adapterEndpoint` and `endpointDeploymentName` components

BREAKING CHANGES:
Old admin configs which don't specify `endpointDeploymentName` field for each model will eventually have incorrect model endpoint, since previously model endpoint was built as `<adapter_base_url>/<model_name>(/chat/completions | /embeddings)`
and currently it's built as `<adapter_base_url>/<endpoint_deployment_name>(/chat/completions | /embeddings)`.

Original PRs:

- #87 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.