### PR TITLE
fix: fix model endpoint building when endpointDeploymentName is empty string

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.domain.utils;
 import com.epam.aidial.cfg.domain.model.Model;
 import com.epam.aidial.cfg.domain.model.ModelType;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
@@ -75,7 +76,7 @@ public class ModelEndpointUtils {
     }
 
     private String modelPath(String endpointDeploymentName, ModelType type) {
-        return endpointDeploymentName != null
+        return StringUtils.isNotBlank(endpointDeploymentName)
                 ? endpointDeploymentName + "/" + getEndpointByType(type)
                 : getEndpointByType(type);
     }

--- a/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtilsTest.java
@@ -66,6 +66,10 @@ class ModelEndpointUtilsTest {
         modelWithAdapterAndEndpointDeploymentName.setAdapter(adapter);
         modelWithAdapterAndEndpointDeploymentName.setEndpointDeploymentName("endpoint-deployment-name");
 
+        Model modelWithAdapterAndEmptyEndpointDeploymentName = new Model();
+        modelWithAdapterAndEmptyEndpointDeploymentName.setAdapter(adapter);
+        modelWithAdapterAndEmptyEndpointDeploymentName.setEndpointDeploymentName("");
+
         Model modelWithAdapter = new Model();
         modelWithAdapter.setAdapter(adapter);
 
@@ -90,6 +94,7 @@ class ModelEndpointUtilsTest {
         return Stream.of(
                 Arguments.of(modelWithoutAdapter, null),
                 Arguments.of(modelWithAdapterAndEndpointDeploymentName, "http://host/openai/deployments/endpoint-deployment-name/chat/completions"),
+                Arguments.of(modelWithAdapterAndEmptyEndpointDeploymentName, "http://host/openai/deployments/chat/completions"),
                 Arguments.of(modelWithAdapter, "http://host/openai/deployments/chat/completions"),
                 Arguments.of(chatModelWithAdapterAndEndpointDeploymentName, "http://host/openai/deployments/endpoint-deployment-name/chat/completions"),
                 Arguments.of(chatModelWithAdapter, "http://host/openai/deployments/chat/completions"),


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #139

### Description of changes
Fixed model endpoint building when endpointDeploymentName is empty string, so that there is no double slash between adapterBaseEndpoint and endpoint ending, e.g. like `adapterBaseEndpoint//chat/completions`

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.