### PR TITLE
fix: increase io.netty:netty-codec-http2 transitive dependency version from 4.1.122.Final to 4.2.4.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,9 @@ dependencies {
         implementation ('io.projectreactor.netty:reactor-netty-http:1.2.8') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Description of changes

Added version constraint for netty-codec-http2 dependency.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.