### PR TITLE
fix: increase reactor-netty-http transitive dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,9 @@ dependencies {
         implementation ('com.nimbusds:nimbus-jose-jwt:10.3.1') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.projectreactor.netty:reactor-netty-http:1.2.8') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Increased `io.projectreactor.netty:reactor-netty-http` transitive dependency version from `1.2.7` to `1.2.8`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.