### PR TITLE
hotfix: add placeholder for deployment manager client url

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -244,12 +244,12 @@ example of json file provided via METRICS_CONFIGFILE_CONTENTENVVAR or METRICS_CO
 
 ## Plugins Configuration
 
-| Setting                                              | Environment Variable                                    | Default | Required | Applied when                                               | Description                                              |
-|------------------------------------------------------|---------------------------------------------------------|---------|----------|------------------------------------------------------------|----------------------------------------------------------|
-| plugins.deployment.manager.client.url                | PLUGINS_DEPLOYMENT_MANAGER_CLIENT_URL                   | -       | No       | -                                                          | Deployment manager client URL                            |
-| plugins.deployment.manager.cache.expiration.interval | PLUGINS_DEPLOYMENT_MANAGER_CACHE_EXPIRATION_INTERVAL_MS | 300000  | No       | -                                                          | Expiration interval (in ms) of deployment manager cache  |
-| plugins.deployment.manager.endpoint.refresh.enabled  | ENABLE_PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH      | false   | No       | -                                                          | Enable deployment manager endpoint refresh               |
-| plugins.deployment.manager.endpoint.refresh.interval | PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH_INTERVAL_MS | 360000  | No       | plugins.deployment.manager.endpoint.refresh.enabled = true | Refresh interval (in ms) of deployment manager endpoints |
+| Setting                                              | Environment Variable                                    | Default         | Required | Applied when                                               | Description                                              |
+|------------------------------------------------------|---------------------------------------------------------|-----------------|----------|------------------------------------------------------------|----------------------------------------------------------|
+| plugins.deployment.manager.client.url                | PLUGINS_DEPLOYMENT_MANAGER_CLIENT_URL                   | url-placeholder | No       | -                                                          | Deployment manager client URL                            |
+| plugins.deployment.manager.cache.expiration.interval | PLUGINS_DEPLOYMENT_MANAGER_CACHE_EXPIRATION_INTERVAL_MS | 300000          | No       | -                                                          | Expiration interval (in ms) of deployment manager cache  |
+| plugins.deployment.manager.endpoint.refresh.enabled  | ENABLE_PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH      | false           | No       | -                                                          | Enable deployment manager endpoint refresh               |
+| plugins.deployment.manager.endpoint.refresh.interval | PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH_INTERVAL_MS | 360000          | No       | plugins.deployment.manager.endpoint.refresh.enabled = true | Refresh interval (in ms) of deployment manager endpoints |
 
 ## Validation Configuration
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentManagerService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentManagerService.java
@@ -6,7 +6,6 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.exception.DeploymentClientNotExistsException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.networknt.schema.utils.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -49,7 +48,7 @@ public class DeploymentManagerService {
     }
 
     private DeploymentInfoDto getDeploymentInfoDto(String id) {
-        if (StringUtils.isBlank(deploymentClientUrl)) {
+        if ("url-placeholder".equals(deploymentClientUrl)) {
             throw new DeploymentClientNotExistsException();
         }
         return deploymentManagerClient.getDeployment(id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -159,7 +159,7 @@ config.import.configsMaxCount=${IMPORT_CONFIGS_MAX_COUNT:64}
 features.flags.addonsSupported=${ADDONS_SUPPORTED:false}
 features.flags.assistantsSupported=${ASSISTANTS_SUPPORTED:false}
 
-plugins.deployment.manager.client.url=${PLUGINS_DEPLOYMENT_MANAGER_CLIENT_URL}
+plugins.deployment.manager.client.url=${PLUGINS_DEPLOYMENT_MANAGER_CLIENT_URL:url-placeholder}
 plugins.deployment.manager.cache.expiration.interval=${PLUGINS_DEPLOYMENT_MANAGER_CACHE_EXPIRATION_INTERVAL_MS:300000}
 plugins.deployment.manager.endpoint.refresh.enabled=${ENABLE_PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH:false}
 plugins.deployment.manager.endpoint.refresh.interval=${PLUGINS_DEPLOYMENT_MANAGER_ENDPOINT_REFRESH_INTERVAL_MS:360000}


### PR DESCRIPTION
### Applicable issues

- related to #99 

### Description of changes

Added 'url-placeholder' default value for 'plugins.deployment.manager.client.url'

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.