### PR TITLE
fix: Add Display Name property support for Interseptors and Routes 

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/model/RouteEntity.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/model/RouteEntity.java
@@ -32,6 +32,7 @@ public class RouteEntity extends TimeTrackableEntity<String> {
     private DeploymentEntity deployment;
 
     private String description;
+    private String displayName;
     @Embedded
     private ResponseEntity response;
     private boolean rewritePath;

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RouteCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RouteCoreMapper.java
@@ -37,6 +37,7 @@ public abstract class RouteCoreMapper {
     @Mapping(target = "description", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "displayName", ignore = true)
     public abstract Route mapRoute(CoreRoute route);
 
     @Mapping(target = "deployment.name", source = "name")

--- a/src/main/java/com/epam/aidial/cfg/domain/model/route/Route.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/route/Route.java
@@ -8,5 +8,5 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class Route extends BaseRoute {
-
+  private String displayName;
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/model/route/Route.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/route/Route.java
@@ -8,5 +8,5 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class Route extends BaseRoute {
-  private String displayName;
+    private String displayName;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/route/RouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/RouteDto.java
@@ -8,5 +8,5 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RouteDto extends BaseRouteDto {
-
+  private String displayName;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/route/RouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/RouteDto.java
@@ -8,5 +8,5 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RouteDto extends BaseRouteDto {
-  private String displayName;
+    private String displayName;
 }

--- a/src/main/resources/db/migration/H2/V1.55__AddDisplayNameToRouteEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.55__AddDisplayNameToRouteEntity.sql
@@ -1,0 +1,3 @@
+-- add new field display_name to route_entity, route_entity_aud tables
+alter table if exists route_entity add column if not exists display_name text;
+alter table if exists route_entity_aud add column if not exists display_name text;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.55__AddDisplayNameToRouteEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.55__AddDisplayNameToRouteEntity.sql
@@ -1,0 +1,3 @@
+-- add new field display_name to route_entity, route_entity_aud tables
+alter table route_entity add display_name nvarchar(max);
+alter table route_entity_aud add display_name nvarchar(max);

--- a/src/main/resources/db/migration/POSTGRES/V1.55__AddDisplayNameToRouteEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.55__AddDisplayNameToRouteEntity.sql
@@ -1,0 +1,3 @@
+-- add new field display_name to route_entity, route_entity_aud tables
+alter table if exists route_entity add column if not exists display_name text;
+alter table if exists route_entity_aud add column if not exists display_name text;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -219,6 +219,7 @@ public abstract class InterceptorFunctionalTest {
         InterceptorDto interceptorDto = new InterceptorDto();
         interceptorDto.setName("interceptor" + suffix);
         interceptorDto.setDescription("description" + suffix);
+        interceptorDto.setDisplayName("displayName" + suffix);
         interceptorDto.setEndpoint("https://endpoint.test.com/interceptor" + suffix);
         interceptorDto.setEntities(List.of("application" + suffix));
         return interceptorDto;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
@@ -98,6 +98,7 @@ public abstract class RouteFunctionalTest {
         RouteDto routeDto = new RouteDto();
         routeDto.setName("route" + suffix);
         routeDto.setDescription("description" + suffix);
+        routeDto.setDisplayName("displayName" + suffix);
         routeDto.setRoleLimits(Map.of(
                 "role2", new LimitDto()
         ));

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
@@ -184,6 +184,7 @@ public abstract class InterceptorHistoryFunctionalTest {
         InterceptorDto interceptorDto = new InterceptorDto();
         interceptorDto.setName("interceptor" + suffix);
         interceptorDto.setDescription("description" + suffix);
+        interceptorDto.setDisplayName("displayName" + suffix);
         interceptorDto.setEndpoint("https://endpoint.test.com/interceptor" + suffix);
         interceptorDto.setEntities(List.of());
         return interceptorDto;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
@@ -120,6 +120,7 @@ public abstract class RouteHistoryFunctionalTest {
         RouteDto routeDto = new RouteDto();
         routeDto.setName("route" + suffix);
         routeDto.setDescription("description" + suffix);
+        routeDto.setDisplayName("displayName" + suffix);
         routeDto.setRoleLimits(Map.of(
                 "role" + suffix, new LimitDto()
         ));

--- a/src/test/resources/route_dto.json
+++ b/src/test/resources/route_dto.json
@@ -1,6 +1,7 @@
 {
 	"name": "test_route",
 	"description": "routeDescription",
+	"displayName": "routeDisplayName",
 	"response": {
 		"status": 200,
 		"body": "OK"

--- a/src/test/resources/route_dto_with_empty_paths.json
+++ b/src/test/resources/route_dto_with_empty_paths.json
@@ -1,6 +1,7 @@
 {
 	"name": "test_route",
 	"description": "routeDescription",
+	"displayName": "routeDisplayName",
 	"response": {
 		"status": 200,
 		"body": "OK"

--- a/src/test/resources/route_dtos.json
+++ b/src/test/resources/route_dtos.json
@@ -2,6 +2,7 @@
 	{
 		"name": "SampleRoute",
 		"description": "routeDescription",
+		"displayName": "routeDisplayName",
 		"response": {
 			"status": 200,
 			"body": "OK"


### PR DESCRIPTION
### Applicable issues

- fixes # https://github.com/epam/ai-dial-admin-backend/issues/161

### Description of changes

- Support for the property displayName for the Route entity has been added.
- Support for the property displayName for the Interceptor entity was added earlier:

model: https://github.com/epam/ai-dial-admin-backend/blob/0f3de459c966f9bd57527851d8b2c75dd1c2297c/src/main/java/com/epam/aidial/cfg/domain/model/Interceptor.java#L15
dto:   https://github.com/epam/ai-dial-admin-backend/blob/0f3de459c966f9bd57527851d8b2c75dd1c2297c/src/main/java/com/epam/aidial/cfg/dto/InterceptorDto.java#L19

entity: https://github.com/epam/ai-dial-admin-backend/blob/0f3de459c966f9bd57527851d8b2c75dd1c2297c/src/main/java/com/epam/aidial/cfg/dao/model/InterceptorEntity.java#L32



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.