### PR TITLE
fix: add default value for 'order' in route

### DIFF
--- a/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -4,5 +4,5 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
 ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 
 -- Update route_entity_aud
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,0 +1,5 @@
+UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+
+ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -5,4 +5,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
-ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -6,4 +6,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;
-ALTER TABLE route_entity_aud ALTER COLUMN order_value SET NOT NULL;

--- a/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,5 +1,9 @@
+-- Update route_entity
 UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
-
 ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
+
+-- Update route_entity_aud
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity_aud ALTER COLUMN order_value SET NOT NULL;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -5,4 +5,4 @@ ALTER TABLE route_entity ALTER COLUMN order_value INT NOT NULL;
 
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
-ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;
+ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value_aud DEFAULT 2147483647 FOR order_value;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,5 +1,9 @@
+-- Update route_entity
 UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
-
 ALTER TABLE route_entity ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;
+ALTER TABLE route_entity ALTER COLUMN order_value INT NOT NULL;
+
+-- Update route_entity_aud
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;
+ALTER TABLE route_entity_aud ALTER COLUMN order_value INT NOT NULL;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -6,4 +6,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value INT NOT NULL;
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;
-ALTER TABLE route_entity_aud ALTER COLUMN order_value INT NOT NULL;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -4,5 +4,5 @@ ALTER TABLE route_entity ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR or
 ALTER TABLE route_entity ALTER COLUMN order_value INT NOT NULL;
 
 -- Update route_entity_aud
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
 ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value_aud DEFAULT 2147483647 FOR order_value;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,0 +1,5 @@
+UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+
+ALTER TABLE route_entity ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;
+ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value DEFAULT 2147483647 FOR order_value;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -5,4 +5,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value INT NOT NULL;
 
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
-ALTER TABLE route_entity_aud ADD CONSTRAINT df_order_value_aud DEFAULT 2147483647 FOR order_value;

--- a/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -4,5 +4,5 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
 ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 
 -- Update route_entity_aud
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,0 +1,5 @@
+UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
+
+ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -5,4 +5,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL AND revtype != 2;
-ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;

--- a/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -6,4 +6,3 @@ ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
 -- Update route_entity_aud
 UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;
-ALTER TABLE route_entity_aud ALTER COLUMN order_value SET NOT NULL;

--- a/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.53__AddDefaultValueForOrderInRouteEntity.sql
@@ -1,5 +1,9 @@
+-- Update route_entity
 UPDATE route_entity SET order_value = 2147483647 WHERE order_value IS NULL;
-UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
-
 ALTER TABLE route_entity ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity ALTER COLUMN order_value SET NOT NULL;
+
+-- Update route_entity_aud
+UPDATE route_entity_aud SET order_value = 2147483647 WHERE order_value IS NULL;
 ALTER TABLE route_entity_aud ALTER COLUMN order_value SET DEFAULT 2147483647;
+ALTER TABLE route_entity_aud ALTER COLUMN order_value SET NOT NULL;


### PR DESCRIPTION
### Description of changes

Set integer max value (2147483647) to order for routes where it is not set. Added default value for new entities.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.