### PR TITLE
chore: change jre image to eclipse-temurin:17-jre-noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY query-language/build.gradle query-language/
 RUN gradle --no-daemon clean bootJar
 
 # Runtime stage
-FROM eclipse-temurin:17-jre-alpine AS runtime
+FROM eclipse-temurin:17-jre-noble AS runtime
 WORKDIR /app
 
 RUN adduser -u 1001 --disabled-password --gecos "" appuser && \


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes
Changed jre image from eclipse-temurin:17-jre-alpine to eclipse-temurin:17-jre-noble due to CVE-2025-6965
<img width="1121" height="578" alt="image" src="https://github.com/user-attachments/assets/a7695fc0-ff70-44e7-a1bd-cae622c86ef2" />

Links:
[17-jre-noble](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-noble/images/sha256-7b95b9e99d990ba4a61ef0f831899d20be73a36cbca07954b50e2bb340e63c6b)
[17-jre-alpine](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-abdeb8e68308f36e577ab612b2e629ba7f73556676139e049f45427d54bd74c2)




<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.