### PR TITLE
fix: include "userRoles" and "endpoint" fields into manually exported core config, use only enabled roles when defining "userRoles" during export, do not store disabled roles with empty limits

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
@@ -184,8 +184,12 @@ public interface RoleCoreMapper {
                     String deploymentName = e.getKey();
                     Set<String> userRoles = userRolesByDeploymentName.get(deploymentName);
                     boolean enabled = SetUtils.emptyIfNull(userRoles).contains(roleName);
-                    return toLimit(e.getValue(), deploymentName, enabled);
+                    RoleLimit roleLimit = toLimit(e.getValue(), deploymentName, enabled);
+                    Limit limit = roleLimit.getLimit();
+                    boolean isDisabledEmptyLimit = !roleLimit.isEnabled() && limit.isEmpty();
+                    return isDisabledEmptyLimit ? null : roleLimit;
                 })
+                .filter(Objects::nonNull)
                 .toList();
         Set<String> deploymentNamesOfAlreadyAddedRoleLimits = roleLimits.stream()
                 .map(RoleLimit::getDeploymentName)

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -23,6 +23,7 @@ public interface RoleLimitMapper {
             return null;
         }
         return deployment.getRoleLimits().stream()
+                .filter(RoleLimit::isEnabled)
                 .map(this::mapUserRole)
                 .collect(Collectors.toSet());
     }
