### PR TITLE
chore: Set scheduling tasks pool size to 8

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/logger/ConfigUpdaterLoggerLevel.java
+++ b/src/main/java/com/epam/aidial/cfg/logger/ConfigUpdaterLoggerLevel.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.Map;
@@ -14,7 +13,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class ConfigUpdaterLoggerLevel {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -182,4 +182,4 @@ validation.applicationTypeSchema.id=${APPLICATION_TYPE_SCHEMA_ID_VALIDATION_PATT
 validation.toolSet.name=${TOOLSET_NAME_VALIDATION_PATTERN:}
 
 # Scheduling
-spring.task.scheduling.pool.size=2
+spring.task.scheduling.pool.size=8

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -180,3 +180,6 @@ validation.model.name=${MODEL_NAME_VALIDATION_PATTERN:}
 validation.route.name=${ROUTE_NAME_VALIDATION_PATTERN:}
 validation.applicationTypeSchema.id=${APPLICATION_TYPE_SCHEMA_ID_VALIDATION_PATTERN:}
 validation.toolSet.name=${TOOLSET_NAME_VALIDATION_PATTERN:}
+
+# Scheduling
+spring.task.scheduling.pool.size=2


### PR DESCRIPTION
### Applicable issues

### Description of changes
Set scheduling tasks pool size to 8, so that scheduled export and log updater do not conflict with each other for single scheduling thread

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.