### PR TITLE
fix: remove 'applicationTypeRoutes' from ApplicationTypeSchema in schema-v0.33.0.json

### DIFF
--- a/src/main/resources/core-config-schemas/schema-v0.33.0.json
+++ b/src/main/resources/core-config-schemas/schema-v0.33.0.json
@@ -296,7 +296,6 @@
             "applicationTypeTruncatePromptEndpoint": {"type": "string"},
             "appendApplicationPropertiesHeader": {"type": "boolean"},
             "applicationTypeIconUrl": {"type": "string"},
-            "applicationTypeRoutes": {"type": "object"},
             "defs": {"type": "object"},
             "properties": {"type": "object"},
             "required": {


### PR DESCRIPTION
### Applicable issues

- fixes #204 

### Description of changes

Removed 'applicationTypeRoutes' from ApplicationTypeSchema schema-v0.33.0.json. It means that exported core config won't contain 'applicationTypeRoutes' if core_config_version is 0.33.0 or lower. The reason is that schema was incorrect in version 0.33.0 and was fixed in 0.34.0: https://github.com/epam/ai-dial-core/pull/957

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.