@@ -85,13 +86,17 @@ public interface RoleLimitMapper {
 
     private RoleLimit mapRoleLimit(Set<String> userRoles, String roleName, String entityName, CoreRole role) {
         Map<String, CoreLimit> limits = role.getLimits();
-        CoreLimit limit = MapUtils.emptyIfNull(limits).get(entityName);
-        if (limit == null) {
+        CoreLimit coreLimit = MapUtils.emptyIfNull(limits).get(entityName);
+        if (coreLimit == null) {
             return null;
         }
 
         boolean isEnable = userRoles != null && userRoles.contains(roleName);
-        return createRoleLimit(roleName, limit, isEnable);
+        RoleLimit roleLimit = createRoleLimit(roleName, coreLimit, isEnable);
+        Limit limit = roleLimit.getLimit();
+        boolean isDisabledEmptyLimit = !roleLimit.isEnabled() && limit.isEmpty();
+
+        return isDisabledEmptyLimit ? null : roleLimit;
     }
 
     private RoleLimit createRoleLimit(String roleName, CoreLimit limit, boolean isEnable) {

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 @Data
@@ -10,4 +11,9 @@ public class Limit {
     private Long month;
     private Long requestHour;
     private Long requestDay;
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return minute == null && day == null && week == null && month == null && requestHour == null && requestDay == null;
+    }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
@@ -90,7 +90,9 @@ public class ApplicationExporter {
         if (!componentTypes.contains(ExportConfigComponentType.APPLICATION_TYPE_SCHEMA)) {
             app.setApplicationTypeSchemaId(null);
         }
-        app.getDeployment().setRoleLimits(null);
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+            app.getDeployment().setRoleLimits(null);
+        }
         return app;
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.service.transfer.exporter;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
+import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.Model;
 import com.epam.aidial.cfg.domain.model.Upstream;
 import com.epam.aidial.cfg.domain.service.ModelService;
@@ -36,7 +37,7 @@ public class ModelExporter {
                     .collect(Collectors.toMap(model -> model.getDeployment().getName(), Function.identity()))
                     : new HashMap<>();
         } else if (request instanceof SelectedItemsExportRequest selectedItemsExportRequest) {
-            return getModels(selectedItemsExportRequest.getComponents(), request.isAddSecrets()).stream()
+            return getModels(selectedItemsExportRequest, request.isAddSecrets()).stream()
                     .collect(Collectors.toMap(model -> model.getDeployment().getName(), Function.identity()));
         }
         throw new IllegalArgumentException("Unsupported request type: " + request.getClass());
@@ -46,7 +47,8 @@ public class ModelExporter {
         return modelService.getAll();
     }
 
-    private List<Model> getModels(List<ExportConfigComponent> components, boolean addSecrets) {
+    private List<Model> getModels(SelectedItemsExportRequest selectedItemsExportRequest, boolean addSecrets) {
+        List<ExportConfigComponent> components = selectedItemsExportRequest.getComponents();
         return components.stream()
                 .filter(component -> component.getType() == ExportConfigComponentType.MODEL)
                 .collect(Collectors.toMap(ExportConfigComponent::getName, Function.identity(),
@@ -59,7 +61,7 @@ public class ModelExporter {
                 .stream()
                 .map(component -> {
                     Model model = getModel(component.getName());
-                    return removeDependency(model, component.getDependencies());
+                    return removeDependency(model, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
                 })
                 .map(model -> removeUpstreamKey(model, addSecrets))
                 .toList();
@@ -68,7 +70,7 @@ public class ModelExporter {
     private Collection<Model> getModels(FullExportRequest fullExportRequest) {
         return getModels().stream()
                 .map(model -> removeUpstreamKey(model, fullExportRequest.isAddSecrets()))
-                .map(model -> removeDependency(model, fullExportRequest.getComponentTypes()))
+                .map(model -> removeDependency(model, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
                 .toList();
     }
 
@@ -88,12 +90,14 @@ public class ModelExporter {
         return modelService.getModel(modelName);
     }
 
-    private Model removeDependency(Model model, Set<ExportConfigComponentType> componentTypes) {
-        model.getDeployment().setRoleLimits(null);
+    private Model removeDependency(Model model, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+            model.getDeployment().setRoleLimits(null);
+        }
         if (!componentTypes.contains(ExportConfigComponentType.INTERCEPTOR)) {
             model.setInterceptors(null);
         }
-        if (!componentTypes.contains(ExportConfigComponentType.ADAPTER)) {
+        if (!componentTypes.contains(ExportConfigComponentType.ADAPTER) && exportFormat != ExportFormat.CORE) {
             model.setAdapter(null);
         }
         return model;

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -62,16 +63,18 @@ public class RouteExporter {
                 ))
                 .values()
                 .stream()
-                .map(component -> routeService.get(component.getName()))
+                .map(component -> {
+                    Route route = routeService.get(component.getName());
+                    return removeDependency(route, component.getDependencies());
+                })
                 .map(route -> removeUpstreamKey(route, addSecrets))
-                .map(this::removeDependency)
                 .toList();
     }
 
     private Collection<Route> getRoutes(FullExportRequest fullExportRequest) {
         return getRoutes().stream()
                 .map(route -> removeUpstreamKey(route, fullExportRequest.isAddSecrets()))
-                .map(this::removeDependency)
+                .map(route -> removeDependency(route, fullExportRequest.getComponentTypes()))
                 .toList();
     }
 
@@ -85,8 +88,10 @@ public class RouteExporter {
                 .collect(Collectors.toList());
     }
 
-    private Route removeDependency(Route route) {
-        route.getDeployment().setRoleLimits(null);
+    private Route removeDependency(Route route, Set<ExportConfigComponentType> componentTypes) {
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+            route.getDeployment().setRoleLimits(null);
+        }
         return route;
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -11,6 +11,7 @@ import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.ExportKeyInfo;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
 import com.epam.aidial.cfg.domain.model.Model;
+import com.epam.aidial.cfg.domain.model.Route;
 import com.epam.aidial.cfg.dto.AdapterDto;
 import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.ApplicationDto;
@@ -136,18 +137,22 @@ public abstract class ConfigTransferFunctionalTest {
         Map<String, ModelDto> models = modelFacade.getAll().stream().collect(Collectors.toMap(ModelDto::getName, a -> a));
         Assertions.assertThat(models).containsOnlyKeys("testModel1", "testModel2");
         Assertions.assertThat(models.get("testModel1")).satisfies(modelDto -> {
-            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole2", "testRole3", "default");
+            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole3", "default");
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole1")).satisfies(limit1 -> {
                 Assertions.assertThat(limit1.isEnabled()).isTrue();
                 Assertions.assertThat(limit1.getDay()).isEqualTo(1);
                 Assertions.assertThat(limit1.getMinute()).isNull();
             });
-            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2"))
-                    .satisfies(limit2 -> Assertions.assertThat(limit2.isEnabled()).isFalse());
+            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2")).isNull();
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole3")).satisfies(limit3 -> {
                 Assertions.assertThat(limit3.isEnabled()).isTrue();
                 Assertions.assertThat(limit3.getDay()).isNull();
                 Assertions.assertThat(limit3.getMinute()).isNull();
+            });
+            Assertions.assertThat(modelDto.getRoleLimits().get("default")).satisfies(limitDefault -> {
+                Assertions.assertThat(limitDefault.isEnabled()).isFalse();
+                Assertions.assertThat(limitDefault.getDay()).isEqualTo(3);
+                Assertions.assertThat(limitDefault.getMinute()).isNull();
             });
             Assertions.assertThat(modelDto.getInterceptors()).isNotEmpty()
                     .hasSize(1).first().isEqualTo("testInterceptor1");
@@ -435,7 +440,17 @@ public abstract class ConfigTransferFunctionalTest {
                     .satisfies(models -> {
                         Model model = models.get("modelName");
                         Assertions.assertThat(model.getInterceptors()).containsExactlyInAnyOrder("interceptorName");
-                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNull();
+                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
+                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
+                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
+                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("modelName");
+                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
+                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
+                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
+                                    Assertions.assertThat(limit.getDay()).isNull();
+                                });
+                            });
+                        });
                         Assertions.assertThat(model.getAdapter()).isNull();
                     });
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("interceptorName");
@@ -510,7 +525,17 @@ public abstract class ConfigTransferFunctionalTest {
                     .satisfies(models -> {
                         Model model = models.get("modelName");
                         Assertions.assertThat(model.getInterceptors()).containsExactlyInAnyOrder("interceptorName");
-                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNull();
+                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
+                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
+                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
+                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("modelName");
+                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
+                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
+                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
+                                    Assertions.assertThat(limit.getDay()).isNull();
+                                });
+                            });
+                        });
                         Assertions.assertThat(model.getAdapter().getName()).isEqualTo("testAdapter");
                     });
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("interceptorName");
@@ -561,8 +586,20 @@ public abstract class ConfigTransferFunctionalTest {
         Assertions.assertThat(result).isNotNull().satisfies(config -> {
             Assertions.assertThat(config.getRoutes()).isNotEmpty()
                     .containsOnlyKeys("routeName")
-                    .satisfies(routes ->
-                            Assertions.assertThat(routes.get("routeName").getDeployment().getRoleLimits()).isNull());
+                    .satisfies(routes -> {
+                        Route route = routes.get("routeName");
+                        Assertions.assertThat(route.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
+                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
+                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
+                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("routeName");
+                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
+                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
+                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
+                                    Assertions.assertThat(limit.getDay()).isNull();
+                                });
+                            });
+                        });
+                    });
             Assertions.assertThat(config.getRoles()).isNotEmpty().containsKey("testRole");
             Assertions.assertThat(config.getRoles().get("testRole").getLimits()).isNotEmpty().hasSize(1).first()
                     .satisfies(limit -> Assertions.assertThat(limit.getDeploymentName()).isEqualTo("routeName"));
