### PR TITLE
fix: remove application type schema that doesn't conform to meta schema and associated applications from exported core config

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
@@ -32,6 +32,7 @@ public class ApplicationTypeSchemaCoreConfigNormalizer implements CoreConfigNorm
                 applicationTypeSchemas.remove(schemaId);
 
                 List<String> applicationsWithInvalidAppTypeSchema = applications.entrySet().stream()
+                        .filter(appEntry -> appEntry.getValue().getApplicationTypeSchemaId() != null)
                         .filter(appEntry -> appEntry.getValue().getApplicationTypeSchemaId().toString().equals(schemaId))
                         .map(Map.Entry::getKey)
                         .toList();

--- a/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
@@ -2,11 +2,14 @@ package com.epam.aidial.cfg.service.normalizer.impl;
 
 import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
 import com.epam.aidial.core.config.validation.SchemaConformToMetaSchemaValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -20,11 +23,20 @@ public class ApplicationTypeSchemaCoreConfigNormalizer implements CoreConfigNorm
             return;
         }
 
-        for (Map.Entry<String, String> entry : applicationTypeSchemas.entrySet()) {
+        Map<String, CoreApplication> applications = config.getApplications();
+
+        for (Map.Entry<String, String> entry : new HashMap<>(applicationTypeSchemas).entrySet()) {
             String schemaId = entry.getKey();
             if (!SchemaConformToMetaSchemaValidator.isValid(entry.getValue())) {
-                log.debug("normalizeConfig. remove invalid application type schema which doesn't conform to meta schema: {}", schemaId);
+                log.warn("normalizeConfig. remove invalid application type schema which doesn't conform to meta schema: {}", schemaId);
                 applicationTypeSchemas.remove(schemaId);
+
+                List<String> applicationsWithInvalidAppTypeSchema = applications.entrySet().stream()
+                        .filter(appEntry -> appEntry.getValue().getApplicationTypeSchemaId().toString().equals(schemaId))
+                        .map(Map.Entry::getKey)
+                        .toList();
+                log.warn("normalizeConfig. remove applications with invalid application type schema: {}", applicationsWithInvalidAppTypeSchema);
+                applicationsWithInvalidAppTypeSchema.forEach(applications::remove);
             }
         }
     }

