### PR TITLE
fix: fix model endpoint parsing when "endpointDeploymentName" part ends with v1

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -40,7 +40,7 @@ public class ModelEndpointUtils {
     public ModelEndpointComponents parseModelEndpoint(String modelEndpoint, com.epam.aidial.core.config.ModelType type) {
         boolean isChat = isChat(type);
         String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
-        boolean isDirectOpenAiEndpoint = modelEndpoint.endsWith("v1/" + endpointEnding);
+        boolean isDirectOpenAiEndpoint = modelEndpoint.endsWith("/v1/" + endpointEnding);
 
         if (isDirectOpenAiEndpoint) {
             String adapterEndpoint = Strings.CS.removeEnd(modelEndpoint, endpointEnding);

--- a/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
@@ -119,6 +119,16 @@ class ModelEndpointUtilsTest {
                         "http://host/v1/embeddings",
                         ModelType.EMBEDDING,
                         new ModelEndpointComponents("http://host/v1/", null)
+                ),
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name-v1/chat/completions",
+                        ModelType.CHAT,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name-v1")
+                ),
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name-v1/embeddings",
+                        ModelType.EMBEDDING,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name-v1")
                 )
         );
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #112 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Fixed model endpoint parsing when "endpointDeploymentName" part ends with v1

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.