@@ -619,7 +656,7 @@ public abstract class ConfigTransferFunctionalTest {
         FullExportRequest request = new FullExportRequest();
         request.setExportFormat(ExportFormat.ADMIN);
         request.setComponentTypes(componentTypes);
-        
+
         // Create interceptor runner
         InterceptorRunnerDto runnerDto = new InterceptorRunnerDto();
         runnerDto.setName("testRunner");
@@ -628,24 +665,24 @@ public abstract class ConfigTransferFunctionalTest {
         runnerDto.setCompletionEndpoint("https://test.com/completion");
         runnerDto.setConfigurationEndpoint("https://test.com/configuration");
         interceptorRunnerFacade.createInterceptorRunner(runnerDto);
-        
+
         // Create interceptors associated with the runner
         InterceptorDto interceptor1 = new InterceptorDto();
         interceptor1.setName("testInterceptor1");
         interceptor1.setDescription("Test interceptor 1");
         interceptor1.setInterceptorRunner("testRunner");
-        
+
         InterceptorDto interceptor2 = new InterceptorDto();
         interceptor2.setName("testInterceptor2");
         interceptor2.setDescription("Test interceptor 2");
         interceptor2.setInterceptorRunner("testRunner");
-        
+
         interceptorFacade.createInterceptor(interceptor1);
         interceptorFacade.createInterceptor(interceptor2);
-        
+
         // when
         StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
-        
+
         // then
         ExportConfig result = extractConfigFromZip(streamingResponseBody);
         Assertions.assertThat(result).isNotNull().satisfies(config -> {
@@ -659,7 +696,7 @@ public abstract class ConfigTransferFunctionalTest {
                         // Verify interceptors are not included in the runner (they're exported separately)
                         Assertions.assertThat(runners.get("testRunner").getInterceptors()).isNull();
                     });
-            
+
             Assertions.assertThat(config.getInterceptors()).isNotEmpty()
                     .containsOnlyKeys("testInterceptor1", "testInterceptor2")
                     .satisfies(interceptors -> {
@@ -702,7 +739,17 @@ public abstract class ConfigTransferFunctionalTest {
                     .satisfies(apps -> {
 
                         Assertions.assertThat(apps.get("applicationName").getApplicationTypeSchemaId()).isEqualTo(customAppSchemaId);
-                        Assertions.assertThat(apps.get("applicationName").getDeployment().getRoleLimits()).isNull();
+                        Assertions.assertThat(apps.get("applicationName").getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
+                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
+                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
+                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("applicationName");
+                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
+                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
+                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
+                                    Assertions.assertThat(limit.getDay()).isNull();
+                                });
+                            });
+                        });
                     });
 
             Assertions.assertThat(config.getApplicationRunners()).isNotEmpty().containsOnlyKeys("https://test-schema-id.example");
@@ -1324,20 +1371,20 @@ public abstract class ConfigTransferFunctionalTest {
 
     private String getAppRunnerDto() {
         return """
-            {"$id": "https://test-schema-id.example",
-                    "dial:applicationTypeEditorUrl": "https://test.com/billings",
-                    "dial:applicationTypeViewerUrl": "https://test.com/claims",
-                    "dial:applicationTypeDisplayName": "runner display name",
-                    "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
-                    "dial:applicationTypeConfigurationEndpoint": "https://test.com/conf",
-                    "dial:applicationTypeRateEndpoint": "https://test.com/rate",
-                    "dial:applicationTypeTokenizeEndpoint": "https://test.com/tokenize",
-                    "dial:applicationTypeTruncatePromptEndpoint": "https://test.com/truncate-prompt",
-                    "dial:appendApplicationPropertiesHeader": false,
-                    "$defs": {},
-                    "properties": {},
-                    "required": []
-                  }""";
+                {"$id": "https://test-schema-id.example",
+                        "dial:applicationTypeEditorUrl": "https://test.com/billings",
+                        "dial:applicationTypeViewerUrl": "https://test.com/claims",
+                        "dial:applicationTypeDisplayName": "runner display name",
+                        "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
+                        "dial:applicationTypeConfigurationEndpoint": "https://test.com/conf",
+                        "dial:applicationTypeRateEndpoint": "https://test.com/rate",
+                        "dial:applicationTypeTokenizeEndpoint": "https://test.com/tokenize",
+                        "dial:applicationTypeTruncatePromptEndpoint": "https://test.com/truncate-prompt",
+                        "dial:appendApplicationPropertiesHeader": false,
+                        "$defs": {},
+                        "properties": {},
+                        "required": []
+                      }""";
     }
 
     private static ConfigImportOptions overrideAndCreateRoleAndCreateNew() {

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -21,11 +21,6 @@
             "limit": {}
           },
           {
-            "deploymentName": "testModel2",
-            "enabled": false,
-            "limit": {}
-          },
-          {
             "deploymentName": "testModel1",
             "enabled": true,
             "limit": {
@@ -53,28 +48,7 @@
       "importAction": "create",
       "value": {
         "name": "testRole2",
-        "limits": [
-          {
-            "deploymentName": "testApplication1",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testApplication2",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testModel2",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testModel1",
-            "enabled": false,
-            "limit": {}
-          }
-        ]
+        "limits": []
       }
     },
     {
@@ -82,21 +56,6 @@
       "value": {
         "name": "testRole3",
         "limits": [
-          {
-            "deploymentName": "testApplication1",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testApplication2",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testModel2",
-            "enabled": false,
-            "limit": {}
-          },
           {
             "deploymentName": "testModel1",
             "enabled": true,
@@ -110,21 +69,6 @@
       "value": {
         "name": "default",
         "limits": [
-          {
-            "deploymentName": "testApplication1",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testApplication2",
-            "enabled": false,
-            "limit": {}
-          },
-          {
-            "deploymentName": "testModel2",
-            "enabled": false,
-            "limit": {}
-          },
           {
             "deploymentName": "testModel1",
             "enabled": false,
@@ -258,28 +202,7 @@
       "value": {
         "deployment": {
           "name": "testModel2",
-          "roleLimits": [
-            {
-              "role": "testRole1",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "testRole2",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "testRole3",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "default",
-              "enabled": false,
-              "limit": {}
-            }
-          ],
+          "roleLimits": [],
           "isPublic": true,
           "defaultRoleLimit": {}
         },
@@ -332,11 +255,6 @@
               "limit": {
                 "day": 1
               }
-            },
-            {
-              "role": "testRole2",
-              "enabled": false,
-              "limit": {}
             },
             {
               "role": "testRole3",
@@ -404,21 +322,6 @@
               "role": "testRole1",
               "enabled": true,
               "limit": {}
-            },
-            {
-              "role": "testRole2",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "testRole3",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "default",
-              "enabled": false,
-              "limit": {}
             }
           ],
           "isPublic": false,
@@ -467,21 +370,6 @@
             {
               "role": "testRole1",
               "enabled": true,
-              "limit": {}
-            },
-            {
-              "role": "testRole2",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "testRole3",
-              "enabled": false,
-              "limit": {}
-            },
-            {
-              "role": "default",
-              "enabled": false,
               "limit": {}
             }
           ],


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #103 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

- Included `userRoles` and `endpoint` fields into manually exported core config
- Only enabled roles are exported as `userRoles`
- Roles that are disabled (are not mentioned as userRoles for deployment in imported config) and have empty limits are not stored by application

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.