### PR TITLE
fix: exclude "roleLimits" field from deployments for config export in Admin format

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
+import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.service.ApplicationService;
 import com.epam.aidial.cfg.model.ExportConfigComponent;
 import com.epam.aidial.cfg.model.ExportRequest;
@@ -30,11 +31,11 @@ public class ApplicationExporter {
     protected Map<String, Application> getApplications(ExportRequest request) {
         if (request instanceof FullExportRequest fullExportRequest) {
             return fullExportRequest.getComponentTypes().contains(ExportConfigComponentType.APPLICATION)
-                    ? getApplicationsWithRemovedDependencies(fullExportRequest.getComponentTypes()).stream()
+                    ? getApplicationsWithRemovedDependencies(fullExportRequest).stream()
                     .collect(Collectors.toMap(app -> app.getDeployment().getName(), Function.identity()))
                     : new HashMap<>();
         } else if (request instanceof SelectedItemsExportRequest selectedItemsExportRequest) {
-            return getApplicationsWithRemovedDependencies(selectedItemsExportRequest.getComponents()).stream()
+            return getApplicationsWithRemovedDependencies(selectedItemsExportRequest).stream()
                     .collect(Collectors.toMap(app -> app.getDeployment().getName(), Function.identity()));
         }
         throw new IllegalArgumentException("Unsupported request type: " + request.getClass());
@@ -60,13 +61,14 @@ public class ApplicationExporter {
         return applicationService.getApplication(applicationName);
     }
 
-    private Collection<Application> getApplicationsWithRemovedDependencies(Set<ExportConfigComponentType> componentTypes) {
+    private Collection<Application> getApplicationsWithRemovedDependencies(FullExportRequest fullExportRequest) {
         return getApplications().stream()
-                .map(app -> removeDependency(app, componentTypes))
+                .map(app -> removeDependency(app, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
                 .toList();
     }
 
-    private List<Application> getApplicationsWithRemovedDependencies(List<ExportConfigComponent> components) {
+    private List<Application> getApplicationsWithRemovedDependencies(SelectedItemsExportRequest selectedItemsExportRequest) {
+        List<ExportConfigComponent> components = selectedItemsExportRequest.getComponents();
         return components.stream()
                 .filter(component -> component.getType() == ExportConfigComponentType.APPLICATION)
                 .collect(Collectors.toMap(ExportConfigComponent::getName, Function.identity(),
@@ -78,19 +80,19 @@ public class ApplicationExporter {
                 .stream()
                 .map(component -> {
                     Application application = getApplication(component.getName());
-                    return removeDependency(application, component.getDependencies());
+                    return removeDependency(application, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
                 })
                 .toList();
     }
 
-    private Application removeDependency(Application app, Set<ExportConfigComponentType> componentTypes) {
+    private Application removeDependency(Application app, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
         if (!componentTypes.contains(ExportConfigComponentType.INTERCEPTOR)) {
             app.setInterceptors(null);
         }
         if (!componentTypes.contains(ExportConfigComponentType.APPLICATION_TYPE_SCHEMA)) {
             app.setApplicationTypeSchemaId(null);
         }
-        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             app.getDeployment().setRoleLimits(null);
         }
         return app;

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ApplicationExporter.java
@@ -92,6 +92,8 @@ public class ApplicationExporter {
         if (!componentTypes.contains(ExportConfigComponentType.APPLICATION_TYPE_SCHEMA)) {
             app.setApplicationTypeSchemaId(null);
         }
+        // Exclude role limits from deployment for Admin export format in order to have unidirectional association
+        // between deployments and roles, so it means that role with its limits will be defined only under "roles" section
         if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             app.getDeployment().setRoleLimits(null);
         }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -91,7 +91,7 @@ public class ModelExporter {
     }
 
     private Model removeDependency(Model model, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
-        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             model.getDeployment().setRoleLimits(null);
         }
         if (!componentTypes.contains(ExportConfigComponentType.INTERCEPTOR)) {

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -91,6 +91,8 @@ public class ModelExporter {
     }
 
     private Model removeDependency(Model model, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
+        // Exclude role limits from deployment for Admin export format in order to have unidirectional association
+        // between deployments and roles, so it means that role with its limits will be defined only under "roles" section
         if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             model.getDeployment().setRoleLimits(null);
         }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.service.transfer.exporter;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
+import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.Route;
 import com.epam.aidial.cfg.domain.model.Upstream;
 import com.epam.aidial.cfg.domain.service.RouteService;
@@ -36,7 +37,7 @@ public class RouteExporter {
                             (existing, newRoute) -> newRoute, LinkedHashMap::new))
                     : new LinkedHashMap<>();
         } else if (request instanceof SelectedItemsExportRequest selectedItemsExportRequest) {
-            return getRoutes(selectedItemsExportRequest.getComponents(), request.isAddSecrets()).stream()
+            return getRoutes(selectedItemsExportRequest, request.isAddSecrets()).stream()
                     .collect(Collectors.toMap(
                             route -> route.getDeployment().getName(), Function.identity(),
                             (existing, replacement) -> {
@@ -52,7 +53,8 @@ public class RouteExporter {
         return routeService.getAll();
     }
 
-    private List<Route> getRoutes(List<ExportConfigComponent> elements, boolean addSecrets) {
+    private List<Route> getRoutes(SelectedItemsExportRequest selectedItemsExportRequest, boolean addSecrets) {
+        List<ExportConfigComponent> elements = selectedItemsExportRequest.getComponents();
         return elements.stream()
                 .filter(component -> component.getType() == ExportConfigComponentType.ROUTE)
                 .collect(Collectors.toMap(ExportConfigComponent::getName, Function.identity(),
@@ -65,7 +67,7 @@ public class RouteExporter {
                 .stream()
                 .map(component -> {
                     Route route = routeService.get(component.getName());
-                    return removeDependency(route, component.getDependencies());
+                    return removeDependency(route, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
                 })
                 .map(route -> removeUpstreamKey(route, addSecrets))
                 .toList();
@@ -74,7 +76,7 @@ public class RouteExporter {
     private Collection<Route> getRoutes(FullExportRequest fullExportRequest) {
         return getRoutes().stream()
                 .map(route -> removeUpstreamKey(route, fullExportRequest.isAddSecrets()))
-                .map(route -> removeDependency(route, fullExportRequest.getComponentTypes()))
+                .map(route -> removeDependency(route, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
                 .toList();
     }
 
@@ -88,8 +90,8 @@ public class RouteExporter {
                 .collect(Collectors.toList());
     }
 
-    private Route removeDependency(Route route, Set<ExportConfigComponentType> componentTypes) {
-        if (!componentTypes.contains(ExportConfigComponentType.ROLE)) {
+    private Route removeDependency(Route route, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
+        if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             route.getDeployment().setRoleLimits(null);
         }
         return route;

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/RouteExporter.java
@@ -91,6 +91,8 @@ public class RouteExporter {
     }
 
     private Route removeDependency(Route route, Set<ExportConfigComponentType> componentTypes, ExportFormat exportFormat) {
+        // Exclude role limits from deployment for Admin export format in order to have unidirectional association
+        // between deployments and roles, so it means that role with its limits will be defined only under "roles" section
         if (!componentTypes.contains(ExportConfigComponentType.ROLE) || exportFormat == ExportFormat.ADMIN) {
             route.getDeployment().setRoleLimits(null);
         }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -440,17 +440,7 @@ public abstract class ConfigTransferFunctionalTest {
                     .satisfies(models -> {
                         Model model = models.get("modelName");
                         Assertions.assertThat(model.getInterceptors()).containsExactlyInAnyOrder("interceptorName");
-                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
-                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
-                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
-                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("modelName");
-                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
-                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
-                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
-                                    Assertions.assertThat(limit.getDay()).isNull();
-                                });
-                            });
-                        });
+                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNull();
                         Assertions.assertThat(model.getAdapter()).isNull();
                     });
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("interceptorName");
@@ -525,17 +515,7 @@ public abstract class ConfigTransferFunctionalTest {
                     .satisfies(models -> {
                         Model model = models.get("modelName");
                         Assertions.assertThat(model.getInterceptors()).containsExactlyInAnyOrder("interceptorName");
-                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
-                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
-                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
-                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("modelName");
-                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
-                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
-                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
-                                    Assertions.assertThat(limit.getDay()).isNull();
-                                });
-                            });
-                        });
+                        Assertions.assertThat(model.getDeployment().getRoleLimits()).isNull();
                         Assertions.assertThat(model.getAdapter().getName()).isEqualTo("testAdapter");
                     });
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("interceptorName");
@@ -586,20 +566,7 @@ public abstract class ConfigTransferFunctionalTest {
         Assertions.assertThat(result).isNotNull().satisfies(config -> {
             Assertions.assertThat(config.getRoutes()).isNotEmpty()
                     .containsOnlyKeys("routeName")
-                    .satisfies(routes -> {
-                        Route route = routes.get("routeName");
-                        Assertions.assertThat(route.getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
-                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
-                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
-                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("routeName");
-                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
-                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
-                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
-                                    Assertions.assertThat(limit.getDay()).isNull();
-                                });
-                            });
-                        });
-                    });
+                    .satisfies(routes -> Assertions.assertThat(routes.get("routeName").getDeployment().getRoleLimits()).isNull());
             Assertions.assertThat(config.getRoles()).isNotEmpty().containsKey("testRole");
             Assertions.assertThat(config.getRoles().get("testRole").getLimits()).isNotEmpty().hasSize(1).first()
                     .satisfies(limit -> Assertions.assertThat(limit.getDeploymentName()).isEqualTo("routeName"));
@@ -737,19 +704,8 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(config.getApplications()).isNotEmpty()
                     .containsOnlyKeys("applicationName")
                     .satisfies(apps -> {
-
                         Assertions.assertThat(apps.get("applicationName").getApplicationTypeSchemaId()).isEqualTo(customAppSchemaId);
-                        Assertions.assertThat(apps.get("applicationName").getDeployment().getRoleLimits()).isNotNull().satisfies(roleLimits -> {
-                            Assertions.assertThat(roleLimits).hasSize(1).first().satisfies(roleLimit -> {
-                                Assertions.assertThat(roleLimit.getRole()).isEqualTo("testRole");
-                                Assertions.assertThat(roleLimit.getDeploymentName()).isEqualTo("applicationName");
-                                Assertions.assertThat(roleLimit.isEnabled()).isTrue();
-                                Assertions.assertThat(roleLimit.getLimit()).isNotNull().satisfies(limit -> {
-                                    Assertions.assertThat(limit.getMinute()).isEqualTo(5);
-                                    Assertions.assertThat(limit.getDay()).isNull();
-                                });
-                            });
-                        });
+                        Assertions.assertThat(apps.get("applicationName").getDeployment().getRoleLimits()).isNull();
                     });
 
             Assertions.assertThat(config.getApplicationRunners()).isNotEmpty().containsOnlyKeys("https://test-schema-id.example");


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #109 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Exclude `roleLimits` field from deployments for config export in Admin format

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.