--- a/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizer.java
@@ -1,0 +1,31 @@
+package com.epam.aidial.cfg.service.normalizer.impl;
+
+import com.epam.aidial.cfg.service.normalizer.CoreConfigNormalizer;
+import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.validation.SchemaConformToMetaSchemaValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class ApplicationTypeSchemaCoreConfigNormalizer implements CoreConfigNormalizer {
+
+    @Override
+    public void normalize(Config config) {
+        Map<String, String> applicationTypeSchemas = config.getApplicationTypeSchemas();
+        if (MapUtils.isEmpty(applicationTypeSchemas)) {
+            return;
+        }
+
+        for (Map.Entry<String, String> entry : applicationTypeSchemas.entrySet()) {
+            String schemaId = entry.getKey();
+            if (!SchemaConformToMetaSchemaValidator.isValid(entry.getValue())) {
+                log.debug("normalizeConfig. remove invalid application type schema which doesn't conform to meta schema: {}", schemaId);
+                applicationTypeSchemas.remove(schemaId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/core/config/validation/ConformToMetaSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/core/config/validation/ConformToMetaSchemaValidator.java
@@ -1,20 +1,11 @@
 package com.epam.aidial.core.config.validation;
 
-import java.util.Map;
-
-import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
-
-import com.networknt.schema.InputFormat;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class ConformToMetaSchemaValidator implements ConstraintValidator<ConformToMetaSchema, Map<String, String>> {
+import java.util.Map;
 
-    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
-    private static final JsonSchema SCHEMA = SCHEMA_FACTORY.getSchema(MetaSchemaHolder.getCustomApplicationMetaSchema());
+public class ConformToMetaSchemaValidator implements ConstraintValidator<ConformToMetaSchema, Map<String, String>> {
 
     @Override
     public boolean isValid(Map<String, String> idSchemaMap, ConstraintValidatorContext context) {
@@ -22,7 +13,7 @@ public class ConformToMetaSchemaValidator implements ConstraintValidator<Conform
             return true;
         }
         for (Map.Entry<String, String> entry : idSchemaMap.entrySet()) {
-            if (!SCHEMA.validate(entry.getValue(), InputFormat.JSON).isEmpty()) {
+            if (!SchemaConformToMetaSchemaValidator.isValid(entry.getValue())) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
                         .addBeanNode()

--- a/src/main/java/com/epam/aidial/core/config/validation/SchemaConformToMetaSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/core/config/validation/SchemaConformToMetaSchemaValidator.java
@@ -1,0 +1,17 @@
+package com.epam.aidial.core.config.validation;
+
+import com.epam.aidial.core.metaschemas.MetaSchemaHolder;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+
+public class SchemaConformToMetaSchemaValidator {
+
+    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+    private static final JsonSchema SCHEMA = SCHEMA_FACTORY.getSchema(MetaSchemaHolder.getCustomApplicationMetaSchema());
+
+    public static boolean isValid(String schema) {
+        return SCHEMA.validate(schema, InputFormat.JSON).isEmpty();
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationCoreConfigNormalizerTest.java
@@ -42,7 +42,7 @@ class ApplicationCoreConfigNormalizerTest {
     }
 
     @Test
-    void testNormalize_applicationDoesNotConformToItsSchema_RemoveApplication() {
+    void testNormalize_applicationDoesNotConformToItsSchema_removeApplication() {
         // given
         CoreApplication application = new CoreApplication();
 
@@ -65,7 +65,7 @@ class ApplicationCoreConfigNormalizerTest {
     }
 
     @Test
-    void testNormalize_applicationConformsToItsSchema_DoesNotRemoveApplication() {
+    void testNormalize_applicationConformsToItsSchema_doesNotRemoveApplication() {
         // given
         CoreApplication application = new CoreApplication();
 

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
@@ -1,0 +1,123 @@
+package com.epam.aidial.cfg.service.normalizer.impl;
+
+import com.epam.aidial.core.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationTypeSchemaCoreConfigNormalizerTest {
+
+    private ApplicationTypeSchemaCoreConfigNormalizer normalizer;
+
+    @BeforeEach
+    void init() {
+        normalizer = new ApplicationTypeSchemaCoreConfigNormalizer();
+    }
+
+    @Test
+    void testNormalize_applicationTypeSchemasMissingInConfig_doNothing() {
+        // given
+        Config config = new Config();
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplicationTypeSchemas()).isEmpty();
+    }
+
+    @Test
+    void testNormalize_applicationTypeSchemaDoesNotConformToMetaSchema_removeApplicationTypeSchema() {
+        // given
+        String applicationTypeSchema = """
+                {
+                     "properties": {},
+                     "applications": [],
+                     "createdAt": "2025-08-29T11:34:26.709Z",
+                     "updatedAt": "2025-08-29T11:34:26.709Z",
+                     "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                     "$id": "https://runner-char",
+                     "dial:applicationTypeDisplayName": "char1",
+                     "dial:applicationTypeCompletionEndpoint": "https://app_hostname/openai/deployments/app_name/chat/completions",
+                     "dial:applicationTypeRoutes": [
+                         {
+                             "isPublic": false,
+                             "name": "char_route",
+                             "rewritePath": false,
+                             "paths": [
+                                 "/auto-test-global-route/some/suffix/here",
+                                 ""
+                             ],
+                             "methods": [
+                                 "POST",
+                                 "GET"
+                             ],
+                             "upstreams": [
+                                 {
+                                     "weight": 1,
+                                     "tier": 0
+                                 }
+                             ],
+                             "maxRetryAttempts": 1,
+                             "order": 1,
+                             "permissions": [
+                                 "read",
+                                 "write"
+                             ]
+                         }
+                     ],
+                     "$defs": {}
+                 }
+                """;
+
+        Map<String, String> applicationTypeSchemasMap = new HashMap<>();
+        applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
+
+        Config config = new Config();
+        config.setApplicationTypeSchemas(applicationTypeSchemasMap);
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplications()).isEmpty();
+    }
+
+    @Test
+    void testNormalize_applicationTypeSchemaConformsToMetaSchema_doesNotRemoveApplicationTypeSchema() {
+        // given
+        String applicationTypeSchema = """
+                {
+                    "properties": {},
+                    "applications": [],
+                    "createdAt": "2025-08-29T11:34:26.709Z",
+                    "updatedAt": "2025-08-29T11:34:26.709Z",
+                    "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                    "$id": "https://runner-char",
+                    "dial:applicationTypeDisplayName": "char1",
+                    "dial:applicationTypeCompletionEndpoint": "https://app_hostname/openai/deployments/app_name/chat/completions",
+                    "$defs": {}
+                }
+                """;
+
+        Map<String, String> applicationTypeSchemasMap = new HashMap<>();
+        applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
+
+        Config config = new Config();
+        config.setApplicationTypeSchemas(applicationTypeSchemasMap);
+
+        // when
+        normalizer.normalize(config);
+
+        // then
+        assertThat(config.getApplicationTypeSchemas()).hasSize(1).satisfies(applicationTypeSchemas -> {
+            String schema = applicationTypeSchemas.get("https://runner-char");
+            assertThat(schema).isNotNull();
+        });
+    }
+
+}

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
@@ -1,9 +1,11 @@
 package com.epam.aidial.cfg.service.normalizer.impl;
 
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,64 +33,51 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
     }
 
     @Test
-    void testNormalize_applicationTypeSchemaDoesNotConformToMetaSchema_removeApplicationTypeSchema() {
+    void testNormalize_applicationTypeSchemaDoesNotConformToMetaSchema_removeApplicationTypeSchemaAndAssociatedApplications() {
         // given
         String applicationTypeSchema = """
                 {
-                     "properties": {},
-                     "applications": [],
-                     "createdAt": "2025-08-29T11:34:26.709Z",
-                     "updatedAt": "2025-08-29T11:34:26.709Z",
-                     "$schema": "https://dial.epam.com/application_type_schemas/schema#",
-                     "$id": "https://runner-char",
-                     "dial:applicationTypeDisplayName": "char1",
-                     "dial:applicationTypeCompletionEndpoint": "https://app_hostname/openai/deployments/app_name/chat/completions",
-                     "dial:applicationTypeRoutes": [
-                         {
-                             "isPublic": false,
-                             "name": "char_route",
-                             "rewritePath": false,
-                             "paths": [
-                                 "/auto-test-global-route/some/suffix/here",
-                                 ""
-                             ],
-                             "methods": [
-                                 "POST",
-                                 "GET"
-                             ],
-                             "upstreams": [
-                                 {
-                                     "weight": 1,
-                                     "tier": 0
-                                 }
-                             ],
-                             "maxRetryAttempts": 1,
-                             "order": 1,
-                             "permissions": [
-                                 "read",
-                                 "write"
-                             ]
-                         }
-                     ],
-                     "$defs": {}
-                 }
+                    "properties": {},
+                    "applications": [],
+                    "createdAt": "2025-08-29T11:34:26.709Z",
+                    "updatedAt": "2025-08-29T11:34:26.709Z",
+                    "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                    "$id": "https://runner-char",
+                    "dial:applicationTypeDisplayName": "char1",
+                    "$defs": {}
+                }
                 """;
 
         Map<String, String> applicationTypeSchemasMap = new HashMap<>();
         applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
 
+        CoreApplication application1 = new CoreApplication();
+        application1.setApplicationTypeSchemaId(URI.create("https://runner-char"));
+
+        CoreApplication application2 = new CoreApplication();
+        application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        Map<String, CoreApplication> applicationsMap = new HashMap<>();
+        applicationsMap.put("testApplication1", application1);
+        applicationsMap.put("testApplication2", application2);
+
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
+        config.setApplications(applicationsMap);
 
         // when
         normalizer.normalize(config);
 
         // then
-        assertThat(config.getApplications()).isEmpty();
+        assertThat(config.getApplicationTypeSchemas()).isEmpty();
+        assertThat(config.getApplications()).hasSize(1).satisfies(applications -> {
+            assertThat(applications.get("testApplication1")).isNull();
+            assertThat(applications.get("testApplication2")).isNotNull();
+        });
     }
 
     @Test
-    void testNormalize_applicationTypeSchemaConformsToMetaSchema_doesNotRemoveApplicationTypeSchema() {
+    void testNormalize_applicationTypeSchemaConformsToMetaSchema_doesNotRemoveApplicationTypeSchemaAndAssociatedApplications() {
         // given
         String applicationTypeSchema = """
                 {
@@ -107,8 +96,19 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         Map<String, String> applicationTypeSchemasMap = new HashMap<>();
         applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
 
+        CoreApplication application1 = new CoreApplication();
+        application1.setApplicationTypeSchemaId(URI.create("https://runner-char"));
+
+        CoreApplication application2 = new CoreApplication();
+        application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        Map<String, CoreApplication> applicationsMap = new HashMap<>();
+        applicationsMap.put("testApplication1", application1);
+        applicationsMap.put("testApplication2", application2);
+
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
+        config.setApplications(applicationsMap);
 
         // when
         normalizer.normalize(config);
@@ -117,6 +117,10 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         assertThat(config.getApplicationTypeSchemas()).hasSize(1).satisfies(applicationTypeSchemas -> {
             String schema = applicationTypeSchemas.get("https://runner-char");
             assertThat(schema).isNotNull();
+        });
+        assertThat(config.getApplications()).hasSize(2).satisfies(applications -> {
+            assertThat(applications.get("testApplication1")).isNotNull();
+            assertThat(applications.get("testApplication2")).isNotNull();
         });
     }
 

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
@@ -57,9 +57,13 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         CoreApplication application2 = new CoreApplication();
         application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
 
+        CoreApplication application3 = new CoreApplication();
+        application3.setEndpoint("https://endpoint");
+
         Map<String, CoreApplication> applicationsMap = new HashMap<>();
         applicationsMap.put("testApplication1", application1);
         applicationsMap.put("testApplication2", application2);
+        applicationsMap.put("testApplication3", application3);
 
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
@@ -70,9 +74,10 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
 
         // then
         assertThat(config.getApplicationTypeSchemas()).isEmpty();
-        assertThat(config.getApplications()).hasSize(1).satisfies(applications -> {
+        assertThat(config.getApplications()).hasSize(2).satisfies(applications -> {
             assertThat(applications.get("testApplication1")).isNull();
             assertThat(applications.get("testApplication2")).isNotNull();
+            assertThat(applications.get("testApplication3")).isNotNull();
         });
     }
 
@@ -102,9 +107,13 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         CoreApplication application2 = new CoreApplication();
         application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
 
+        CoreApplication application3 = new CoreApplication();
+        application3.setEndpoint("https://endpoint");
+
         Map<String, CoreApplication> applicationsMap = new HashMap<>();
         applicationsMap.put("testApplication1", application1);
         applicationsMap.put("testApplication2", application2);
+        applicationsMap.put("testApplication3", application3);
 
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
@@ -118,9 +127,10 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
             String schema = applicationTypeSchemas.get("https://runner-char");
             assertThat(schema).isNotNull();
         });
-        assertThat(config.getApplications()).hasSize(2).satisfies(applications -> {
+        assertThat(config.getApplications()).hasSize(3).satisfies(applications -> {
             assertThat(applications.get("testApplication1")).isNotNull();
             assertThat(applications.get("testApplication2")).isNotNull();
+            assertThat(applications.get("testApplication3")).isNotNull();
         });
     }
 

--- a/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/normalizer/impl/ApplicationTypeSchemaCoreConfigNormalizerTest.java
@@ -35,7 +35,7 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
     @Test
     void testNormalize_applicationTypeSchemaDoesNotConformToMetaSchema_removeApplicationTypeSchemaAndAssociatedApplications() {
         // given
-        String applicationTypeSchema = """
+        String invalidApplicationTypeSchema = """
                 {
                     "properties": {},
                     "applications": [],
@@ -47,23 +47,49 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
                     "$defs": {}
                 }
                 """;
+        String validApplicationTypeSchema = """
+                {
+                    "properties": {},
+                    "applications": [],
+                    "createdAt": "2025-08-29T11:34:26.709Z",
+                    "updatedAt": "2025-08-29T11:34:26.709Z",
+                    "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                    "$id": "https://runner-char-new",
+                    "dial:applicationTypeDisplayName": "char1-new",
+                    "dial:applicationTypeCompletionEndpoint": "https://app_hostname/openai/deployments/app_name/chat/completions",
+                    "$defs": {}
+                }
+                """;
 
         Map<String, String> applicationTypeSchemasMap = new HashMap<>();
-        applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
+        applicationTypeSchemasMap.put("https://runner-char", invalidApplicationTypeSchema);
+        applicationTypeSchemasMap.put("https://runner-char-new", validApplicationTypeSchema);
 
         CoreApplication application1 = new CoreApplication();
         application1.setApplicationTypeSchemaId(URI.create("https://runner-char"));
 
         CoreApplication application2 = new CoreApplication();
-        application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+        application2.setApplicationTypeSchemaId(URI.create("https://runner-char"));
 
         CoreApplication application3 = new CoreApplication();
-        application3.setEndpoint("https://endpoint");
+        application3.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        CoreApplication application4 = new CoreApplication();
+        application4.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        CoreApplication application5 = new CoreApplication();
+        application5.setEndpoint("https://endpoint");
+
+        CoreApplication application6 = new CoreApplication();
+        application6.setEndpoint("https://endpoint-new");
 
         Map<String, CoreApplication> applicationsMap = new HashMap<>();
         applicationsMap.put("testApplication1", application1);
         applicationsMap.put("testApplication2", application2);
         applicationsMap.put("testApplication3", application3);
+        applicationsMap.put("testApplication4", application4);
+        applicationsMap.put("testApplication5", application5);
+        applicationsMap.put("testApplication6", application6);
 
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
@@ -73,18 +99,24 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         normalizer.normalize(config);
 
         // then
-        assertThat(config.getApplicationTypeSchemas()).isEmpty();
-        assertThat(config.getApplications()).hasSize(2).satisfies(applications -> {
+        assertThat(config.getApplicationTypeSchemas()).hasSize(1).satisfies(applicationTypeSchemas -> {
+            assertThat(applicationTypeSchemas.get("https://runner-char")).isNull();
+            assertThat(applicationTypeSchemas.get("https://runner-char-new")).isNotNull();
+        });
+        assertThat(config.getApplications()).hasSize(4).satisfies(applications -> {
             assertThat(applications.get("testApplication1")).isNull();
-            assertThat(applications.get("testApplication2")).isNotNull();
+            assertThat(applications.get("testApplication2")).isNull();
             assertThat(applications.get("testApplication3")).isNotNull();
+            assertThat(applications.get("testApplication4")).isNotNull();
+            assertThat(applications.get("testApplication5")).isNotNull();
+            assertThat(applications.get("testApplication6")).isNotNull();
         });
     }
 
     @Test
     void testNormalize_applicationTypeSchemaConformsToMetaSchema_doesNotRemoveApplicationTypeSchemaAndAssociatedApplications() {
         // given
-        String applicationTypeSchema = """
+        String validApplicationTypeSchema1 = """
                 {
                     "properties": {},
                     "applications": [],
@@ -97,23 +129,49 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
                     "$defs": {}
                 }
                 """;
+        String validApplicationTypeSchema2 = """
+                {
+                    "properties": {},
+                    "applications": [],
+                    "createdAt": "2025-08-29T11:34:26.709Z",
+                    "updatedAt": "2025-08-29T11:34:26.709Z",
+                    "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                    "$id": "https://runner-char-new",
+                    "dial:applicationTypeDisplayName": "char1-new",
+                    "dial:applicationTypeCompletionEndpoint": "https://app_hostname/openai/deployments/app_name/chat/completions",
+                    "$defs": {}
+                }
+                """;
 
         Map<String, String> applicationTypeSchemasMap = new HashMap<>();
-        applicationTypeSchemasMap.put("https://runner-char", applicationTypeSchema);
+        applicationTypeSchemasMap.put("https://runner-char", validApplicationTypeSchema1);
+        applicationTypeSchemasMap.put("https://runner-char-new", validApplicationTypeSchema2);
 
         CoreApplication application1 = new CoreApplication();
         application1.setApplicationTypeSchemaId(URI.create("https://runner-char"));
 
         CoreApplication application2 = new CoreApplication();
-        application2.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+        application2.setApplicationTypeSchemaId(URI.create("https://runner-char"));
 
         CoreApplication application3 = new CoreApplication();
-        application3.setEndpoint("https://endpoint");
+        application3.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        CoreApplication application4 = new CoreApplication();
+        application4.setApplicationTypeSchemaId(URI.create("https://runner-char-new"));
+
+        CoreApplication application5 = new CoreApplication();
+        application5.setEndpoint("https://endpoint");
+
+        CoreApplication application6 = new CoreApplication();
+        application6.setEndpoint("https://endpoint-new");
 
         Map<String, CoreApplication> applicationsMap = new HashMap<>();
         applicationsMap.put("testApplication1", application1);
         applicationsMap.put("testApplication2", application2);
         applicationsMap.put("testApplication3", application3);
+        applicationsMap.put("testApplication4", application4);
+        applicationsMap.put("testApplication5", application5);
+        applicationsMap.put("testApplication6", application6);
 
         Config config = new Config();
         config.setApplicationTypeSchemas(applicationTypeSchemasMap);
@@ -123,14 +181,17 @@ class ApplicationTypeSchemaCoreConfigNormalizerTest {
         normalizer.normalize(config);
 
         // then
-        assertThat(config.getApplicationTypeSchemas()).hasSize(1).satisfies(applicationTypeSchemas -> {
-            String schema = applicationTypeSchemas.get("https://runner-char");
-            assertThat(schema).isNotNull();
+        assertThat(config.getApplicationTypeSchemas()).hasSize(2).satisfies(applicationTypeSchemas -> {
+            assertThat(applicationTypeSchemas.get("https://runner-char")).isNotNull();
+            assertThat(applicationTypeSchemas.get("https://runner-char-new")).isNotNull();
         });
-        assertThat(config.getApplications()).hasSize(3).satisfies(applications -> {
+        assertThat(config.getApplications()).hasSize(6).satisfies(applications -> {
             assertThat(applications.get("testApplication1")).isNotNull();
             assertThat(applications.get("testApplication2")).isNotNull();
             assertThat(applications.get("testApplication3")).isNotNull();
+            assertThat(applications.get("testApplication4")).isNotNull();
+            assertThat(applications.get("testApplication5")).isNotNull();
+            assertThat(applications.get("testApplication6")).isNotNull();
         });
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #214 

### Description of changes
Remove application type schema that doesn't conform to meta schema and associated applications from exported core config

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.