### PR TITLE
fix!: validate entity id is not empty and doesn't have illegal characters during creation

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
@@ -26,7 +26,7 @@ public class AdapterValidator {
     public void validateAdapterCreation(Adapter adapter) {
         final String adapterName = adapter.getName();
 
-        idFieldValidator.validateName(adapterName);
+        idFieldValidator.validateName("Adapter", adapterName);
 
         if (StringUtils.isEmpty(adapterNameValidationPattern)) {
             log.debug("Adapter name validation pattern is empty, skipping validation for adapter: {}", adapterName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Adapter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,14 +11,22 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class AdapterValidator {
 
-    @Value("${validation.adapter.name:}")
-    private String adapterNameValidationPattern;
+    private final IdFieldValidator idFieldValidator;
+
+    private final String adapterNameValidationPattern;
+
+    public AdapterValidator(IdFieldValidator idFieldValidator,
+                            @Value("${validation.adapter.name:}") String adapterNameValidationPattern) {
+        this.idFieldValidator = idFieldValidator;
+        this.adapterNameValidationPattern = adapterNameValidationPattern;
+    }
 
     public void validateAdapterCreation(Adapter adapter) {
         final String adapterName = adapter.getName();
+
+        idFieldValidator.validateName(adapterName);
 
         if (StringUtils.isEmpty(adapterNameValidationPattern)) {
             log.debug("Adapter name validation pattern is empty, skipping validation for adapter: {}", adapterName);
@@ -28,7 +35,7 @@ public class AdapterValidator {
 
         if (!Pattern.matches(adapterNameValidationPattern, adapterName)) {
             throw new IllegalArgumentException("Adapter name '" + adapterName
-                + "' does not match the required pattern: " + adapterNameValidationPattern);
+                    + "' does not match the required pattern: " + adapterNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Addon;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,16 +10,22 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class AddonValidator {
 
     private final DeploymentValidator deploymentValidator;
 
-    @Value("${validation.addon.name:}")
-    private String addonNameValidationPattern;
+    private final String addonNameValidationPattern;
+
+    public AddonValidator(DeploymentValidator deploymentValidator,
+                          @Value("${validation.addon.name:}") String addonNameValidationPattern) {
+        this.deploymentValidator = deploymentValidator;
+        this.addonNameValidationPattern = addonNameValidationPattern;
+    }
 
     public void validateAddonCreation(Addon addon) {
         final String addonName = addon.getDeployment().getName();
+
+        deploymentValidator.validateCreation(addonName);
 
         if (StringUtils.isEmpty(addonNameValidationPattern)) {
             log.debug("Addon name validation pattern is empty, skipping validation for addon: {}", addonName);
@@ -29,7 +34,7 @@ public class AddonValidator {
 
         if (!Pattern.matches(addonNameValidationPattern, addonName)) {
             throw new IllegalArgumentException("Addon name '" + addonName
-                + "' does not match the required pattern: " + addonNameValidationPattern);
+                    + "' does not match the required pattern: " + addonNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
@@ -25,7 +25,7 @@ public class AddonValidator {
     public void validateAddonCreation(Addon addon) {
         final String addonName = addon.getDeployment().getName();
 
-        deploymentValidator.validateCreation(addonName);
+        deploymentValidator.validateCreation("Addon", addonName);
 
         if (StringUtils.isEmpty(addonNameValidationPattern)) {
             log.debug("Addon name validation pattern is empty, skipping validation for addon: {}", addonName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
@@ -26,7 +26,7 @@ public class ApplicationTypeSchemaValidator {
     public void validateCreation(ApplicationTypeSchema applicationTypeSchema) {
         final String schemaId = applicationTypeSchema.getSchemaId();
 
-        idFieldValidator.validateId(schemaId, "schemaId");
+        idFieldValidator.validateId("ApplicationTypeSchema", schemaId, "schemaId");
 
         if (StringUtils.isEmpty(applicationTypeSchemaIdValidationPattern)) {
             log.debug("ApplicationTypeSchema id validation pattern is empty, skipping validation for schema id: {}", schemaId);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
@@ -13,11 +13,20 @@ import java.util.regex.Pattern;
 @Component
 public class ApplicationTypeSchemaValidator {
 
-    @Value("${validation.applicationTypeSchema.id:}")
-    private String applicationTypeSchemaIdValidationPattern;
+    private final IdFieldValidator idFieldValidator;
+
+    private final String applicationTypeSchemaIdValidationPattern;
+
+    public ApplicationTypeSchemaValidator(IdFieldValidator idFieldValidator,
+                                          @Value("${validation.applicationTypeSchema.id:}") String applicationTypeSchemaIdValidationPattern) {
+        this.idFieldValidator = idFieldValidator;
+        this.applicationTypeSchemaIdValidationPattern = applicationTypeSchemaIdValidationPattern;
+    }
 
     public void validateCreation(ApplicationTypeSchema applicationTypeSchema) {
         final String schemaId = applicationTypeSchema.getSchemaId();
+
+        idFieldValidator.validateId(schemaId, "schemaId");
 
         if (StringUtils.isEmpty(applicationTypeSchemaIdValidationPattern)) {
             log.debug("ApplicationTypeSchema id validation pattern is empty, skipping validation for schema id: {}", schemaId);
@@ -26,7 +35,7 @@ public class ApplicationTypeSchemaValidator {
 
         if (!Pattern.matches(applicationTypeSchemaIdValidationPattern, schemaId)) {
             throw new IllegalArgumentException("ApplicationTypeSchema ID '" + schemaId
-                + "' does not match the required pattern: " + applicationTypeSchemaIdValidationPattern);
+                    + "' does not match the required pattern: " + applicationTypeSchemaIdValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
@@ -41,7 +41,7 @@ public class ApplicationValidator {
     private void validateApplicationName(Application application) {
         final String applicationName = application.getDeployment().getName();
 
-        deploymentValidator.validateCreation(applicationName);
+        deploymentValidator.validateCreation("Application", applicationName);
 
         if (StringUtils.isEmpty(applicationNameValidationPattern)) {
             log.debug("Application name validation pattern is empty, skipping validation for application: {}", applicationName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Application;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,14 +11,20 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class ApplicationValidator {
 
     private final DisplayFieldsValidator displayFieldsValidator;
     private final DeploymentValidator deploymentValidator;
 
-    @Value("${validation.application.name:}")
-    private String applicationNameValidationPattern;
+    private final String applicationNameValidationPattern;
+
+    public ApplicationValidator(DisplayFieldsValidator displayFieldsValidator,
+                                DeploymentValidator deploymentValidator,
+                                @Value("${validation.application.name:}") String applicationNameValidationPattern) {
+        this.displayFieldsValidator = displayFieldsValidator;
+        this.deploymentValidator = deploymentValidator;
+        this.applicationNameValidationPattern = applicationNameValidationPattern;
+    }
 
     public void validateCreation(Application application) {
         validateApplicationName(application);
@@ -36,6 +41,8 @@ public class ApplicationValidator {
     private void validateApplicationName(Application application) {
         final String applicationName = application.getDeployment().getName();
 
+        deploymentValidator.validateCreation(applicationName);
+
         if (StringUtils.isEmpty(applicationNameValidationPattern)) {
             log.debug("Application name validation pattern is empty, skipping validation for application: {}", applicationName);
             return;
@@ -43,7 +50,7 @@ public class ApplicationValidator {
 
         if (!Pattern.matches(applicationNameValidationPattern, applicationName)) {
             throw new IllegalArgumentException("Application name '" + applicationName
-                + "' does not match the required pattern: " + applicationNameValidationPattern);
+                    + "' does not match the required pattern: " + applicationNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
@@ -25,7 +25,7 @@ public class AssistantValidator {
     public void validateAssistantCreation(Assistant assistant) {
         final String assistantName = assistant.getDeployment().getName();
 
-        deploymentValidator.validateCreation(assistantName);
+        deploymentValidator.validateCreation("Assistant", assistantName);
 
         if (StringUtils.isEmpty(assistantNameValidationPattern)) {
             log.debug("Assistant name validation pattern is empty, skipping validation for assistant: {}", assistantName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Assistant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,16 +10,22 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class AssistantValidator {
 
     private final DeploymentValidator deploymentValidator;
 
-    @Value("${validation.assistant.name:}")
-    private String assistantNameValidationPattern;
+    private final String assistantNameValidationPattern;
+
+    public AssistantValidator(DeploymentValidator deploymentValidator,
+                              @Value("${validation.assistant.name:}") String assistantNameValidationPattern) {
+        this.deploymentValidator = deploymentValidator;
+        this.assistantNameValidationPattern = assistantNameValidationPattern;
+    }
 
     public void validateAssistantCreation(Assistant assistant) {
         final String assistantName = assistant.getDeployment().getName();
+
+        deploymentValidator.validateCreation(assistantName);
 
         if (StringUtils.isEmpty(assistantNameValidationPattern)) {
             log.debug("Assistant name validation pattern is empty, skipping validation for assistant: {}", assistantName);
@@ -29,7 +34,7 @@ public class AssistantValidator {
 
         if (!Pattern.matches(assistantNameValidationPattern, assistantName)) {
             throw new IllegalArgumentException("Assistant name '" + assistantName
-                + "' does not match the required pattern: " + assistantNameValidationPattern);
+                    + "' does not match the required pattern: " + assistantNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/DeploymentValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/DeploymentValidator.java
@@ -12,8 +12,8 @@ public class DeploymentValidator {
 
     private final IdFieldValidator idFieldValidator;
 
-    public void validateCreation(String deploymentName) {
-        idFieldValidator.validateName(deploymentName);
+    public void validateCreation(String domainObjectType, String deploymentName) {
+        idFieldValidator.validateName(domainObjectType, deploymentName);
     }
 
     public void validateUpdate(String deploymentName, Deployment deployment, String deploymentType) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/DeploymentValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/DeploymentValidator.java
@@ -1,12 +1,20 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Deployment;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
 @Component
+@RequiredArgsConstructor
 public class DeploymentValidator {
+
+    private final IdFieldValidator idFieldValidator;
+
+    public void validateCreation(String deploymentName) {
+        idFieldValidator.validateName(deploymentName);
+    }
 
     public void validateUpdate(String deploymentName, Deployment deployment, String deploymentType) {
         if (!Objects.equals(deploymentName, deployment.getName())) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
@@ -1,0 +1,32 @@
+package com.epam.aidial.cfg.domain.validator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class IdFieldValidator {
+
+    private static final Pattern NAME_LEGAL_CHARACTERS_PATTERN = Pattern.compile("^[A-Za-z0-9-_.,:;<>(){}\\[\\] ]+$");
+
+    public void validateName(String name) {
+        validateId(name, "name");
+
+        Matcher matcher = NAME_LEGAL_CHARACTERS_PATTERN.matcher(name);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Illegal characters found in name");
+        }
+    }
+
+    public void validateId(Object id, String idFieldName) {
+        if (id == null) {
+            throw new IllegalArgumentException("%s must not be empty".formatted(idFieldName));
+        }
+
+        if (id instanceof String stringId && StringUtils.isBlank(stringId)) {
+            throw new IllegalArgumentException("%s must not be empty".formatted(idFieldName));
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
@@ -10,23 +10,23 @@ public class IdFieldValidator {
 
     private static final Set<Character> NAME_ILLEGAL_CHARACTERS = Set.of('%', ';', '/', '\\');
 
-    public void validateName(String name) {
-        validateId(name, "name");
+    public void validateName(String domainObjectType, String name) {
+        validateId(domainObjectType, name, "name");
 
         for (var character : name.toCharArray()) {
             if (NAME_ILLEGAL_CHARACTERS.contains(character)) {
-                throw new IllegalArgumentException("Illegal character '%s' found in name".formatted(character));
+                throw new IllegalArgumentException("Illegal character '%s' found in %s name: %s".formatted(character, domainObjectType, name));
             }
         }
     }
 
-    public void validateId(Object id, String idFieldName) {
+    public void validateId(String domainObjectClassName, Object id, String idFieldName) {
         if (id == null) {
-            throw new IllegalArgumentException("%s must not be empty".formatted(idFieldName));
+            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectClassName, idFieldName));
         }
 
         if (id instanceof String stringId && StringUtils.isBlank(stringId)) {
-            throw new IllegalArgumentException("%s must not be empty".formatted(idFieldName));
+            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectClassName, idFieldName));
         }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
@@ -3,20 +3,21 @@ package com.epam.aidial.cfg.domain.validator;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 public class IdFieldValidator {
 
-    private static final Set<Character> NAME_ILLEGAL_CHARACTERS = Set.of('%', ';', '/', '\\');
+    private static final Pattern NAME_ILLEGAL_CHARACTERS_PATTERN = Pattern.compile("^[^%;/\\\\]*$");
 
     public void validateName(String domainObjectType, String name) {
         validateId(domainObjectType, name, "name");
 
-        for (var character : name.toCharArray()) {
-            if (NAME_ILLEGAL_CHARACTERS.contains(character)) {
-                throw new IllegalArgumentException("Illegal character '%s' found in %s name: %s".formatted(character, domainObjectType, name));
-            }
+        Matcher matcher = NAME_ILLEGAL_CHARACTERS_PATTERN.matcher(name);
+
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Illegal characters found in %s name: %s".formatted(domainObjectType, name));
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
@@ -3,20 +3,20 @@ package com.epam.aidial.cfg.domain.validator;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 @Component
 public class IdFieldValidator {
 
-    private static final Pattern NAME_LEGAL_CHARACTERS_PATTERN = Pattern.compile("^[A-Za-z0-9-_.,:;<>(){}\\[\\] ]+$");
+    private static final Set<Character> NAME_ILLEGAL_CHARACTERS = Set.of('%', ';', '/', '\\');
 
     public void validateName(String name) {
         validateId(name, "name");
 
-        Matcher matcher = NAME_LEGAL_CHARACTERS_PATTERN.matcher(name);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("Illegal characters found in name");
+        for (var character : name.toCharArray()) {
+            if (NAME_ILLEGAL_CHARACTERS.contains(character)) {
+                throw new IllegalArgumentException("Illegal character '%s' found in name".formatted(character));
+            }
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
@@ -13,8 +13,15 @@ import java.util.regex.Pattern;
 @Component
 public class InterceptorRunnerValidator {
 
-    @Value("${validation.interceptorRunner.name:}")
-    private String interceptorRunnerNameValidationPattern;
+    private final IdFieldValidator idFieldValidator;
+
+    private final String interceptorRunnerNameValidationPattern;
+
+    public InterceptorRunnerValidator(IdFieldValidator idFieldValidator,
+                                      @Value("${validation.interceptorRunner.name:}") String interceptorRunnerNameValidationPattern) {
+        this.idFieldValidator = idFieldValidator;
+        this.interceptorRunnerNameValidationPattern = interceptorRunnerNameValidationPattern;
+    }
 
     public void validateCreation(InterceptorRunner interceptorRunner) {
         validateInterceptorRunnerName(interceptorRunner);
@@ -24,13 +31,15 @@ public class InterceptorRunnerValidator {
     public void validateUpdate(String interceptorRunnerName, InterceptorRunner interceptorRunner) {
         if (!Objects.equals(interceptorRunnerName, interceptorRunner.getName())) {
             throw new IllegalArgumentException("InterceptorRunner with name: '%s' can not be renamed. New interceptor runner name: '%s'"
-                .formatted(interceptorRunnerName, interceptorRunner.getName()));
+                    .formatted(interceptorRunnerName, interceptorRunner.getName()));
         }
         validateEndpoints(interceptorRunner.getCompletionEndpoint(), interceptorRunner.getConfigurationEndpoint());
     }
-    
+
     private void validateInterceptorRunnerName(InterceptorRunner interceptorRunner) {
         final String interceptorRunnerName = interceptorRunner.getName();
+
+        idFieldValidator.validateName(interceptorRunnerName);
 
         if (StringUtils.isEmpty(interceptorRunnerNameValidationPattern)) {
             log.debug("InterceptorRunner name validation pattern is empty, skipping validation for interceptor runner: {}", interceptorRunnerName);
@@ -39,7 +48,7 @@ public class InterceptorRunnerValidator {
 
         if (!Pattern.matches(interceptorRunnerNameValidationPattern, interceptorRunnerName)) {
             throw new IllegalArgumentException("InterceptorRunner name '" + interceptorRunnerName
-                + "' does not match the required pattern: " + interceptorRunnerNameValidationPattern);
+                    + "' does not match the required pattern: " + interceptorRunnerNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
@@ -39,7 +39,7 @@ public class InterceptorRunnerValidator {
     private void validateInterceptorRunnerName(InterceptorRunner interceptorRunner) {
         final String interceptorRunnerName = interceptorRunner.getName();
 
-        idFieldValidator.validateName(interceptorRunnerName);
+        idFieldValidator.validateName("InterceptorRunner", interceptorRunnerName);
 
         if (StringUtils.isEmpty(interceptorRunnerNameValidationPattern)) {
             log.debug("InterceptorRunner name validation pattern is empty, skipping validation for interceptor runner: {}", interceptorRunnerName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
@@ -54,7 +54,7 @@ public class InterceptorValidator {
     private void validateInterceptorName(Interceptor interceptor) {
         final String interceptorName = interceptor.getName();
 
-        idFieldValidator.validateName(interceptorName);
+        idFieldValidator.validateName("Interceptor", interceptorName);
 
         if (StringUtils.isEmpty(interceptorNameValidationPattern)) {
             log.debug("Interceptor name validation pattern is empty, skipping validation for interceptor: {}", interceptorName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
@@ -7,7 +7,6 @@ import com.epam.aidial.cfg.domain.model.source.InterceptorEndpointsSource;
 import com.epam.aidial.cfg.domain.model.source.InterceptorRunnerSource;
 import com.epam.aidial.cfg.domain.model.source.InterceptorSource;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +17,6 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class InterceptorValidator {
 
     private static final String COMPLETION_ENDPOINT_LOG_NAME = "completion";
@@ -26,9 +24,19 @@ public class InterceptorValidator {
 
     private final DeploymentManagerService deploymentManagerService;
     private final DeploymentInfoValidator deploymentInfoValidator;
+    private final IdFieldValidator idFieldValidator;
 
-    @Value("${validation.interceptor.name:}")
-    private String interceptorNameValidationPattern;
+    private final String interceptorNameValidationPattern;
+
+    public InterceptorValidator(DeploymentManagerService deploymentManagerService,
+                                DeploymentInfoValidator deploymentInfoValidator,
+                                IdFieldValidator idFieldValidator,
+                                @Value("${validation.interceptor.name:}") String interceptorNameValidationPattern) {
+        this.deploymentManagerService = deploymentManagerService;
+        this.deploymentInfoValidator = deploymentInfoValidator;
+        this.idFieldValidator = idFieldValidator;
+        this.interceptorNameValidationPattern = interceptorNameValidationPattern;
+    }
 
     public void validateCreation(Interceptor interceptor) {
         validateInterceptorName(interceptor);
@@ -38,13 +46,15 @@ public class InterceptorValidator {
     public void validateUpdate(String interceptorName, Interceptor interceptor) {
         if (!Objects.equals(interceptorName, interceptor.getName())) {
             throw new IllegalArgumentException("Interceptor with name: '%s' can not be renamed. New interceptor name: '%s'"
-                .formatted(interceptorName, interceptor.getName()));
+                    .formatted(interceptorName, interceptor.getName()));
         }
         validateInterceptorSource(interceptor);
     }
-    
+
     private void validateInterceptorName(Interceptor interceptor) {
         final String interceptorName = interceptor.getName();
+
+        idFieldValidator.validateName(interceptorName);
 
         if (StringUtils.isEmpty(interceptorNameValidationPattern)) {
             log.debug("Interceptor name validation pattern is empty, skipping validation for interceptor: {}", interceptorName);
@@ -53,7 +63,7 @@ public class InterceptorValidator {
 
         if (!Pattern.matches(interceptorNameValidationPattern, interceptorName)) {
             throw new IllegalArgumentException("Interceptor name '" + interceptorName
-                + "' does not match the required pattern: " + interceptorNameValidationPattern);
+                    + "' does not match the required pattern: " + interceptorNameValidationPattern);
         }
     }
 
@@ -71,7 +81,7 @@ public class InterceptorValidator {
                 validateContainerSource(containerSource);
             } else {
                 throw new IllegalArgumentException(
-                    "Unsupported interceptor source: %s. Interceptor: %s".formatted(source, interceptor.getName())
+                        "Unsupported interceptor source: %s. Interceptor: %s".formatted(source, interceptor.getName())
                 );
             }
             return;

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
@@ -41,7 +41,7 @@ public class KeyValidator {
     private void validateKeyName(Key key) {
         final String keyName = key.getName();
 
-        idFieldValidator.validateName(keyName);
+        idFieldValidator.validateName("Key", keyName);
 
         if (StringUtils.isEmpty(keyNameValidationPattern)) {
             log.debug("Key name validation pattern is empty, skipping validation for key: {}", keyName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
@@ -3,7 +3,6 @@ package com.epam.aidial.cfg.domain.validator;
 import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,17 +13,24 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class KeyValidator {
 
+    private final IdFieldValidator idFieldValidator;
     private final TransactionTimestampContext transactionTimestampContext;
 
-    @Value("${validation.key.name:}")
-    private String keyNameValidationPattern;
+    private final String keyNameValidationPattern;
+
+    public KeyValidator(IdFieldValidator idFieldValidator,
+                        TransactionTimestampContext transactionTimestampContext,
+                        @Value("${validation.key.name:}") String keyNameValidationPattern) {
+        this.idFieldValidator = idFieldValidator;
+        this.transactionTimestampContext = transactionTimestampContext;
+        this.keyNameValidationPattern = keyNameValidationPattern;
+    }
 
     public void validateCreation(Key key) {
         validateKeyName(key);
-        
+
         long now = transactionTimestampContext.getTimestamp();
         Long expiresAt = key.getExpiresAt();
         if (expiresAt != null && expiresAt <= now) {
@@ -35,6 +41,8 @@ public class KeyValidator {
     private void validateKeyName(Key key) {
         final String keyName = key.getName();
 
+        idFieldValidator.validateName(keyName);
+
         if (StringUtils.isEmpty(keyNameValidationPattern)) {
             log.debug("Key name validation pattern is empty, skipping validation for key: {}", keyName);
             return;
@@ -42,7 +50,7 @@ public class KeyValidator {
 
         if (!Pattern.matches(keyNameValidationPattern, keyName)) {
             throw new IllegalArgumentException("Key name '" + keyName
-                + "' does not match the required pattern: " + keyNameValidationPattern);
+                    + "' does not match the required pattern: " + keyNameValidationPattern);
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
@@ -38,7 +38,7 @@ public class ModelValidator {
     private void validateModelName(Model model) {
         final String modelName = model.getDeployment().getName();
 
-        deploymentValidator.validateCreation(modelName);
+        deploymentValidator.validateCreation("Model", modelName);
 
         if (StringUtils.isEmpty(modelNameValidationPattern)) {
             log.debug("Model name validation pattern is empty, skipping validation for model: {}", modelName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Model;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,14 +10,20 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class ModelValidator {
 
     private final DisplayFieldsValidator displayFieldsValidator;
     private final DeploymentValidator deploymentValidator;
 
-    @Value("${validation.model.name:}")
-    private String modelNameValidationPattern;
+    private final String modelNameValidationPattern;
+
+    public ModelValidator(DisplayFieldsValidator displayFieldsValidator,
+                          DeploymentValidator deploymentValidator,
+                          @Value("${validation.model.name:}") String modelNameValidationPattern) {
+        this.displayFieldsValidator = displayFieldsValidator;
+        this.deploymentValidator = deploymentValidator;
+        this.modelNameValidationPattern = modelNameValidationPattern;
+    }
 
     public void validateCreation(Model model) {
         validateModelName(model);
@@ -33,6 +38,8 @@ public class ModelValidator {
     private void validateModelName(Model model) {
         final String modelName = model.getDeployment().getName();
 
+        deploymentValidator.validateCreation(modelName);
+
         if (StringUtils.isEmpty(modelNameValidationPattern)) {
             log.debug("Model name validation pattern is empty, skipping validation for model: {}", modelName);
             return;
@@ -40,7 +47,7 @@ public class ModelValidator {
 
         if (!Pattern.matches(modelNameValidationPattern, modelName)) {
             throw new IllegalArgumentException("Model name '" + modelName
-                + "' does not match the required pattern: " + modelNameValidationPattern);
+                    + "' does not match the required pattern: " + modelNameValidationPattern);
         }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
@@ -28,7 +28,7 @@ public class RoleValidator {
     public void validateRoleCreation(Role role) {
         final String roleName = role.getName();
 
-        idFieldValidator.validateName(roleName);
+        idFieldValidator.validateName("Role", roleName);
 
         if (StringUtils.isEmpty(roleNameValidationPattern)) {
             log.debug("Role name validation pattern is empty, skipping validation for role: {}", roleName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
@@ -15,11 +15,20 @@ public class RoleValidator {
 
     private static final String DEFAULT_ROLE_NAME = "default";
 
-    @Value("${validation.role.name:}")
-    private String roleNameValidationPattern;
+    private final IdFieldValidator idFieldValidator;
+
+    private final String roleNameValidationPattern;
+
+    public RoleValidator(IdFieldValidator idFieldValidator,
+                         @Value("${validation.role.name:}") String roleNameValidationPattern) {
+        this.idFieldValidator = idFieldValidator;
+        this.roleNameValidationPattern = roleNameValidationPattern;
+    }
 
     public void validateRoleCreation(Role role) {
         final String roleName = role.getName();
+
+        idFieldValidator.validateName(roleName);
 
         if (StringUtils.isEmpty(roleNameValidationPattern)) {
             log.debug("Role name validation pattern is empty, skipping validation for role: {}", roleName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
@@ -25,7 +25,7 @@ public class RouteValidator {
     public void validateRouteCreation(Route route) {
         final String routeName = route.getDeployment().getName();
 
-        deploymentValidator.validateCreation(routeName);
+        deploymentValidator.validateCreation("Route", routeName);
 
         if (StringUtils.isEmpty(routeNameValidationPattern)) {
             log.debug("Route name validation pattern is empty, skipping validation for route: {}", routeName);

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Route;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,16 +10,22 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class RouteValidator {
 
     private final DeploymentValidator deploymentValidator;
-    
-    @Value("${validation.route.name:}")
-    private String routeNameValidationPattern;
-    
+
+    private final String routeNameValidationPattern;
+
+    public RouteValidator(DeploymentValidator deploymentValidator,
+                          @Value("${validation.route.name:}") String routeNameValidationPattern) {
+        this.deploymentValidator = deploymentValidator;
+        this.routeNameValidationPattern = routeNameValidationPattern;
+    }
+
     public void validateRouteCreation(Route route) {
         final String routeName = route.getDeployment().getName();
+
+        deploymentValidator.validateCreation(routeName);
 
         if (StringUtils.isEmpty(routeNameValidationPattern)) {
             log.debug("Route name validation pattern is empty, skipping validation for route: {}", routeName);
@@ -29,7 +34,7 @@ public class RouteValidator {
 
         if (!Pattern.matches(routeNameValidationPattern, routeName)) {
             throw new IllegalArgumentException("Route name '" + routeName
-                + "' does not match the required pattern: " + routeNameValidationPattern);
+                    + "' does not match the required pattern: " + routeNameValidationPattern);
         }
     }
 

--- a/src/test/java/com/epam/aidial/cfg/domain/normalizer/ApplicationNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/normalizer/ApplicationNormalizerTest.java
@@ -1,7 +1,6 @@
-package com.epam.aidial.cfg.dao.normalizer;
+package com.epam.aidial.cfg.domain.normalizer;
 
 import com.epam.aidial.cfg.domain.model.Application;
-import com.epam.aidial.cfg.domain.normalizer.ApplicationNormalizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/epam/aidial/cfg/domain/normalizer/ModelNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/normalizer/ModelNormalizerTest.java
@@ -1,7 +1,6 @@
-package com.epam.aidial.cfg.dao.normalizer;
+package com.epam.aidial.cfg.domain.normalizer;
 
 import com.epam.aidial.cfg.domain.model.Model;
-import com.epam.aidial.cfg.domain.normalizer.ModelNormalizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/epam/aidial/cfg/domain/resolver/key/KeyGeneratedAtResolverTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/resolver/key/KeyGeneratedAtResolverTest.java
@@ -1,8 +1,7 @@
-package com.epam.aidial.cfg.dao.resolver.key;
+package com.epam.aidial.cfg.domain.resolver.key;
 
 import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Key;
-import com.epam.aidial.cfg.domain.resolver.key.KeyGeneratedAtResolver;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/AddonValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/AddonValidatorTest.java
@@ -1,19 +1,18 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Addon;
 import com.epam.aidial.cfg.domain.model.Deployment;
-import com.epam.aidial.cfg.domain.validator.AddonValidator;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,8 +23,12 @@ class AddonValidatorTest {
     @Mock
     private DeploymentValidator deploymentValidator;
 
-    @InjectMocks
     private AddonValidator addonValidator;
+
+    @BeforeEach
+    void setUp() {
+        addonValidator = new AddonValidator(deploymentValidator, null);
+    }
 
     @Test
     void validateUpdate_shouldDelegateToDeploymentValidator() {
@@ -59,7 +62,7 @@ class AddonValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name",
             "name-that-is-way-too-long-for-validation-pattern"})
     void validateAddonCreation_shouldThrowExceptionForInvalidName(String name) {
         // given
@@ -73,6 +76,23 @@ class AddonValidatorTest {
         Assertions.assertThatThrownBy(() -> addonValidator.validateAddonCreation(addon))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateAddonCreation_shouldThrowExceptionWhenDeploymentValidatorThrows() {
+        // given
+        String deploymentName = "deploymentName";
+
+        Deployment deployment = new Deployment(deploymentName);
+
+        Addon addon = new Addon();
+        addon.setDeployment(deployment);
+
+        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> addonValidator.validateAddonCreation(addon))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/AddonValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/AddonValidatorTest.java
@@ -88,7 +88,8 @@ class AddonValidatorTest {
         Addon addon = new Addon();
         addon.setDeployment(deployment);
 
-        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+        doThrow(IllegalArgumentException.class).when(deploymentValidator)
+                .validateCreation("Addon", deploymentName);
 
         // when/then
         Assertions.assertThatThrownBy(() -> addonValidator.validateAddonCreation(addon))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidatorTest.java
@@ -83,7 +83,8 @@ class ApplicationTypeSchemaValidatorTest {
         ApplicationTypeSchema applicationTypeSchema = new ApplicationTypeSchema();
         applicationTypeSchema.setSchemaId("schema_id");
 
-        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateId("schema_id", "schemaId");
+        doThrow(IllegalArgumentException.class).when(idFieldValidator)
+                .validateId("ApplicationTypeSchema", "schema_id", "schemaId");
 
         // when/then
         Assertions.assertThatThrownBy(() -> applicationTypeSchemaValidator.validateCreation(applicationTypeSchema))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidatorTest.java
@@ -1,25 +1,33 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
-import com.epam.aidial.cfg.domain.validator.ApplicationTypeSchemaValidator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 
+@ExtendWith(MockitoExtension.class)
 class ApplicationTypeSchemaValidatorTest {
 
     private static final String ID_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
+
+    @Mock
+    private IdFieldValidator idFieldValidator;
 
     private ApplicationTypeSchemaValidator applicationTypeSchemaValidator;
 
     @BeforeEach
     void setUp() {
-        applicationTypeSchemaValidator = new ApplicationTypeSchemaValidator();
+        applicationTypeSchemaValidator = new ApplicationTypeSchemaValidator(idFieldValidator, null);
     }
 
     @Test
@@ -54,7 +62,7 @@ class ApplicationTypeSchemaValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid id with spaces", "invalid@id", "invalid#id", "invalid$id", 
+    @ValueSource(strings = {"invalid id with spaces", "invalid@id", "invalid#id", "invalid$id",
             "id-that-is-way-too-long-for-validation-pattern"})
     void validateCreation_shouldThrowExceptionForInvalidId(String id) {
         // given
@@ -67,6 +75,19 @@ class ApplicationTypeSchemaValidatorTest {
         assertThatThrownBy(() -> applicationTypeSchemaValidator.validateCreation(schema))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateCreation_shouldThrowExceptionWhenIdFieldValidatorThrows() {
+        // given
+        ApplicationTypeSchema applicationTypeSchema = new ApplicationTypeSchema();
+        applicationTypeSchema.setSchemaId("schema_id");
+
+        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateId("schema_id", "schemaId");
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> applicationTypeSchemaValidator.validateCreation(applicationTypeSchema))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
@@ -230,7 +230,8 @@ class ApplicationValidatorTest {
         Application application = new Application();
         application.setDeployment(deployment);
 
-        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+        doThrow(IllegalArgumentException.class).when(deploymentValidator)
+                .validateCreation("Application", deploymentName);
 
         // when/then
         Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
@@ -1,23 +1,21 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.model.Deployment;
-import com.epam.aidial.cfg.domain.validator.ApplicationValidator;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
-import com.epam.aidial.cfg.domain.validator.DisplayFieldsValidator;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.net.URI;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,8 +28,12 @@ class ApplicationValidatorTest {
     @Mock
     private DeploymentValidator deploymentValidator;
 
-    @InjectMocks
     private ApplicationValidator applicationValidator;
+
+    @BeforeEach
+    void setUp() {
+        applicationValidator = new ApplicationValidator(displayFieldsValidator, deploymentValidator, null);
+    }
 
     @Test
     void validateCreation_shouldDelegateToDisplayFieldsValidator() {
@@ -184,7 +186,7 @@ class ApplicationValidatorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Both endpoint: 'test' and application type schema id: 'https://test.com' are specified. Only one of them should be specified");
     }
-    
+
     @ParameterizedTest
     @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
     void validateCreation_shouldNotThrowExceptionForValidName(String name) {
@@ -201,7 +203,7 @@ class ApplicationValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name",
             "name-that-is-way-too-long-for-validation-pattern"})
     void validateCreation_shouldThrowExceptionForInvalidName(String name) {
         // given
@@ -216,5 +218,22 @@ class ApplicationValidatorTest {
         Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateCreation_shouldThrowExceptionWhenDeploymentValidatorThrows() {
+        // given
+        String deploymentName = "deploymentName";
+
+        Deployment deployment = new Deployment(deploymentName);
+
+        Application application = new Application();
+        application.setDeployment(deployment);
+
+        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> applicationValidator.validateCreation(application))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/AssistantValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/AssistantValidatorTest.java
@@ -54,7 +54,8 @@ class AssistantValidatorTest {
         Assistant assistant = new Assistant();
         assistant.setDeployment(deployment);
 
-        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+        doThrow(IllegalArgumentException.class).when(deploymentValidator)
+                .validateCreation("Assistant", deploymentName);
 
         // when/then
         Assertions.assertThatThrownBy(() -> assistantValidator.validateAssistantCreation(assistant))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/AssistantValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/AssistantValidatorTest.java
@@ -1,15 +1,16 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Assistant;
 import com.epam.aidial.cfg.domain.model.Deployment;
-import com.epam.aidial.cfg.domain.validator.AssistantValidator;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,6 +21,11 @@ class AssistantValidatorTest {
 
     @InjectMocks
     private AssistantValidator assistantValidator;
+
+    @BeforeEach
+    void setUp() {
+        assistantValidator = new AssistantValidator(deploymentValidator, null);
+    }
 
     @Test
     void validateUpdate_shouldDelegateToDeploymentValidator() {
@@ -36,6 +42,23 @@ class AssistantValidatorTest {
 
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Assistant");
+    }
+
+    @Test
+    void validateAssistantCreation_shouldThrowExceptionWhenDeploymentValidatorThrows() {
+        // given
+        String deploymentName = "deploymentName";
+
+        Deployment deployment = new Deployment(deploymentName);
+
+        Assistant assistant = new Assistant();
+        assistant.setDeployment(deployment);
+
+        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> assistantValidator.validateAssistantCreation(assistant))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/DeploymentValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/DeploymentValidatorTest.java
@@ -1,20 +1,27 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Deployment;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class DeploymentValidatorTest {
+
+    @Mock
+    private IdFieldValidator idFieldValidator;
 
     private DeploymentValidator deploymentValidator;
 
     @BeforeEach
     void setUp() {
-        deploymentValidator = new DeploymentValidator();
+        deploymentValidator = new DeploymentValidator(idFieldValidator);
     }
 
     @Test
@@ -31,6 +38,13 @@ class DeploymentValidatorTest {
         Deployment deployment = new Deployment("deployment_name");
 
         assertThatNoException().isThrownBy(() -> deploymentValidator.validateUpdate("deployment_name", deployment, "Some deployment"));
+    }
+
+    @Test
+    void validateCreation_shouldDelegateToIdFieldValidator() {
+        deploymentValidator.validateCreation("deployment_name");
+
+        verify(idFieldValidator).validateName("deployment_name");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/DeploymentValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/DeploymentValidatorTest.java
@@ -42,9 +42,9 @@ class DeploymentValidatorTest {
 
     @Test
     void validateCreation_shouldDelegateToIdFieldValidator() {
-        deploymentValidator.validateCreation("deployment_name");
+        deploymentValidator.validateCreation("Deployment", "deployment_name");
 
-        verify(idFieldValidator).validateName("deployment_name");
+        verify(idFieldValidator).validateName("Deployment", "deployment_name");
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidatorTest.java
@@ -1,6 +1,5 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
-import com.epam.aidial.cfg.domain.validator.DisplayFieldsValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
@@ -1,0 +1,56 @@
+package com.epam.aidial.cfg.domain.validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IdFieldValidatorTest {
+
+    private IdFieldValidator idFieldValidator;
+
+    @BeforeEach
+    void setUp() {
+        idFieldValidator = new IdFieldValidator();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
+    void validateName_shouldThrowExceptionWhenEmptyName(String name) {
+        assertThatThrownBy(() -> idFieldValidator.validateName(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("name must not be empty");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"nameWith!", "nameWith@", "nameWith#", "nameWith$", "nameWith%", "nameWith^",
+            "nameWith&", "nameWith*", "nameWith\\", "nameWith|", "nameWith/", "nameWith?"})
+    void validateName_shouldThrowExceptionWhenNameWithIllegalCharacters(String name) {
+        assertThatThrownBy(() -> idFieldValidator.validateName(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal characters found in name");
+    }
+
+    @Test
+    void validateName_shouldNotThrowExceptionWhenValidName() {
+        assertThatCode(() -> idFieldValidator.validateName("name With A-Za-z0-9-_.,:;<>(){}[]"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateId_shouldThrowExceptionWhenNullId() {
+        assertThatThrownBy(() -> idFieldValidator.validateId(null, "idField"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("idField must not be empty");
+    }
+
+    @Test
+    void validateName_shouldNotThrowExceptionWhenValidId() {
+        assertThatCode(() -> idFieldValidator.validateId(new Object(), "idField"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
@@ -23,21 +23,21 @@ class IdFieldValidatorTest {
     void validateName_shouldThrowExceptionWhenEmptyName(String name) {
         assertThatThrownBy(() -> idFieldValidator.validateName(name))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("name must not be empty");
+                .hasMessage("name must not be empty");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"nameWith!", "nameWith@", "nameWith#", "nameWith$", "nameWith%", "nameWith^",
-            "nameWith&", "nameWith*", "nameWith\\", "nameWith|", "nameWith/", "nameWith?"})
+    @ValueSource(strings = {"nameWith%", "nameWith;", "nameWith/", "nameWith\\"})
     void validateName_shouldThrowExceptionWhenNameWithIllegalCharacters(String name) {
         assertThatThrownBy(() -> idFieldValidator.validateName(name))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Illegal characters found in name");
+                .hasMessageContaining("Illegal character")
+                .hasMessageContaining("found in name");
     }
 
     @Test
-    void validateName_shouldNotThrowExceptionWhenValidName() {
-        assertThatCode(() -> idFieldValidator.validateName("name With A-Za-z0-9-_.,:;<>(){}[]"))
+    void validateName_shouldNotThrowExceptionWhenNameWithLegalCharacters() {
+        assertThatCode(() -> idFieldValidator.validateName("name With ~!@#$^&*()-_=+[]{}:'\",<.>?| and some unicode \uD83D\uDE07 Ą Ŏ"))
                 .doesNotThrowAnyException();
     }
 
@@ -45,7 +45,7 @@ class IdFieldValidatorTest {
     void validateId_shouldThrowExceptionWhenNullId() {
         assertThatThrownBy(() -> idFieldValidator.validateId(null, "idField"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("idField must not be empty");
+                .hasMessage("idField must not be empty");
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
@@ -37,7 +37,7 @@ class IdFieldValidatorTest {
 
     @Test
     void validateName_shouldNotThrowExceptionWhenNameWithLegalCharacters() {
-        assertThatCode(() -> idFieldValidator.validateName("name With ~!@#$^&*()-_=+[]{}:'\",<.>?| and some unicode \uD83D\uDE07 Ą Ŏ"))
+        assertThatCode(() -> idFieldValidator.validateName("name With ~!@#$^&*()-_=+[]{}:'\",<.>?| and some unicode 😇 Ą Ŏ"))
                 .doesNotThrowAnyException();
     }
 

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
@@ -31,8 +31,7 @@ class IdFieldValidatorTest {
     void validateName_shouldThrowExceptionWhenNameWithIllegalCharacters(String name) {
         assertThatThrownBy(() -> idFieldValidator.validateName("DomainObjectType", name))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Illegal character")
-                .hasMessageContaining("found in DomainObjectType name: " + name);
+                .hasMessage("Illegal characters found in DomainObjectType name: " + name);
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/IdFieldValidatorTest.java
@@ -21,36 +21,36 @@ class IdFieldValidatorTest {
     @ParameterizedTest
     @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
     void validateName_shouldThrowExceptionWhenEmptyName(String name) {
-        assertThatThrownBy(() -> idFieldValidator.validateName(name))
+        assertThatThrownBy(() -> idFieldValidator.validateName("DomainObjectType", name))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("name must not be empty");
+                .hasMessage("DomainObjectType name must not be empty");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"nameWith%", "nameWith;", "nameWith/", "nameWith\\"})
     void validateName_shouldThrowExceptionWhenNameWithIllegalCharacters(String name) {
-        assertThatThrownBy(() -> idFieldValidator.validateName(name))
+        assertThatThrownBy(() -> idFieldValidator.validateName("DomainObjectType", name))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Illegal character")
-                .hasMessageContaining("found in name");
+                .hasMessageContaining("found in DomainObjectType name: " + name);
     }
 
     @Test
     void validateName_shouldNotThrowExceptionWhenNameWithLegalCharacters() {
-        assertThatCode(() -> idFieldValidator.validateName("name With ~!@#$^&*()-_=+[]{}:'\",<.>?| and some unicode 😇 Ą Ŏ"))
+        assertThatCode(() -> idFieldValidator.validateName("DomainObjectType", "name With ~!@#$^&*()-_=+[]{}:'\",<.>?| and some unicode 😇 Ą Ŏ"))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void validateId_shouldThrowExceptionWhenNullId() {
-        assertThatThrownBy(() -> idFieldValidator.validateId(null, "idField"))
+        assertThatThrownBy(() -> idFieldValidator.validateId("DomainObjectType", null, "idField"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("idField must not be empty");
+                .hasMessage("DomainObjectType idField must not be empty");
     }
 
     @Test
     void validateName_shouldNotThrowExceptionWhenValidId() {
-        assertThatCode(() -> idFieldValidator.validateId(new Object(), "idField"))
+        assertThatCode(() -> idFieldValidator.validateId("DomainObjectType", new Object(), "idField"))
                 .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/InterceptorValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/InterceptorValidatorTest.java
@@ -1,4 +1,4 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
 import com.epam.aidial.cfg.domain.model.Interceptor;
@@ -6,20 +6,23 @@ import com.epam.aidial.cfg.domain.model.source.InterceptorContainerSource;
 import com.epam.aidial.cfg.domain.model.source.InterceptorEndpointsSource;
 import com.epam.aidial.cfg.domain.model.source.InterceptorRunnerSource;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
-import com.epam.aidial.cfg.domain.validator.DeploymentInfoValidator;
-import com.epam.aidial.cfg.domain.validator.InterceptorValidator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class InterceptorValidatorTest {
 
     private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
@@ -32,11 +35,18 @@ class InterceptorValidatorTest {
 
     @Mock
     private DeploymentManagerService deploymentManagerService;
+    @Mock
+    private IdFieldValidator idFieldValidator;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        interceptorValidator = new InterceptorValidator(deploymentManagerService, new DeploymentInfoValidator());
+        interceptorValidator = new InterceptorValidator(
+                deploymentManagerService,
+                new DeploymentInfoValidator(),
+                idFieldValidator,
+                null
+        );
     }
 
     @ParameterizedTest
@@ -54,7 +64,7 @@ class InterceptorValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name",
             "name-that-is-way-too-long-for-validation-pattern"})
     void validateCreation_shouldThrowExceptionForInvalidName(String name) {
         // given
@@ -252,5 +262,18 @@ class InterceptorValidatorTest {
 
         // when/then
         assertThatNoException().isThrownBy(() -> interceptorValidator.validateCreation(interceptor));
+    }
+
+    @Test
+    void validateCreation_shouldThrowExceptionWhenIdFieldValidatorThrows() {
+        // given
+        Interceptor interceptor = new Interceptor();
+        interceptor.setName("test-interceptor");
+
+        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("test-interceptor");
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> interceptorValidator.validateCreation(interceptor))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/InterceptorValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/InterceptorValidatorTest.java
@@ -270,7 +270,8 @@ class InterceptorValidatorTest {
         Interceptor interceptor = new Interceptor();
         interceptor.setName("test-interceptor");
 
-        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("test-interceptor");
+        doThrow(IllegalArgumentException.class).when(idFieldValidator)
+                .validateName("Interceptor", "test-interceptor");
 
         // when/then
         Assertions.assertThatThrownBy(() -> interceptorValidator.validateCreation(interceptor))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/KeyValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/KeyValidatorTest.java
@@ -136,7 +136,8 @@ class KeyValidatorTest {
         Key key = new Key();
         key.setName("key_name");
 
-        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("key_name");
+        doThrow(IllegalArgumentException.class).when(idFieldValidator)
+                .validateName("Key", "key_name");
 
         // when/then
         Assertions.assertThatThrownBy(() -> keyValidator.validateCreation(key))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/KeyValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/KeyValidatorTest.java
@@ -1,21 +1,22 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.domain.model.Key;
-import com.epam.aidial.cfg.domain.validator.KeyValidator;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,9 +26,15 @@ class KeyValidatorTest {
 
     @Mock
     private TransactionTimestampContext transactionTimestampContext;
+    @Mock
+    private IdFieldValidator idFieldValidator;
 
-    @InjectMocks
     private KeyValidator keyValidator;
+
+    @BeforeEach
+    void setUp() {
+        keyValidator = new KeyValidator(idFieldValidator, transactionTimestampContext, null);
+    }
 
     @ParameterizedTest
     @CsvSource({"1", "2"})
@@ -90,7 +97,7 @@ class KeyValidatorTest {
 
         assertThatNoException().isThrownBy(() -> keyValidator.validateUpdate("key_name", key, keyEntity));
     }
-    
+
     @ParameterizedTest
     @ValueSource(strings = {"valid-name", "valid_name", "ValidName123", "name-123_456", "name.with.dots"})
     void validateCreation_shouldNotThrowExceptionForValidName(String name) {
@@ -107,7 +114,7 @@ class KeyValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name",
             "name-that-is-way-too-long-for-validation-pattern"})
     void validateCreation_shouldThrowExceptionForInvalidName(String name) {
         // given
@@ -121,6 +128,19 @@ class KeyValidatorTest {
         assertThatThrownBy(() -> keyValidator.validateCreation(key))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateCreation_shouldThrowExceptionWhenIdFieldValidatorThrows() {
+        // given
+        Key key = new Key();
+        key.setName("key_name");
+
+        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("key_name");
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> keyValidator.validateCreation(key))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
@@ -111,7 +111,8 @@ class ModelValidatorTest {
         Model model = new Model();
         model.setDeployment(deployment);
 
-        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+        doThrow(IllegalArgumentException.class).when(deploymentValidator)
+                .validateCreation("Model", deploymentName);
 
         // when/then
         Assertions.assertThatThrownBy(() -> modelValidator.validateCreation(model))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
@@ -1,21 +1,20 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Model;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
-import com.epam.aidial.cfg.domain.validator.DisplayFieldsValidator;
-import com.epam.aidial.cfg.domain.validator.ModelValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,8 +27,12 @@ class ModelValidatorTest {
     @Mock
     private DeploymentValidator deploymentValidator;
 
-    @InjectMocks
     private ModelValidator modelValidator;
+
+    @BeforeEach
+    void setUp() {
+        modelValidator = new ModelValidator(displayFieldsValidator, deploymentValidator, null);
+    }
 
     @Test
     void validateCreation_shouldDelegateToDisplayFieldsValidator() {
@@ -96,6 +99,23 @@ class ModelValidatorTest {
         assertThatThrownBy(() -> modelValidator.validateCreation(model))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateCreation_shouldThrowExceptionWhenDeploymentValidatorThrows() {
+        // given
+        String deploymentName = "deploymentName";
+
+        Deployment deployment = new Deployment(deploymentName);
+
+        Model model = new Model();
+        model.setDeployment(deployment);
+
+        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> modelValidator.validateCreation(model))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/RoleValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/RoleValidatorTest.java
@@ -95,7 +95,8 @@ class RoleValidatorTest {
         Role role = new Role();
         role.setName("role_name");
 
-        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("role_name");
+        doThrow(IllegalArgumentException.class).when(idFieldValidator)
+                .validateName("Role", "role_name");
 
         // when/then
         Assertions.assertThatThrownBy(() -> roleValidator.validateRoleCreation(role))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/RoleValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/RoleValidatorTest.java
@@ -1,25 +1,33 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Role;
-import com.epam.aidial.cfg.domain.validator.RoleValidator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 
+@ExtendWith(MockitoExtension.class)
 class RoleValidatorTest {
 
     private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
+
+    @Mock
+    private IdFieldValidator idFieldValidator;
 
     private RoleValidator roleValidator;
 
     @BeforeEach
     void setUp() {
-        roleValidator = new RoleValidator();
+        roleValidator = new RoleValidator(idFieldValidator, null);
     }
 
     @Test
@@ -79,5 +87,18 @@ class RoleValidatorTest {
         assertThatThrownBy(() -> roleValidator.validateRoleCreation(role))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateRoleCreation_shouldThrowExceptionWhenIdFieldValidatorThrows() {
+        // given
+        Role role = new Role();
+        role.setName("role_name");
+
+        doThrow(IllegalArgumentException.class).when(idFieldValidator).validateName("role_name");
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> roleValidator.validateRoleCreation(role))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/RouteValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/RouteValidatorTest.java
@@ -90,7 +90,8 @@ class RouteValidatorTest {
         Route route = new Route();
         route.setDeployment(deployment);
 
-        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+        doThrow(IllegalArgumentException.class).when(deploymentValidator)
+                .validateCreation("Route", deploymentName);
 
         // when/then
         Assertions.assertThatThrownBy(() -> routeValidator.validateRouteCreation(route))

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/RouteValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/RouteValidatorTest.java
@@ -1,20 +1,20 @@
-package com.epam.aidial.cfg.dao.validator;
+package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Route;
-import com.epam.aidial.cfg.domain.validator.DeploymentValidator;
-import com.epam.aidial.cfg.domain.validator.RouteValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,8 +25,12 @@ class RouteValidatorTest {
     @Mock
     private DeploymentValidator deploymentValidator;
 
-    @InjectMocks
     private RouteValidator routeValidator;
+
+    @BeforeEach
+    void setUp() {
+        routeValidator = new RouteValidator(deploymentValidator, null);
+    }
 
     @Test
     void validateUpdate_shouldDelegateToDeploymentValidator() {
@@ -60,7 +64,7 @@ class RouteValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name", 
+    @ValueSource(strings = {"invalid name with spaces", "invalid@name", "invalid#name", "invalid$name",
             "name-that-is-way-too-long-for-validation-pattern"})
     void validateRouteCreation_shouldThrowExceptionForInvalidName(String name) {
         // given
@@ -74,6 +78,23 @@ class RouteValidatorTest {
         assertThatThrownBy(() -> routeValidator.validateRouteCreation(route))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern");
+    }
+
+    @Test
+    void validateRouteCreation_shouldThrowExceptionWhenDeploymentValidatorThrows() {
+        // given
+        String deploymentName = "deploymentName";
+
+        Deployment deployment = new Deployment(deploymentName);
+
+        Route route = new Route();
+        route.setDeployment(deployment);
+
+        doThrow(IllegalArgumentException.class).when(deploymentValidator).validateCreation(deploymentName);
+
+        // when/then
+        Assertions.assertThatThrownBy(() -> routeValidator.validateRouteCreation(route))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
@@ -12,6 +12,8 @@ import com.epam.aidial.cfg.web.facade.RoleFacade;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
@@ -117,6 +119,19 @@ public abstract class RolesFunctionalTest {
         var expected = createDto("1");
         expected.setDescription("new role description");
         assertRole(actual, expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
+    public void shouldThrowExceptionWhenEmptyName(String name) {
+        RoleDto roleDto = createDto("1");
+        roleDto.setName(name);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> roleFacade.createRole(roleDto)
+        );
+        Assertions.assertEquals("name must not be empty", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
@@ -131,7 +131,7 @@ public abstract class RolesFunctionalTest {
                 IllegalArgumentException.class,
                 () -> roleFacade.createRole(roleDto)
         );
-        Assertions.assertEquals("name must not be empty", exception.getMessage());
+        Assertions.assertEquals("Role name must not be empty", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #63
- fixes #83
- fixes #90

### Description of changes
Added validation that entity id (which is usually `name`) is not empty and doesn't have illegal characters during creation

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.