### PR TITLE
fix: materialize deployment default limits in exported Core config

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
@@ -14,15 +14,18 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -31,7 +34,8 @@ import java.util.stream.Collectors;
 @Mapper(componentModel = "spring", uses = RoleLimitMapper.class)
 public interface RoleCoreMapper {
 
-    CoreRole mapRole(Role role, Collection<Deployment> deployments);
+    @Mapping(target = "limits", qualifiedByName = "mapToCoreLimits")
+    CoreRole mapRole(Role role, @Context Collection<Deployment> deployments);
 
     @Mapping(target = "keys", ignore = true)
     @Mapping(target = "limits", ignore = true)
@@ -88,14 +92,19 @@ public interface RoleCoreMapper {
         return limitsByDeploymentName.values().stream().toList();
     }
 
-    default Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits) {
+    @Named("mapToCoreLimits")
+    default Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits, @Context Collection<Deployment> deployments) {
         if (roleLimits == null) {
             return Map.of();
         }
 
+        Map<String, Deployment> deploymentsByName = CollectionUtils.emptyIfNull(deployments).stream()
+                .collect(Collectors.toMap(Deployment::getName, Function.identity()));
+
         return roleLimits.stream()
                 .map(roleLimit -> {
-                    CoreLimit mappedLimit = mapLimit(roleLimit.getLimit());
+                    Deployment deployment = deploymentsByName.get(roleLimit.getDeploymentName());
+                    CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
                     return mappedLimit != null ? new AbstractMap.SimpleEntry<>(roleLimit.getDeploymentName(), mappedLimit) : null;
                 })
                 .filter(Objects::nonNull)
@@ -116,17 +125,23 @@ public interface RoleCoreMapper {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    default CoreLimit mapLimit(Limit limit) {
-        if (limit == null || isUnlimited(limit)) {
+    default CoreLimit mapLimit(Limit limit, Deployment deployment) {
+        if (limit == null || deployment == null) {
             return null;
         }
+
+        Limit defaultLimit = Optional.ofNullable(deployment.getDefaultRoleLimit()).orElse(new Limit());
+        if (isUnlimited(limit) && defaultLimit.isEmpty()) {
+            return null;
+        }
+
         CoreLimit coreLimit = new CoreLimit();
-        setIfNotNull(coreLimit::setMinute, limit.getMinute());
-        setIfNotNull(coreLimit::setDay, limit.getDay());
-        setIfNotNull(coreLimit::setWeek, limit.getWeek());
-        setIfNotNull(coreLimit::setMonth, limit.getMonth());
-        setIfNotNull(coreLimit::setRequestHour, limit.getRequestHour());
-        setIfNotNull(coreLimit::setRequestDay, limit.getRequestDay());
+        setIfNotNull(coreLimit::setMinute, getLimitOrDefault(limit, defaultLimit, Limit::getMinute));
+        setIfNotNull(coreLimit::setDay, getLimitOrDefault(limit, defaultLimit, Limit::getDay));
+        setIfNotNull(coreLimit::setWeek, getLimitOrDefault(limit, defaultLimit, Limit::getWeek));
+        setIfNotNull(coreLimit::setMonth, getLimitOrDefault(limit, defaultLimit, Limit::getMonth));
+        setIfNotNull(coreLimit::setRequestHour, getLimitOrDefault(limit, defaultLimit, Limit::getRequestHour));
+        setIfNotNull(coreLimit::setRequestDay, getLimitOrDefault(limit, defaultLimit, Limit::getRequestDay));
         return coreLimit;
     }
 
@@ -156,12 +171,21 @@ public interface RoleCoreMapper {
     }
 
     private boolean isUnlimited(Limit limit) {
-        return (limit.getMinute() == null || limit.getMinute() == Long.MAX_VALUE)
-                && (limit.getDay() == null || limit.getDay() == Long.MAX_VALUE)
-                && (limit.getWeek() == null || limit.getWeek() == Long.MAX_VALUE)
-                && (limit.getMonth() == null || limit.getMonth() == Long.MAX_VALUE)
-                && (limit.getRequestHour() == null || limit.getRequestHour() == Long.MAX_VALUE)
-                && (limit.getRequestDay() == null || limit.getRequestDay() == Long.MAX_VALUE);
+        return isUnlimited(limit.getMinute())
+                && isUnlimited(limit.getDay())
+                && isUnlimited(limit.getWeek())
+                && isUnlimited(limit.getMonth())
+                && isUnlimited(limit.getRequestHour())
+                && isUnlimited(limit.getRequestDay());
+    }
+
+    private boolean isUnlimited(Long value) {
+        return value == null || value == Long.MAX_VALUE;
+    }
+
+    private Long getLimitOrDefault(Limit limit, Limit defaultLimit, Function<Limit, Long> limitValueGetter) {
+        Long limitValue = limitValueGetter.apply(limit);
+        return isUnlimited(limitValue) ? limitValueGetter.apply(defaultLimit) : limitValue;
     }
 
     @Mapping(target = "role", ignore = true)

--- a/src/test/java/com/epam/aidial/cfg/service/export/ConfigServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/export/ConfigServiceTest.java
@@ -5,6 +5,7 @@ import com.epam.aidial.cfg.domain.mapper.MapperPackage;
 import com.epam.aidial.cfg.domain.model.Addon;
 import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
+import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Interceptor;
 import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.domain.model.Model;
@@ -196,7 +197,11 @@ class ConfigServiceTest {
         var rawRoles = ResourceUtils.readResource("/domain/model/roles.json");
         var roles = objectMapper.readValue(rawRoles, new TypeReference<List<Role>>() {
         });
+        var rawDeployments = ResourceUtils.readResource("/domain/model/deployments_for_roles.json");
+        var deployments = objectMapper.readValue(rawDeployments, new TypeReference<List<Deployment>>() {
+        });
         when(roleService.getAllRoles()).thenReturn(roles);
+        when(deploymentService.getAll()).thenReturn(deployments);
 
         var actualConfig = configService.getConfig();
 

--- a/src/test/resources/domain/config/config_only_roles.json
+++ b/src/test/resources/domain/config/config_only_roles.json
@@ -19,13 +19,21 @@
           "requestHour": 500,
           "requestDay": 2000
         },
-        "sampleDeployment2": {
+        "sampleDeployment5": {
+          "minute": 23,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        },
+        "sampleDeployment6": {
           "minute": 20,
           "day": 2000,
-          "week": 10000,
-          "month": 40000,
-          "requestHour": 200,
-          "requestDay": 1000
+          "week": 9223372036854775807,
+          "month": 1000,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       },
       "share": {}

--- a/src/test/resources/domain/model/deployments_for_roles.json
+++ b/src/test/resources/domain/model/deployments_for_roles.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "sampleDeployment1",
+    "defaultRoleLimit": {}
+  },
+  {
+    "name": "sampleDeployment3",
+    "defaultRoleLimit": {
+      "minute": 23
+    }
+  },
+  {
+    "name": "sampleDeployment4"
+  },
+  {
+    "name": "sampleDeployment5",
+    "defaultRoleLimit": {
+      "minute": 23
+    }
+  },
+  {
+    "name": "sampleDeployment6",
+    "defaultRoleLimit": {
+      "day": 23,
+      "month": 1000
+    }
+  }
+]

--- a/src/test/resources/domain/model/roles.json
+++ b/src/test/resources/domain/model/roles.json
@@ -29,6 +29,32 @@
           "requestHour": 200,
           "requestDay": 1000
         }
+      },
+      {
+        "role": "admin",
+        "deploymentName": "sampleDeployment3",
+        "enabled": true
+      },
+      {
+        "role": "admin",
+        "deploymentName": "sampleDeployment4",
+        "enabled": true,
+        "limit": {}
+      },
+      {
+        "role": "admin",
+        "deploymentName": "sampleDeployment5",
+        "enabled": true,
+        "limit": {}
+      },
+      {
+        "role": "admin",
+        "deploymentName": "sampleDeployment6",
+        "enabled": true,
+        "limit": {
+          "minute": 20,
+          "day": 2000
+        }
       }
     ],
     "roles": [],


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #107 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Role limits which are being exported into Core config now are being overriden with default role limits if there are any

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.