### PR TITLE
feat!: rename property from `config.import.autoImport.enabled` to `config.import.autoImportOnBootstrap.enabled`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,10 @@ This document provides a comprehensive list of all configurable properties in th
 
 ## AIDIAL Config File Import Configuration
 
-| Setting                          | Environment Variable      | Default | Required | Applied when | Description                                                                                                                       |
-|----------------------------------|---------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| config.import.configsMaxCount    | IMPORT_CONFIGS_MAX_COUNT  | 64      | No       | -            | Maximum number of files allowed for a single import config operation                                                              |
-| config.import.autoImport.enabled | ENABLE_CONFIG_AUTO_IMPORT | false   | No       | -            | Enable core config auto import from the same location where export is configured. Auto import runs once on startup if DB is empty |
+| Setting                                     | Environment Variable                   | Default | Required | Applied when | Description                                                                                                                       |
+|---------------------------------------------|----------------------------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| config.import.configsMaxCount               | IMPORT_CONFIGS_MAX_COUNT               | 64      | No       | -            | Maximum number of files allowed for a single import config operation                                                              |
+| config.import.autoImportOnBootstrap.enabled | ENABLE_CONFIG_AUTO_IMPORT_ON_BOOTSTRAP | false   | No       | -            | Enable core config auto import from the same location where export is configured. Auto import runs once on startup if DB is empty |
 
 ## Kubernetes Configuration
 

--- a/src/main/java/com/epam/aidial/cfg/service/export/ConfigExportScheduler.java
+++ b/src/main/java/com/epam/aidial/cfg/service/export/ConfigExportScheduler.java
@@ -2,7 +2,7 @@ package com.epam.aidial.cfg.service.export;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
-import com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportLock;
+import com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportOnBootstrapLock;
 import com.epam.aidial.core.config.Config;
 import lombok.RequiredArgsConstructor;
 import lombok.Synchronized;
@@ -28,7 +28,7 @@ public class ConfigExportScheduler {
     private final ConfigExportService configExportService;
     private final List<CoreConfigNormalizer> normalizers;
     private final ConfigExportErrorHandler errorHandler;
-    private final Optional<CoreConfigAutoImportLock> coreConfigAutoImportLock;
+    private final Optional<CoreConfigAutoImportOnBootstrapLock> coreConfigAutoImportLock;
 
     @Value("${config.export.createResources}")
     private boolean createResources;

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportOnBootstrapLock.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportOnBootstrapLock.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
-@ConditionalOnProperty(value = "config.import.autoImport.enabled", havingValue = "true")
-public class CoreConfigAutoImportLock {
+@ConditionalOnProperty(value = "config.import.autoImportOnBootstrap.enabled", havingValue = "true")
+public class CoreConfigAutoImportOnBootstrapLock {
 
     private final AtomicBoolean atomicBoolean = new AtomicBoolean(false);
 

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportOnBootstrapService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/CoreConfigAutoImportOnBootstrapService.java
@@ -16,13 +16,13 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@ConditionalOnProperty(value = "config.import.autoImport.enabled", havingValue = "true")
-public class CoreConfigAutoImportService {
+@ConditionalOnProperty(value = "config.import.autoImportOnBootstrap.enabled", havingValue = "true")
+public class CoreConfigAutoImportOnBootstrapService {
 
     private final DatabaseService databaseService;
     private final CoreConfigRetriever coreConfigRetriever;
     private final ConfigImporter configImporter;
-    private final CoreConfigAutoImportLock coreConfigAutoImportLock;
+    private final CoreConfigAutoImportOnBootstrapLock coreConfigAutoImportOnBootstrapLock;
 
     @EventListener(ApplicationReadyEvent.class)
     public void autoImportCoreConfig() {
@@ -35,7 +35,7 @@ public class CoreConfigAutoImportService {
             } else {
                 log.info("Database is not empty. Skipping auto import of core config");
             }
-            coreConfigAutoImportLock.finishAutoImport();
+            coreConfigAutoImportOnBootstrapLock.finishAutoImport();
         } catch (Exception exception) {
             log.error("Auto import of core config failed", exception);
             throw exception;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,7 +34,7 @@ config.export.exportConfigFileZipName=admin.config.zip
 config.export.exportRawConfigFileZipName=admin.raw-config.zip
 
 config.import.configsMaxCount=${IMPORT_CONFIGS_MAX_COUNT:64}
-config.import.autoImport.enabled=${ENABLE_CONFIG_AUTO_IMPORT:false}
+config.import.autoImportOnBootstrap.enabled=${ENABLE_CONFIG_AUTO_IMPORT_ON_BOOTSTRAP:false}
 
 # kube api connection config
 kubernetes-config.connectType=CONFIG_FILE

--- a/src/test/java/com/epam/aidial/cfg/functional/H2FunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/H2FunctionalTests.java
@@ -8,7 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
-import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportOnBootstrapFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -67,7 +67,7 @@ public class H2FunctionalTests extends FunctionalTestSuite {
     }
 
     @Nested
-    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
+    class CoreConfigAutoImportOnBootstrapTests extends CoreConfigAutoImportOnBootstrapFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/MsSqlServerFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/MsSqlServerFunctionalTests.java
@@ -8,7 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
-import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportOnBootstrapFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -111,7 +111,7 @@ public class MsSqlServerFunctionalTests extends FunctionalTestSuite {
     }
 
     @Nested
-    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
+    class CoreConfigAutoImportOnBootstrapTests extends CoreConfigAutoImportOnBootstrapFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/PostgresFunctionalTests.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/PostgresFunctionalTests.java
@@ -8,7 +8,7 @@ import com.epam.aidial.cfg.functional.tests.ApplicationTypeSchemaFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.AssistantsPropertyFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.ConfigTransferFunctionalTest;
-import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportFunctionalTest;
+import com.epam.aidial.cfg.functional.tests.CoreConfigAutoImportOnBootstrapFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.InterceptorRunnerFunctionalTest;
 import com.epam.aidial.cfg.functional.tests.KeyFunctionalTest;
@@ -80,7 +80,7 @@ public class PostgresFunctionalTests extends FunctionalTestSuite {
     }
 
     @Nested
-    class CoreConfigAutoImportTests extends CoreConfigAutoImportFunctionalTest {
+    class CoreConfigAutoImportOnBootstrapTests extends CoreConfigAutoImportOnBootstrapFunctionalTest {
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/CoreConfigAutoImportOnBootstrapFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/CoreConfigAutoImportOnBootstrapFunctionalTest.java
@@ -11,13 +11,13 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @see com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportService
+ * @see com.epam.aidial.cfg.service.transfer.CoreConfigAutoImportOnBootstrapService
  */
 
 @TestPropertySource(properties = {
-        "config.import.autoImport.enabled=true",
+        "config.import.autoImportOnBootstrap.enabled=true",
 })
-public abstract class CoreConfigAutoImportFunctionalTest {
+public abstract class CoreConfigAutoImportOnBootstrapFunctionalTest {
 
     @Autowired
     private ModelFacade modelFacade;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #162 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Renamed property from `config.import.autoImport.enabled` to `config.import.autoImportOnBootstrap.enabled`

BREAKING CHANGES:
Env var renamed from `ENABLE_CONFIG_AUTO_IMPORT` to `ENABLE_CONFIG_AUTO_IMPORT_ON_BOOTSTRAP`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.