### PR TITLE
fix: Remove applicationTypeEditorUrl default value in application type schema

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/ApplicationTypeSchemaDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ApplicationTypeSchemaDto.java
@@ -27,7 +27,7 @@ public class ApplicationTypeSchemaDto {
     private String description;
 
     @JsonProperty("dial:applicationTypeEditorUrl")
-    private String applicationTypeEditorUrl = "https://app_editor_url";
+    private String applicationTypeEditorUrl;
 
     @JsonProperty("dial:applicationTypeViewerUrl")
     private String applicationTypeViewerUrl;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #150

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Removed `applicationTypeEditorUrl` default value in application type schema

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.