### PR TITLE
fix: allow absent/null 'order' in Route

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/model/route/BaseRoute.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/route/BaseRoute.java
@@ -31,5 +31,5 @@ public abstract class BaseRoute extends RoleBased {
     private int maxRetryAttempts;
     private Long createdAt;
     private Long updatedAt;
-    private int order;
+    private int order = Integer.MAX_VALUE;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
@@ -39,5 +39,5 @@ public abstract class BaseRouteDto extends RoleBasedDto {
     @EqualsAndHashCode.Exclude
     private Instant updatedAt;
     @Min(value = 0, message = "Order can't be negative")
-    private int order = Integer.MAX_VALUE;
+    private Integer order;
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
@@ -63,6 +63,7 @@ public abstract class RouteHistoryFunctionalTest {
         expected.setDefaultRoleLimit(new LimitDto());
         expected.setDefaultRoleShareResourceLimit(new ShareResourceLimitDto());
         expected.setUpstreams(List.of());
+        expected.setOrder(Integer.MAX_VALUE);
         assertRoute(actual, expected);
 
         // 3 add roles to route1
@@ -71,6 +72,7 @@ public abstract class RouteHistoryFunctionalTest {
         updatedRoute.setRoleLimits(Map.of("role2", new LimitDto(), "role3", new LimitDto()));
         updatedRoute.setRoleShareResourceLimits(Map.of("role2", new ShareResourceLimitDto(), "role3", new ShareResourceLimitDto()));
         updatedRoute.setUpstreams(List.of());
+        updatedRoute.setOrder(Integer.MAX_VALUE);
         routeFacade.updateRoute(routeDto.getName(), updatedRoute);
         actual = routeFacade.getRoute(routeDto.getName());
         assertRoute(actual, updatedRoute);


### PR DESCRIPTION
### Description of changes

Allowed absent/null 'order' in Route. In this case, 'order' will default to Integer.MAX_VALUE (2_147_483_647).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.