### PR TITLE
fix: set `createRoleIfAbsent` to true by default during import preview

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/web/controller/ConfigController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/ConfigController.java
@@ -132,6 +132,7 @@ public class ConfigController {
     @PostMapping(path = "/import/preview", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ImportConfigPreviewDto importConfigPreview(@RequestPart("file") @Valid @Size(min = 1) List<MultipartFile> files,
                                                       @RequestParam("resolutionPolicy") ConflictResolutionPolicy resolutionPolicy,
+                                                      @RequestParam(value = "createRoleIfAbsent", required = false, defaultValue = "true") boolean createRoleIfAbsent,
                                                       @RequestParam(value = "createAdapterIfAbsent", required = false, defaultValue = "true") boolean createAdapterIfAbsent) {
         int filesSize = CollectionUtils.size(files);
         if (filesSize > importConfigsMaxCount) {
@@ -139,7 +140,7 @@ public class ConfigController {
                     importConfigsMaxCount, filesSize));
         }
 
-        var configImportOptions = new ConfigImportOptions(resolutionPolicy, false, createAdapterIfAbsent);
+        var configImportOptions = new ConfigImportOptions(resolutionPolicy, createRoleIfAbsent, createAdapterIfAbsent);
         var importConfigPreview = configTransfer.importPreview(files, configImportOptions);
         return importConfigMapper.toImportConfigPreviewDto(importConfigPreview);
     }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -179,7 +179,7 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
                 .models(List.of(new ImportComponent<>(CREATE, model)))
                 .build();
 
-        var configImportOptions = new ConfigImportOptions(ConflictResolutionPolicy.SKIP, false, true);
+        var configImportOptions = new ConfigImportOptions(ConflictResolutionPolicy.SKIP, true, true);
         when(configTransfer.importPreview(List.of(mockFile), configImportOptions)).thenReturn(importConfigPreview);
         String expected = ResourceUtils.readResource("/import/import_preview_model.json");
         // when


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #193

### Description of changes
Set `createRoleIfAbsent` to true by default during import preview to align with actual import

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.