### PR TITLE
feat: add ability to initialize admin app from config files used by core

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,8 @@ This document provides a comprehensive list of all configurable properties in th
 
 ## Table of Contents
 
-- [AIDIAL Config File Exporter](#aidial-config-file-exporter)
+- [AIDIAL Config File Export Configuration](#aidial-config-file-export-configuration)
+- [AIDIAL Config File Import Configuration](#aidial-config-file-import-configuration)
 - [Kubernetes Configuration](#kubernetes-configuration)
 - [Web Server Configuration](#web-server-configuration)
 - [Security Configuration](#security-configuration)
@@ -18,7 +19,7 @@ This document provides a comprehensive list of all configurable properties in th
 - [Retry Configuration](#retry-configuration)
 - [Validation Configuration](#validation-configuration)
 
-## AIDIAL Config File Exporter
+## AIDIAL Config File Export Configuration
 
 | Setting                                  | Environment Variable                     | Default              | Required | Applied when | Description                                                                                                                                 |
 |------------------------------------------|------------------------------------------|----------------------|----------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,6 +41,13 @@ This document provides a comprehensive list of all configurable properties in th
 | config.export.keyvault.expiration.period | CONFIG_EXPORT_KEYVAULT_EXPIRATION_PERIOD | 3                    | No       | -         | Expiration period for keyvault values                                                                                                       |
 | config.export.keyvault.expiration.unit   | CONFIG_EXPORT_KEYVAULT_EXPIRATION_UNIT   | MONTHS               | No       | -         | Unit of time for keyvault value expiration                                                                                                  |
 | config.export.createResources            | CONFIG_EXPORT_CREATE_RESOURCES           | false                | No       | -         | If true, create resources where config is exported if they don't already exist                                                              |
+
+## AIDIAL Config File Import Configuration
+
+| Setting                          | Environment Variable      | Default | Required | Applied when | Description                                                                                                   |
+|----------------------------------|---------------------------|---------|----------|--------------|---------------------------------------------------------------------------------------------------------------|
+| config.import.configsMaxCount    | IMPORT_CONFIGS_MAX_COUNT  | 64      | No       | -            | Maximum number of files allowed for a single import config operation                                          |
+| config.import.autoImport.enabled | ENABLE_CONFIG_AUTO_IMPORT | false   | No       | -            | Enable core config auto import from the same location where export is configured. Auto import runs on startup |
 
 ## Kubernetes Configuration
 
@@ -228,12 +236,6 @@ example of json file provided via METRICS_CONFIGFILE_CONTENTENVVAR or METRICS_CO
 | feign.retry.errorCodes                    | FEIGN_RETRY_ERRORCODES                      | 408,429,500,502,503,504 | No | - | HTTP status codes that trigger retries                             |
 | prompts.import.consecutiveErrorsThreshold | PROMPTS_IMPORT_CONSECUTIVE_ERRORS_THRESHOLD | 2                       | No | - | Maximum number of consecutive errors allowed during prompts import |
 | files.import.consecutiveErrorsThreshold   | FILES_IMPORT_CONSECUTIVE_ERRORS_THRESHOLD   | 2                       | No | - | Maximum number of consecutive errors allowed during files import   |
-
-## Export/Import Configuration
-
-| Setting | Environment Variable | Default | Required | Applied when | Description |
-|---------|---------------------|---------|----------|-----------|-------------|
-| config.import.configsMaxCount | IMPORT_CONFIGS_MAX_COUNT | 64 | No | - | Maximum number of files allowed for a single import config operation |
 
 ## Additional Entities Configuration
 *(Temporary configuration - will be implemented as managed entities inside admin app)*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,10 @@ This document provides a comprehensive list of all configurable properties in th
 
 ## AIDIAL Config File Import Configuration
 
-| Setting                          | Environment Variable      | Default | Required | Applied when | Description                                                                                                   |
-|----------------------------------|---------------------------|---------|----------|--------------|---------------------------------------------------------------------------------------------------------------|
-| config.import.configsMaxCount    | IMPORT_CONFIGS_MAX_COUNT  | 64      | No       | -            | Maximum number of files allowed for a single import config operation                                          |
-| config.import.autoImport.enabled | ENABLE_CONFIG_AUTO_IMPORT | false   | No       | -            | Enable core config auto import from the same location where export is configured. Auto import runs on startup |
+| Setting                          | Environment Variable      | Default | Required | Applied when | Description                                                                                                                       |
+|----------------------------------|---------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| config.import.configsMaxCount    | IMPORT_CONFIGS_MAX_COUNT  | 64      | No       | -            | Maximum number of files allowed for a single import config operation                                                              |
+| config.import.autoImport.enabled | ENABLE_CONFIG_AUTO_IMPORT | false   | No       | -            | Enable core config auto import from the same location where export is configured. Auto import runs once on startup if DB is empty |
 
 ## Kubernetes Configuration
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/DatabaseService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/DatabaseService.java
@@ -1,0 +1,23 @@
+package com.epam.aidial.cfg.domain.service;
+
+import com.epam.aidial.cfg.dao.audit.jpa.ConfigRevisionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class DatabaseService {
+
+    private final ConfigRevisionJpaRepository configRevisionJpaRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isInitializedEmptyDatabase() {
+        // Initialized empty database is database which contains only predefined entities saved during DB migration:
+        // 1. 'default' role and corresponding record in revinfo table.
+        // Once new default entities are added to the database (along with record in revinfo table), the list above
+        // and check below should be adjusted
+        return configRevisionJpaRepository.count() == 1;
+    }
+
+}

--- a/src/main/java/com/epam/aidial/cfg/service/export/ConfigExportScheduler.java
+++ b/src/main/java/com/epam/aidial/cfg/service/export/ConfigExportScheduler.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.service.export;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
+import com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportLock;
 import com.epam.aidial.core.config.Config;
 import lombok.RequiredArgsConstructor;
 import lombok.Synchronized;
@@ -11,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by Aliaksei Kurnosau on 9/9/24.
@@ -19,12 +21,14 @@ import java.util.List;
 @Service
 @Slf4j
 @LogExecution
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ConfigExportScheduler {
 
     private final CoreConfigAggregatorService configService;
     private final ConfigExportService configExportService;
     private final List<CoreConfigNormalizer> normalizers;
     private final ConfigExportErrorHandler errorHandler;
+    private final Optional<CoreConfigAutoImportLock> coreConfigAutoImportLock;
 
     @Value("${config.export.createResources}")
     private boolean createResources;
@@ -33,6 +37,11 @@ public class ConfigExportScheduler {
     @Synchronized
     public void exportCurrentConfig() {
         try {
+            if (coreConfigAutoImportLock.isPresent() && !coreConfigAutoImportLock.get().isAutoImportFinished()) {
+                log.info("Skipping export of current configuration since auto import of core configuration is not finished");
+                return;
+            }
+
             Config config = configService.getConfig();
             log.debug("Exporting current Configuration settings.");
             normalizers.forEach(n -> n.normalize(config));

--- a/src/main/java/com/epam/aidial/cfg/service/export/CoreConfigAggregatorService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/export/CoreConfigAggregatorService.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.export;
 
-import com.epam.aidial.cfg.domain.mapper.AddonCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationTypeSchemaCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.InterceptorCoreMapper;
@@ -49,7 +48,6 @@ public class CoreConfigAggregatorService {
     private final RouteService routeService;
     private final DeploymentService deploymentService;
 
-    private final AddonCoreMapper addonMapper;
     private final ApplicationCoreMapper applicationMapper;
     private final ApplicationTypeSchemaCoreMapper schemaMapper;
     private final InterceptorCoreMapper interceptorMapper;

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/ConfigTransfer.java
@@ -8,25 +8,13 @@ import com.epam.aidial.cfg.domain.model.ExportConfig;
 import com.epam.aidial.cfg.domain.model.ExportConfigPreview;
 import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
-import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
 import com.epam.aidial.cfg.model.ExportRequest;
 import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
 import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
 import com.epam.aidial.cfg.service.transfer.exporter.ConfigExporter;
 import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
-import com.epam.aidial.cfg.service.transfer.importer.AdapterImporter;
-import com.epam.aidial.cfg.service.transfer.importer.AddonImporter;
-import com.epam.aidial.cfg.service.transfer.importer.ApplicationImporter;
-import com.epam.aidial.cfg.service.transfer.importer.ApplicationTypeSchemaImporter;
-import com.epam.aidial.cfg.service.transfer.importer.AssistantImporter;
-import com.epam.aidial.cfg.service.transfer.importer.InterceptorImporter;
-import com.epam.aidial.cfg.service.transfer.importer.InterceptorRunnerImporter;
-import com.epam.aidial.cfg.service.transfer.importer.KeyImporter;
-import com.epam.aidial.cfg.service.transfer.importer.ModelImporter;
-import com.epam.aidial.cfg.service.transfer.importer.RoleImporter;
-import com.epam.aidial.cfg.service.transfer.importer.RouteImporter;
-import com.epam.aidial.cfg.service.transfer.importer.util.CoreRolesMerger;
+import com.epam.aidial.cfg.service.transfer.importer.ConfigImporter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +24,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -67,19 +54,7 @@ public class ConfigTransfer {
     private final ConfigExportProperties properties;
     private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final List<CoreConfigNormalizer> normalizers;
-    private final CoreRolesMerger coreRolesMerger;
-
-    private final ModelImporter modelImporter;
-    private final AddonImporter addonTransfer;
-    private final ApplicationImporter applicationImporter;
-    private final KeyImporter keyImporter;
-    private final RoleImporter roleImporter;
-    private final InterceptorImporter interceptorImporter;
-    private final InterceptorRunnerImporter interceptorRunnerImporter;
-    private final ApplicationTypeSchemaImporter applicationTypeSchemaImporter;
-    private final RouteImporter routeImporter;
-    private final AssistantImporter assistantImporter;
-    private final AdapterImporter adapterImporter;
+    private final ConfigImporter configImporter;
 
     @Transactional(readOnly = true)
     public StreamingResponseBody exportConfig(ExportRequest request) {
@@ -141,43 +116,16 @@ public class ConfigTransfer {
         return configExporter.preview(request);
     }
 
-    @Transactional(readOnly = true)
-    public ImportConfigPreview importPreview(List<MultipartFile> files,
-                                             ConfigImportOptions importOptions) {
+    public ImportConfigPreview importPreview(List<MultipartFile> files, ConfigImportOptions importOptions) {
         try {
-            ConflictResolutionPolicy resolutionPolicy = importOptions.conflictResolutionPolicy();
             Config config = readAndMergeConfig(files);
-            Map<String, Role> configRoles = coreRolesMerger.mergeCoreRoles(config, importOptions.createRoleIfAbsent());
-            var interceptors = interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, true);
-            var applicationRunners = applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, true);
-            var adapters = adapterImporter.importAdapters(config.getModels(), importOptions, true);
-            var models = modelImporter.importModels(config.getModels(), configRoles, importOptions, adapters, true);
-            var addons = addonTransfer.importAddons(config.getAddons(), configRoles, importOptions, true);
-            var applications = applicationImporter.importApplications(config.getApplications(), configRoles, importOptions, true);
-            var routes = routeImporter.importRoutes(config.getRoutes(), configRoles, importOptions, true);
-            var assistants = assistantImporter.importAssistants(config.getAssistant(), configRoles, importOptions, true);
-            var roles = roleImporter.importRoles(configRoles, resolutionPolicy, true);
-            var keys = keyImporter.importKeys(config.getKeys(), resolutionPolicy, true);
-            return ImportConfigPreview.builder()
-                    .roles(roles)
-                    .keys(keys)
-                    .interceptors(interceptors)
-                    .applicationRunners(applicationRunners)
-                    .routes(routes)
-                    .adapters(adapters)
-                    .models(models)
-                    .applications(applications)
-                    .addons(addons)
-                    .assistants(assistants)
-                    .build();
+            return configImporter.importPreview(config, importOptions);
         } catch (Exception exception) {
             log.warn("Failed to import config. Config import options: {}. Error: {}", importOptions, exception);
             throw exception;
         }
-
     }
 
-    @Transactional(readOnly = true)
     public ImportConfigPreview importPreviewZip(MultipartFile zipFile,
                                                 ConflictResolutionPolicy resolutionPolicy) {
         try (var zipInputStream = new ZipInputStream(new ByteArrayInputStream(zipFile.getBytes()))) {
@@ -192,7 +140,7 @@ public class ConfigTransfer {
                         throw new IllegalArgumentException("Multiple files {" + exportConfigFileName + "} with data found in the ZIP archive.");
                     }
                     ExportConfig config = jsonMapper.readValue(zipInputStream, ExportConfig.class);
-                    importConfigPreview = importPreviewAdminConfig(config, resolutionPolicy);
+                    importConfigPreview = configImporter.importPreviewAdminConfig(config, resolutionPolicy);
                 } else {
                     log.info("Ignoring file {} in zip archive during import", zipEntry.getName());
                 }
@@ -208,55 +156,16 @@ public class ConfigTransfer {
         }
     }
 
-    private ImportConfigPreview importPreviewAdminConfig(ExportConfig config, ConflictResolutionPolicy resolutionPolicy) {
-        var interceptorRunners = interceptorRunnerImporter.importAdminInterceptorRunners(config.getInterceptorRunners(), resolutionPolicy, true);
-        var interceptors = interceptorImporter.importAdminInterceptors(config.getInterceptors(), resolutionPolicy, true);
-        var applicationRunners = applicationTypeSchemaImporter.importAdminSchemas(config.getApplicationRunners(), resolutionPolicy, true);
-        ConfigImportOptions importOptions = createConfigImportOptions(resolutionPolicy);
-        var routes = routeImporter.importAdminRoutes(config.getRoutes(), config.getRoles(), importOptions, true);
-        var adapters = adapterImporter.importAdminAdapters(config.getAdapters(), importOptions, true);
-        var models = modelImporter.importAdminModels(config.getModels(), config.getRoles(), importOptions, true);
-        var applications = applicationImporter.importAdminApplications(config.getApplications(), config.getRoles(), importOptions, true);
-        var roles = roleImporter.importAdminRoles(config.getRoles(), resolutionPolicy, true);
-        var keys = keyImporter.importAdminKeys(config.getKeys(), resolutionPolicy, true);
-
-        return ImportConfigPreview.builder()
-                .roles(roles)
-                .keys(keys)
-                .interceptors(interceptors)
-                .interceptorRunners(interceptorRunners)
-                .applicationRunners(applicationRunners)
-                .routes(routes)
-                .adapters(adapters)
-                .models(models)
-                .applications(applications)
-                .build();
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED)
-    public void importConfig(List<MultipartFile> files,
-                             ConfigImportOptions importOptions) {
+    public void importConfig(List<MultipartFile> files, ConfigImportOptions importOptions) {
         try {
-            ConflictResolutionPolicy resolutionPolicy = importOptions.conflictResolutionPolicy();
             Config config = readAndMergeConfig(files);
-            Map<String, Role> configRoles = coreRolesMerger.mergeCoreRoles(config, importOptions.createRoleIfAbsent());
-            interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, false);
-            applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, false);
-            adapterImporter.importAdapters(config.getModels(), importOptions, false);
-            modelImporter.importModels(config.getModels(), configRoles, importOptions, List.of(), false);
-            addonTransfer.importAddons(config.getAddons(), configRoles, importOptions, false);
-            applicationImporter.importApplications(config.getApplications(), configRoles, importOptions, false);
-            routeImporter.importRoutes(config.getRoutes(), configRoles, importOptions, false);
-            assistantImporter.importAssistants(config.getAssistant(), configRoles, importOptions, false);
-            roleImporter.importRoles(configRoles, resolutionPolicy, false);
-            keyImporter.importKeys(config.getKeys(), resolutionPolicy, false);
+            configImporter.importConfig(config, importOptions);
         } catch (Exception exception) {
             log.warn("Failed to import config. Conflict resolution policy: {}. Error: {}", importOptions.conflictResolutionPolicy(), exception);
             throw exception;
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
     public void importConfigZip(MultipartFile zipFile,
                                 ConfigImportOptions importOptions) {
         try (var zipInputStream = new ZipInputStream(new ByteArrayInputStream(zipFile.getBytes()))) {
@@ -264,7 +173,7 @@ public class ConfigTransfer {
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 if (zipEntry.getName().equals(properties.getExportConfigFileName())) {
                     ExportConfig config = jsonMapper.readValue(zipInputStream, ExportConfig.class);
-                    importAdminConfig(config, importOptions);
+                    configImporter.importAdminConfig(config, importOptions);
                 } else {
                     log.info("Ignoring file {} in zip archive during import", zipEntry.getName());
                 }
@@ -274,24 +183,6 @@ public class ConfigTransfer {
             log.debug("Config file {} import failed", zipFile.getOriginalFilename(), ex);
             throw new IllegalArgumentException(ex.getMessage(), ex);
         }
-    }
-
-    private void importAdminConfig(ExportConfig config,
-                                   ConfigImportOptions importOptions) {
-        var resolutionPolicy = importOptions.conflictResolutionPolicy();
-        interceptorRunnerImporter.importAdminInterceptorRunners(config.getInterceptorRunners(), resolutionPolicy, false);
-        interceptorImporter.importAdminInterceptors(config.getInterceptors(), resolutionPolicy, false);
-        applicationTypeSchemaImporter.importAdminSchemas(config.getApplicationRunners(), resolutionPolicy, false);
-        routeImporter.importAdminRoutes(config.getRoutes(), config.getRoles(), importOptions, false);
-        adapterImporter.importAdminAdapters(config.getAdapters(), importOptions, false);
-        modelImporter.importAdminModels(config.getModels(), config.getRoles(), importOptions, false);
-        applicationImporter.importAdminApplications(config.getApplications(), config.getRoles(), importOptions, false);
-        roleImporter.importAdminRoles(config.getRoles(), resolutionPolicy, false);
-        keyImporter.importAdminKeys(config.getKeys(), resolutionPolicy, false);
-    }
-
-    private ConfigImportOptions createConfigImportOptions(ConflictResolutionPolicy resolutionPolicy) {
-        return new ConfigImportOptions(resolutionPolicy, false, false);
     }
 
     private Config readAndMergeConfig(List<MultipartFile> files) {

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportLock.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportLock.java
@@ -1,0 +1,21 @@
+package com.epam.aidial.cfg.service.transfer;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+@ConditionalOnProperty(value = "config.import.autoImport.enabled", havingValue = "true")
+public class CoreConfigAutoImportLock {
+
+    private final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+
+    public boolean isAutoImportFinished() {
+        return atomicBoolean.get();
+    }
+
+    public void finishAutoImport() {
+        atomicBoolean.set(true);
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportService.java
@@ -35,11 +35,10 @@ public class CoreConfigAutoImportService {
             } else {
                 log.info("Database is not empty. Skipping auto import of core config");
             }
+            coreConfigAutoImportLock.finishAutoImport();
         } catch (Exception exception) {
             log.error("Auto import of core config failed", exception);
             throw exception;
-        } finally {
-            coreConfigAutoImportLock.finishAutoImport();
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportService.java
@@ -1,0 +1,46 @@
+package com.epam.aidial.cfg.service.transfer;
+
+import com.epam.aidial.cfg.domain.service.DatabaseService;
+import com.epam.aidial.cfg.model.ConfigImportOptions;
+import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
+import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
+import com.epam.aidial.cfg.service.transfer.importer.ConfigImporter;
+import com.epam.aidial.core.config.Config;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(value = "config.import.autoImport.enabled", havingValue = "true")
+public class CoreConfigAutoImportService {
+
+    private final DatabaseService databaseService;
+    private final CoreConfigRetriever coreConfigRetriever;
+    private final ConfigImporter configImporter;
+    private final CoreConfigAutoImportLock coreConfigAutoImportLock;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void autoImportCoreConfig() {
+        try {
+            if (databaseService.isInitializedEmptyDatabase()) {
+                log.info("Auto import of core config started");
+                Config config = coreConfigRetriever.getConfig(true);
+                configImporter.importConfig(config, new ConfigImportOptions(ConflictResolutionPolicy.OVERRIDE));
+                log.info("Auto import of core config finished");
+            } else {
+                log.info("Database is not empty. Skipping auto import of core config");
+            }
+        } catch (Exception exception) {
+            log.error("Auto import of core config failed", exception);
+            throw exception;
+        } finally {
+            coreConfigAutoImportLock.finishAutoImport();
+        }
+    }
+
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ConfigExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ConfigExporter.java
@@ -220,9 +220,9 @@ public class ConfigExporter {
         }
     }
 
-    protected Set<String> getAllEntityNames(Set<String> applications,
-                                            Set<String> models,
-                                            Set<String> routes) {
+    private Set<String> getAllEntityNames(Set<String> applications,
+                                          Set<String> models,
+                                          Set<String> routes) {
         return Stream.of(applications, models, routes)
                 .flatMap(Set::stream)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ConfigImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ConfigImporter.java
@@ -1,0 +1,125 @@
+package com.epam.aidial.cfg.service.transfer.importer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.ExportConfig;
+import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
+import com.epam.aidial.cfg.model.ConfigImportOptions;
+import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
+import com.epam.aidial.cfg.service.transfer.importer.util.CoreRolesMerger;
+import com.epam.aidial.core.config.Config;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@LogExecution
+@Slf4j
+@RequiredArgsConstructor
+public class ConfigImporter {
+
+    private final CoreRolesMerger coreRolesMerger;
+
+    private final ModelImporter modelImporter;
+    private final AddonImporter addonTransfer;
+    private final ApplicationImporter applicationImporter;
+    private final KeyImporter keyImporter;
+    private final RoleImporter roleImporter;
+    private final InterceptorImporter interceptorImporter;
+    private final InterceptorRunnerImporter interceptorRunnerImporter;
+    private final ApplicationTypeSchemaImporter applicationTypeSchemaImporter;
+    private final RouteImporter routeImporter;
+    private final AssistantImporter assistantImporter;
+    private final AdapterImporter adapterImporter;
+
+    @Transactional(readOnly = true)
+    public ImportConfigPreview importPreview(Config config, ConfigImportOptions importOptions) {
+        var resolutionPolicy = importOptions.conflictResolutionPolicy();
+        var configRoles = coreRolesMerger.mergeCoreRoles(config, importOptions.createRoleIfAbsent());
+
+        var interceptors = interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, true);
+        var applicationRunners = applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, true);
+        var adapters = adapterImporter.importAdapters(config.getModels(), importOptions, true);
+        var models = modelImporter.importModels(config.getModels(), configRoles, importOptions, adapters, true);
+        var addons = addonTransfer.importAddons(config.getAddons(), configRoles, importOptions, true);
+        var applications = applicationImporter.importApplications(config.getApplications(), configRoles, importOptions, true);
+        var routes = routeImporter.importRoutes(config.getRoutes(), configRoles, importOptions, true);
+        var assistants = assistantImporter.importAssistants(config.getAssistant(), configRoles, importOptions, true);
+        var roles = roleImporter.importRoles(configRoles, resolutionPolicy, true);
+        var keys = keyImporter.importKeys(config.getKeys(), resolutionPolicy, true);
+
+        return ImportConfigPreview.builder()
+                .roles(roles)
+                .keys(keys)
+                .interceptors(interceptors)
+                .applicationRunners(applicationRunners)
+                .routes(routes)
+                .adapters(adapters)
+                .models(models)
+                .applications(applications)
+                .addons(addons)
+                .assistants(assistants)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public ImportConfigPreview importPreviewAdminConfig(ExportConfig config, ConflictResolutionPolicy resolutionPolicy) {
+        var importOptions = new ConfigImportOptions(resolutionPolicy, false, false);
+
+        var interceptorRunners = interceptorRunnerImporter.importAdminInterceptorRunners(config.getInterceptorRunners(), resolutionPolicy, true);
+        var interceptors = interceptorImporter.importAdminInterceptors(config.getInterceptors(), resolutionPolicy, true);
+        var applicationRunners = applicationTypeSchemaImporter.importAdminSchemas(config.getApplicationRunners(), resolutionPolicy, true);
+        var routes = routeImporter.importAdminRoutes(config.getRoutes(), config.getRoles(), importOptions, true);
+        var adapters = adapterImporter.importAdminAdapters(config.getAdapters(), importOptions, true);
+        var models = modelImporter.importAdminModels(config.getModels(), config.getRoles(), importOptions, true);
+        var applications = applicationImporter.importAdminApplications(config.getApplications(), config.getRoles(), importOptions, true);
+        var roles = roleImporter.importAdminRoles(config.getRoles(), resolutionPolicy, true);
+        var keys = keyImporter.importAdminKeys(config.getKeys(), resolutionPolicy, true);
+
+        return ImportConfigPreview.builder()
+                .roles(roles)
+                .keys(keys)
+                .interceptors(interceptors)
+                .interceptorRunners(interceptorRunners)
+                .applicationRunners(applicationRunners)
+                .routes(routes)
+                .adapters(adapters)
+                .models(models)
+                .applications(applications)
+                .build();
+    }
+
+    @Transactional
+    public void importConfig(Config config, ConfigImportOptions importOptions) {
+        var resolutionPolicy = importOptions.conflictResolutionPolicy();
+        var configRoles = coreRolesMerger.mergeCoreRoles(config, importOptions.createRoleIfAbsent());
+
+        interceptorImporter.importInterceptors(config.getInterceptors(), resolutionPolicy, false);
+        applicationTypeSchemaImporter.importSchemas(config.getApplicationTypeSchemas(), resolutionPolicy, false);
+        adapterImporter.importAdapters(config.getModels(), importOptions, false);
+        modelImporter.importModels(config.getModels(), configRoles, importOptions, List.of(), false);
+        addonTransfer.importAddons(config.getAddons(), configRoles, importOptions, false);
+        applicationImporter.importApplications(config.getApplications(), configRoles, importOptions, false);
+        routeImporter.importRoutes(config.getRoutes(), configRoles, importOptions, false);
+        assistantImporter.importAssistants(config.getAssistant(), configRoles, importOptions, false);
+        roleImporter.importRoles(configRoles, resolutionPolicy, false);
+        keyImporter.importKeys(config.getKeys(), resolutionPolicy, false);
+    }
+
+    @Transactional
+    public void importAdminConfig(ExportConfig config, ConfigImportOptions importOptions) {
+        var resolutionPolicy = importOptions.conflictResolutionPolicy();
+
+        interceptorRunnerImporter.importAdminInterceptorRunners(config.getInterceptorRunners(), resolutionPolicy, false);
+        interceptorImporter.importAdminInterceptors(config.getInterceptors(), resolutionPolicy, false);
+        applicationTypeSchemaImporter.importAdminSchemas(config.getApplicationRunners(), resolutionPolicy, false);
+        routeImporter.importAdminRoutes(config.getRoutes(), config.getRoles(), importOptions, false);
+        adapterImporter.importAdminAdapters(config.getAdapters(), importOptions, false);
+        modelImporter.importAdminModels(config.getModels(), config.getRoles(), importOptions, false);
+        applicationImporter.importAdminApplications(config.getApplications(), config.getRoles(), importOptions, false);
+        roleImporter.importAdminRoles(config.getRoles(), resolutionPolicy, false);
+        keyImporter.importAdminKeys(config.getKeys(), resolutionPolicy, false);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,9 @@ config.export.exportConfigFileName=aidial.config.json
 config.export.exportConfigFileZipName=admin.config.zip
 config.export.exportRawConfigFileZipName=admin.raw-config.zip
 
+config.import.configsMaxCount=${IMPORT_CONFIGS_MAX_COUNT:64}
+config.import.autoImport.enabled=${ENABLE_CONFIG_AUTO_IMPORT:false}
+
 # kube api connection config
 kubernetes-config.connectType=CONFIG_FILE
 kubernetes-config.masterUrl=url
@@ -154,7 +157,6 @@ feign.retry.errorCodes=${FEIGN_RETRY_ERROR_CODES:408,429,500,502,503,504}
 
 prompts.import.consecutiveErrorsThreshold=${PROMPTS_IMPORT_CONSECUTIVE_ERRORS_THRESHOLD:2}
 files.import.consecutiveErrorsThreshold=${FILES_IMPORT_CONSECUTIVE_ERRORS_THRESHOLD:2}
-config.import.configsMaxCount=${IMPORT_CONFIGS_MAX_COUNT:64}
 
 features.flags.addonsSupported=${ADDONS_SUPPORTED:false}
 features.flags.assistantsSupported=${ASSISTANTS_SUPPORTED:false}

--- a/src/test/java/com/epam/aidial/cfg/functional/H2FunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/H2FunctionalTests.java
@@ -8,6 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -61,6 +62,10 @@ public class H2FunctionalTests extends FunctionalTestSuite {
 
     @Nested
     class ConfigTransferTests extends ConfigTransferFunctionalTest {
+    }
+
+    @Nested
+    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/MsSqlServerFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/MsSqlServerFunctionalTests.java
@@ -8,6 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -105,6 +106,10 @@ public class MsSqlServerFunctionalTests extends FunctionalTestSuite {
 
     @Nested
     class ConfigTransferTests extends ConfigTransferFunctionalTest {
+    }
+
+    @Nested
+    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/PostgresFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/PostgresFunctionalTests.java
@@ -8,6 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -74,6 +75,10 @@ public class PostgresFunctionalTests extends FunctionalTestSuite {
 
     @Nested
     class ConfigTransferTests extends ConfigTransferFunctionalTest {
+    }
+
+    @Nested
+    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/config/FunctionalTestConfiguration.java
@@ -7,7 +7,6 @@ import com.epam.aidial.cfg.configuration.HibernateConfiguration;
 import com.epam.aidial.cfg.configuration.JpaConfiguration;
 import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.configuration.ValidationConfig;
-import com.epam.aidial.cfg.domain.mapper.AddonCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.ApplicationTypeSchemaCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.InterceptorCoreMapper;
@@ -30,12 +29,16 @@ import com.epam.aidial.cfg.service.export.CoreConfigAggregatorService;
 import com.epam.aidial.cfg.service.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import com.epam.aidial.cfg.web.facade.HistoryFacade;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreModel;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+
+import java.util.Map;
 
 @TestConfiguration
 @ComponentScan(basePackages = {
@@ -67,14 +70,14 @@ public class FunctionalTestConfiguration {
                                                                KeyService keyService,
                                                                ModelService modelService, RoleService roleService,
                                                                RouteService routeService, DeploymentService deploymentService,
-                                                               AddonCoreMapper addonMapper, ApplicationCoreMapper applicationMapper,
+                                                               ApplicationCoreMapper applicationMapper,
                                                                ApplicationTypeSchemaCoreMapper schemaMapper,
                                                                InterceptorCoreMapper interceptorMapper,
                                                                KeyCoreMapper keyMapper,
                                                                ModelCoreMapper modelMapper, RoleCoreMapper roleMapper,
                                                                RouteCoreMapper routeMapper) {
         return new CoreConfigAggregatorService(applicationService, applicationTypeSchemaService, interceptorService,
-                keyService, modelService, roleService, routeService, deploymentService, addonMapper, applicationMapper, schemaMapper, interceptorMapper,
+                keyService, modelService, roleService, routeService, deploymentService, applicationMapper, schemaMapper, interceptorMapper,
                 keyMapper, modelMapper, roleMapper, routeMapper);
     }
 
@@ -93,7 +96,18 @@ public class FunctionalTestConfiguration {
 
     @Bean
     public CoreConfigRetriever configSource() {
-        return Mockito.mock(CoreConfigRetriever.class);
+        CoreModel model = new CoreModel();
+        model.setName("testModel");
+        model.setDisplayName("testModel displayName");
+
+        Config config = new Config();
+        config.setModels(Map.of(model.getName(), model));
+
+        CoreConfigRetriever mock = Mockito.mock(CoreConfigRetriever.class);
+
+        Mockito.when(mock.getConfig(true)).thenReturn(config);
+
+        return mock;
     }
 
     @Bean

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/CoreConfigAutoImportFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/CoreConfigAutoImportFunctionalTest.java
@@ -1,0 +1,34 @@
+package com.epam.aidial.cfg.functional.tests;
+
+import com.epam.aidial.cfg.dto.ModelDto;
+import com.epam.aidial.cfg.web.facade.ModelFacade;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @see com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportService
+ */
+
+@TestPropertySource(properties = {
+        "config.import.autoImport.enabled=true",
+})
+public abstract class CoreConfigAutoImportFunctionalTest {
+
+    @Autowired
+    private ModelFacade modelFacade;
+
+    @Test
+    public void testCoreConfigAutoImportedSuccessfully() {
+        Collection<ModelDto> models = modelFacade.getAll();
+
+        assertThat(models).hasSize(1).first().satisfies(modelDto -> {
+            assertThat(modelDto.getName()).isEqualTo("testModel");
+            assertThat(modelDto.getDisplayName()).isEqualTo("testModel displayName");
+        });
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #162 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Add ability to initialize admin app from config files used by core. It's set via `config.import.autoImport.enabled` env variable

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.