### PR TITLE
hotfix: fix model endpoint parsing when "endpointDeploymentName" part ends with v1, remove applications that doesn't conform to their schemas from exported core config, remove keys without roles from manually exported core config

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/configuration/ValidationConfig.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/ValidationConfig.java
@@ -1,0 +1,14 @@
+package com.epam.aidial.cfg.configuration;
+
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class ValidationConfig {
+
+    @Bean
+    public CustomApplicationConformToTypeSchemaValidator customApplicationConformToTypeSchemaValidator() {
+        return new CustomApplicationConformToTypeSchemaValidator();
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -40,7 +40,7 @@ public class ModelEndpointUtils {
     public ModelEndpointComponents parseModelEndpoint(String modelEndpoint, com.epam.aidial.core.config.ModelType type) {
         boolean isChat = isChat(type);
         String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
-        boolean isDirectOpenAiEndpoint = modelEndpoint.endsWith("v1/" + endpointEnding);
+        boolean isDirectOpenAiEndpoint = modelEndpoint.endsWith("/v1/" + endpointEnding);
 
         if (isDirectOpenAiEndpoint) {
             String adapterEndpoint = Strings.CS.removeEnd(modelEndpoint, endpointEnding);

--- a/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizer.java
@@ -1,0 +1,40 @@
+package com.epam.aidial.cfg.service.normalizer.impl;
+
+import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidationContext;
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ApplicationCoreConfigNormalizer implements CoreConfigNormalizer {
+
+    private final CustomApplicationConformToTypeSchemaValidator customApplicationConformToTypeSchemaValidator;
+
+    @Override
+    public void normalize(Config config) {
+        Map<String, CoreApplication> applications = config.getApplications();
+        if (MapUtils.isEmpty(applications)) {
+            return;
+        }
+
+        var validationContext = new CustomApplicationConformToTypeSchemaValidationContext(config);
+        for (Map.Entry<String, CoreApplication> applicationEntry : new HashMap<>(applications).entrySet()) {
+            String applicationName = applicationEntry.getKey();
+            CoreApplication application = applicationEntry.getValue();
+            if (!customApplicationConformToTypeSchemaValidator.isValid(application, validationContext)) {
+                log.debug("normalizeConfig. remove invalid application which doesn't conform to its schema: {}", applicationName);
+                applications.remove(applicationName);
+            }
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/KeyCoreConfigNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/KeyCoreConfigNormalizer.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.service.normalizer.impl;
 
 import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
+import com.epam.aidial.cfg.utils.SecretUtils;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 @Component
 @Slf4j
-public class KeyNormalizer implements CoreConfigNormalizer {
+public class KeyCoreConfigNormalizer implements CoreConfigNormalizer {
 
     @Override
     public void normalize(Config config) {
@@ -27,7 +28,7 @@ public class KeyNormalizer implements CoreConfigNormalizer {
             String keyId = keyId2ValuePair.getKey();
             CoreKey key = keyId2ValuePair.getValue();
             if (StringUtils.isEmpty(key.getRole()) && CollectionUtils.isEmpty(key.getRoles())) {
-                log.debug("normalizeConfig. remove invalid key: {}", keyId);
+                log.debug("normalizeConfig. remove invalid key with empty roles: {}", SecretUtils.mask(keyId));
                 keys.remove(keyId);
             }
         }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
@@ -11,6 +11,7 @@ import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
 import com.epam.aidial.cfg.model.ExportRequest;
 import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
+import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
 import com.epam.aidial.cfg.service.transfer.exporter.ConfigExporter;
 import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.service.transfer.importer.AdapterImporter;
@@ -65,6 +66,7 @@ public class ConfigTransfer {
     private final ObjectMapper jsonMapper = JsonMapperConfiguration.createJsonMapper();
     private final ConfigExportProperties properties;
     private final VersionAwareFieldFilter versionAwareFieldFilter;
+    private final List<CoreConfigNormalizer> normalizers;
 
     private final ModelImporter modelImporter;
     private final AddonImporter addonTransfer;
@@ -110,6 +112,7 @@ public class ConfigTransfer {
 
     private StreamingResponseBody exportCoreConfig(ExportConfig config) {
         Config fullCoreConfig = configMapper.toCoreConfig(config);
+        normalizers.forEach(n -> n.normalize(fullCoreConfig));
         Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
         return outputStream -> {
             try {

--- a/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationConformToTypeSchemaValidationContext.java
+++ b/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationConformToTypeSchemaValidationContext.java
@@ -1,0 +1,31 @@
+package com.epam.aidial.core.config.validation;
+
+import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonMetaSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.NonValidationKeyword;
+import com.networknt.schema.SpecVersion;
+import lombok.Getter;
+
+import static com.epam.aidial.core.metaschemas.MetaSchemaHolder.getMetaschemaBuilder;
+
+@Getter
+public class CustomApplicationConformToTypeSchemaValidationContext {
+
+    private static final JsonMetaSchema DIAL_META_SCHEMA = getMetaschemaBuilder()
+            .keyword(new NonValidationKeyword("dial:meta"))
+            .keyword(new NonValidationKeyword("dial:file"))
+            .build();
+
+    private final JsonSchemaFactory schemaFactory;
+    private final ObjectMapper mapper;
+
+    public CustomApplicationConformToTypeSchemaValidationContext(Config value) {
+        schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7, builder ->
+                builder.schemaLoaders(loaders -> loaders.schemas(value.getApplicationTypeSchemas()))
+                        .metaSchema(DIAL_META_SCHEMA)
+        );
+        mapper = new ObjectMapper();
+    }
+}

--- a/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationConformToTypeSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationConformToTypeSchemaValidator.java
@@ -1,0 +1,42 @@
+package com.epam.aidial.core.config.validation;
+
+import com.epam.aidial.core.config.CoreApplication;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.ValidationMessage;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Set;
+
+@Component
+public class CustomApplicationConformToTypeSchemaValidator {
+
+    public boolean isValid(CoreApplication application,
+                           CustomApplicationConformToTypeSchemaValidationContext validationContext) {
+        return CollectionUtils.isEmpty(validate(application, validationContext));
+    }
+
+    public static Set<ValidationMessage> validate(CoreApplication application,
+                                                  CustomApplicationConformToTypeSchemaValidationContext validationContext) {
+        URI schemaId = application.getApplicationTypeSchemaId();
+        if (schemaId == null) {
+            return Set.of();
+        }
+
+        if (application.getApplicationProperties() == null) {
+            return Set.of();
+        }
+
+        JsonSchemaFactory schemaFactory = validationContext.getSchemaFactory();
+        ObjectMapper mapper = validationContext.getMapper();
+
+        JsonNode applicationNode = mapper.valueToTree(application.getApplicationProperties());
+        JsonSchema schema = schemaFactory.getSchema(schemaId);
+
+        return schema.validate(applicationNode);
+    }
+}

--- a/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidator.java
+++ b/src/main/java/com/epam/aidial/core/config/validation/CustomApplicationsConformToTypeSchemasValidator.java
@@ -1,64 +1,39 @@
 package com.epam.aidial.core.config.validation;
 
-import static com.epam.aidial.core.metaschemas.MetaSchemaHolder.getMetaschemaBuilder;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.Set;
-
-import com.epam.aidial.core.config.CoreApplication;
 import com.epam.aidial.core.config.Config;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.JsonMetaSchema;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.NonValidationKeyword;
-import com.networknt.schema.SpecVersion;
+import com.epam.aidial.core.config.CoreApplication;
 import com.networknt.schema.ValidationMessage;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
 @Slf4j
 public class CustomApplicationsConformToTypeSchemasValidator implements ConstraintValidator<CustomApplicationsConformToTypeSchemas, Config> {
-
-
-    private static final JsonMetaSchema DIAL_META_SCHEMA = getMetaschemaBuilder()
-            .keyword(new NonValidationKeyword("dial:meta"))
-            .keyword(new NonValidationKeyword("dial:file"))
-            .build();
 
     @Override
     public boolean isValid(Config value, ConstraintValidatorContext context) {
         if (value == null) {
             return true;
         }
-        JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7, builder ->
-                builder.schemaLoaders(loaders -> loaders.schemas(value.getApplicationTypeSchemas()))
-                        .metaSchema(DIAL_META_SCHEMA)
-        );
 
-        ObjectMapper mapper = new ObjectMapper();
+        var validationContext = new CustomApplicationConformToTypeSchemaValidationContext(value);
+
         for (Map.Entry<String, CoreApplication> entry : value.getApplications().entrySet()) {
             CoreApplication application = entry.getValue();
-            URI schemaId = application.getApplicationTypeSchemaId();
-            if (schemaId == null) {
-                continue;
-            }
-
-            JsonSchema schema = schemaFactory.getSchema(schemaId);
-            if (application.getApplicationProperties() == null) {
-                continue;
-            }
-            JsonNode applicationNode = mapper.valueToTree(application.getApplicationProperties());
-            Set<ValidationMessage> validationResults = schema.validate(applicationNode);
+            Set<ValidationMessage> validationResults = CustomApplicationConformToTypeSchemaValidator.validate(
+                    application,
+                    validationContext
+            );
             if (!validationResults.isEmpty()) {
                 String logMessage = validationResults.stream()
                         .map(ValidationMessage::getMessage)
                         .reduce((a, b) -> a + ", " + b)
                         .orElse("Unknown validation error");
+                URI schemaId = application.getApplicationTypeSchemaId();
                 log.error("Application {} does not conform to schema {}: {}", entry.getKey(), schemaId, logMessage);
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())

--- a/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
@@ -119,6 +119,16 @@ class ModelEndpointUtilsTest {
                         "http://host/v1/embeddings",
                         ModelType.EMBEDDING,
                         new ModelEndpointComponents("http://host/v1/", null)
+                ),
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name-v1/chat/completions",
+                        ModelType.CHAT,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name-v1")
+                ),
+                Arguments.of(
+                        "http://host/openai/deployments/endpoint-deployment-name-v1/embeddings",
+                        ModelType.EMBEDDING,
+                        new ModelEndpointComponents("http://host/openai/deployments/", "endpoint-deployment-name-v1")
                 )
         );
     }

--- a/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
@@ -29,6 +29,7 @@ import com.epam.aidial.cfg.service.export.CoreConfigAggregatorService;
 import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import com.epam.aidial.cfg.web.facade.HistoryFacade;
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidator;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Import;
         "com.epam.aidial.cfg.domain",
         "com.epam.aidial.cfg.web.facade",
         "com.epam.aidial.cfg.service.transfer",
+        "com.epam.aidial.cfg.service.normalizer",
         "com.epam.aidial.cfg.transaction",
 })
 @Import({JsonMapperConfiguration.class, JpaConfiguration.class, HibernateConfiguration.class})
@@ -106,6 +108,11 @@ public class FunctionalTestConfiguration {
     @Bean
     public AnonymousCoreConfigClient coreConfigClient() {
         return Mockito.mock(AnonymousCoreConfigClient.class);
+    }
+
+    @Bean
+    public CustomApplicationConformToTypeSchemaValidator customApplicationConformToTypeSchemaValidator() {
+        return new CustomApplicationConformToTypeSchemaValidator();
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
@@ -6,6 +6,7 @@ import com.epam.aidial.cfg.configuration.CoreConfigVersionProperties;
 import com.epam.aidial.cfg.configuration.HibernateConfiguration;
 import com.epam.aidial.cfg.configuration.JpaConfiguration;
 import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
+import com.epam.aidial.cfg.configuration.ValidationConfig;
 import com.epam.aidial.cfg.domain.mapper.AddonCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationTypeSchemaCoreMapper;
@@ -29,7 +30,6 @@ import com.epam.aidial.cfg.service.export.CoreConfigAggregatorService;
 import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import com.epam.aidial.cfg.web.facade.HistoryFacade;
-import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidator;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -46,7 +46,7 @@ import org.springframework.context.annotation.Import;
         "com.epam.aidial.cfg.service.normalizer",
         "com.epam.aidial.cfg.transaction",
 })
-@Import({JsonMapperConfiguration.class, JpaConfiguration.class, HibernateConfiguration.class})
+@Import({JsonMapperConfiguration.class, JpaConfiguration.class, HibernateConfiguration.class, ValidationConfig.class})
 @EnableAspectJAutoProxy
 public class FunctionalTestConfiguration {
 
@@ -108,11 +108,6 @@ public class FunctionalTestConfiguration {
     @Bean
     public AnonymousCoreConfigClient coreConfigClient() {
         return Mockito.mock(AnonymousCoreConfigClient.class);
-    }
-
-    @Bean
-    public CustomApplicationConformToTypeSchemaValidator customApplicationConformToTypeSchemaValidator() {
-        return new CustomApplicationConformToTypeSchemaValidator();
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -11,7 +11,6 @@ import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.ExportKeyInfo;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
 import com.epam.aidial.cfg.domain.model.Model;
-import com.epam.aidial.cfg.domain.model.Route;
 import com.epam.aidial.cfg.dto.AdapterDto;
 import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.ApplicationDto;
@@ -51,6 +50,7 @@ import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -364,9 +364,6 @@ public abstract class ConfigTransferFunctionalTest {
         ModelDto modelDto = new ModelDto();
         modelDto.setName("modelName");
         modelDto.setInterceptors(List.of("interceptorName"));
-        var dto = jsonMapper.readValue(getAppRunnerDto(), new TypeReference<ApplicationTypeSchemaDto>() {
-        });
-        applicationTypeSchemaFacade.create(dto);
         interceptorFacade.createInterceptor(interceptorDto);
         modelFacade.createModel(modelDto);
         // when
@@ -612,6 +609,70 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("interceptorName");
             Assertions.assertThat(config.getApplicationTypeSchemas()).isNotEmpty().containsOnlyKeys("https://test-schema-id.example");
             Assertions.assertThat(result.getModels()).isEmpty();
+        });
+    }
+
+    @Test
+    void testExport_CoreFormatAppDoesNotConformToAppRunner_FullRequest() throws IOException, URISyntaxException {
+        // given
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.CORE);
+        request.setComponentTypes(Set.of(
+                ExportConfigComponentType.APPLICATION,
+                ExportConfigComponentType.APPLICATION_TYPE_SCHEMA
+        ));
+
+        URI customAppSchemaId = new URI("https://test-schema-id.example");
+        ApplicationDto applicationDto = new ApplicationDto();
+        applicationDto.setName("applicationName");
+        applicationDto.setCustomAppSchemaId(customAppSchemaId);
+
+        ApplicationTypeSchemaDto schemaDto = jsonMapper.readValue(
+                getAppRunnerDtoWithRequiredFields(List.of("external_url")),
+                new TypeReference<>() {
+                }
+        );
+
+        applicationTypeSchemaFacade.create(schemaDto);
+        applicationFacade.createApplication(applicationDto);
+
+        // when
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // then
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        streamingResponseBody.writeTo(outputStream);
+
+        Config result = jsonMapper.readValue(outputStream.toString(), Config.class);
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getApplications()).isEmpty();
+            Assertions.assertThat(config.getApplicationTypeSchemas()).isNotEmpty().containsOnlyKeys("https://test-schema-id.example");
+        });
+    }
+
+    @Test
+    void testExport_CoreFormatKeyWithoutRoles_FullRequest() throws IOException, URISyntaxException {
+        // given
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentType.KEY));
+
+        KeyDto keyDto = new KeyDto();
+        keyDto.setName("testKey");
+        keyDto.setKey("testKeyValue");
+
+        keyFacade.createKey(keyDto);
+
+        // when
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // then
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        streamingResponseBody.writeTo(outputStream);
+
+        Config result = jsonMapper.readValue(outputStream.toString(), Config.class);
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getKeys()).isEmpty();
         });
     }
 
@@ -1326,21 +1387,29 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     private String getAppRunnerDto() {
+        return getAppRunnerDtoWithRequiredFields(null);
+    }
+
+    private String getAppRunnerDtoWithRequiredFields(List<String> requiredFields) {
+        String requiredFieldsString = CollectionUtils.emptyIfNull(requiredFields).stream()
+                .map(field -> "\"" + field + "\"")
+                .collect(Collectors.joining(", "));
         return """
-                {"$id": "https://test-schema-id.example",
-                        "dial:applicationTypeEditorUrl": "https://test.com/billings",
-                        "dial:applicationTypeViewerUrl": "https://test.com/claims",
-                        "dial:applicationTypeDisplayName": "runner display name",
-                        "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
-                        "dial:applicationTypeConfigurationEndpoint": "https://test.com/conf",
-                        "dial:applicationTypeRateEndpoint": "https://test.com/rate",
-                        "dial:applicationTypeTokenizeEndpoint": "https://test.com/tokenize",
-                        "dial:applicationTypeTruncatePromptEndpoint": "https://test.com/truncate-prompt",
-                        "dial:appendApplicationPropertiesHeader": false,
-                        "$defs": {},
-                        "properties": {},
-                        "required": []
-                      }""";
+                {
+                    "$id": "https://test-schema-id.example",
+                    "dial:applicationTypeEditorUrl": "https://test.com/billings",
+                    "dial:applicationTypeViewerUrl": "https://test.com/claims",
+                    "dial:applicationTypeDisplayName": "runner display name",
+                    "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
+                    "dial:applicationTypeConfigurationEndpoint": "https://test.com/conf",
+                    "dial:applicationTypeRateEndpoint": "https://test.com/rate",
+                    "dial:applicationTypeTokenizeEndpoint": "https://test.com/tokenize",
+                    "dial:applicationTypeTruncatePromptEndpoint": "https://test.com/truncate-prompt",
+                    "dial:appendApplicationPropertiesHeader": false,
+                    "$defs": {},
+                    "properties": {},
+                    "required": [%s]
+                }""".formatted(requiredFieldsString);
     }
 
     private static ConfigImportOptions overrideAndCreateRoleAndCreateNew() {

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizerTest.java
@@ -1,0 +1,93 @@
+package com.epam.aidial.cfg.service.normalizer.impl;
+
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidationContext;
+import com.epam.aidial.core.config.validation.CustomApplicationConformToTypeSchemaValidator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationCoreConfigNormalizerTest {
+
+    @Mock
+    private CustomApplicationConformToTypeSchemaValidator customApplicationConformToTypeSchemaValidator;
+
+    @InjectMocks
+    private ApplicationCoreConfigNormalizer normalizer;
+
+    @Test
+    void testNormalize_applicationsMissingInConfig_doNothing() {
+        // given
+        Config config = new Config();
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplications()).isEmpty();
+        verifyNoInteractions(customApplicationConformToTypeSchemaValidator);
+    }
+
+    @Test
+    void testNormalize_applicationDoesNotConformToItsSchema_RemoveApplication() {
+        // given
+        CoreApplication application = new CoreApplication();
+
+        Map<String, CoreApplication> applicationsMap = new HashMap<>();
+        applicationsMap.put("testApplication", application);
+
+        Config config = new Config();
+        config.setApplications(applicationsMap);
+
+        when(customApplicationConformToTypeSchemaValidator.isValid(
+                eq(application),
+                any(CustomApplicationConformToTypeSchemaValidationContext.class))
+        ).thenReturn(false);
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplications()).isEmpty();
+    }
+
+    @Test
+    void testNormalize_applicationConformsToItsSchema_DoesNotRemoveApplication() {
+        // given
+        CoreApplication application = new CoreApplication();
+
+        Map<String, CoreApplication> applicationsMap = new HashMap<>();
+        applicationsMap.put("testApplication", application);
+
+        Config config = new Config();
+        config.setApplications(applicationsMap);
+
+        when(customApplicationConformToTypeSchemaValidator.isValid(
+                eq(application),
+                any(CustomApplicationConformToTypeSchemaValidationContext.class))
+        ).thenReturn(true);
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplications()).hasSize(1).satisfies(applications -> {
+            CoreApplication coreApplication = applications.get("testApplication");
+            assertThat(coreApplication).isNotNull();
+        });
+    }
+
+}

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/KeyCoreConfigNormalizerTests.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/KeyCoreConfigNormalizerTests.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-class KeyNormalizerTests {
+class KeyCoreConfigNormalizerTests {
 
-    private KeyNormalizer normalizer;
+    private KeyCoreConfigNormalizer normalizer;
 
     @BeforeEach
     void init() {
-        normalizer = new KeyNormalizer();
+        normalizer = new KeyCoreConfigNormalizer();
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #112 
- fixes #117
- fixes #118

### Description of changes
- Fixed model endpoint parsing when "endpointDeploymentName" part ends with v1
- Applications that doesn't conform to their schemas are removed from exported Core config
- Keys without roles are removed from manually (on UI) exported Core config

Original PRs:
- #113
- #119
- #120

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.