### PR TITLE
fix: decode value when reading from kubernetes secret

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
@@ -104,7 +104,8 @@ public class K8ConfigService {
         log.debug("readSecretEntry. secret: {} by namespace '{}', resourceName '{}'", secret, namespace, secretName);
         Optional<String> entry = Optional.ofNullable(secret)
                 .map(Secret::getData)
-                .map(stringStringMap -> stringStringMap.get(secretKey));
+                .map(stringStringMap -> stringStringMap.get(secretKey))
+                .map(data -> new String(Base64.getDecoder().decode(data)));
         log.trace("readSecretEntry. secret: {} by configName '{}'", SecretUtils.mask(entry.orElse(null)), secretKey);
         return entry;
     }

--- a/src/test/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigServiceTest.java
@@ -1,0 +1,63 @@
+package com.epam.aidial.cfg.service.impl.storage;
+
+import com.epam.aidial.cfg.configuration.K8sProperties;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class K8ConfigServiceTest {
+
+    private static final String NAMESPACE = "namespace";
+
+    private K8ConfigService k8ConfigService;
+
+    @BeforeEach
+    void setUp() {
+        K8sProperties k8sProperties = new K8sProperties();
+        k8sProperties.setNamespace(NAMESPACE);
+
+        k8ConfigService = new K8ConfigService(k8sProperties);
+    }
+
+    @Test
+    void readSecretEntry_shouldReturnDecodedSecretValue() {
+        // given
+        String secretName = "secretName";
+        String secretKey = "secretKey";
+
+        String expectedResult = "Kubernetes secret value";
+
+        Secret secret = new Secret();
+        secret.setData(Map.of(secretKey, "S3ViZXJuZXRlcyBzZWNyZXQgdmFsdWU="));
+
+        KubernetesClient kubernetesClient = mock(KubernetesClient.class);
+        MixedOperation<Secret, SecretList, Resource<Secret>> mixedOperation = mock(MixedOperation.class);
+        NonNamespaceOperation<Secret, SecretList, Resource<Secret>> nonNamespaceOperation = mock(NonNamespaceOperation.class);
+        Resource<Secret> resource = mock(Resource.class);
+
+        when(kubernetesClient.secrets()).thenReturn(mixedOperation);
+        when(mixedOperation.inNamespace(NAMESPACE)).thenReturn(nonNamespaceOperation);
+        when(nonNamespaceOperation.withName(secretName)).thenReturn(resource);
+        when(resource.get()).thenReturn(secret);
+
+        // when
+        Optional<String> actualResult = k8ConfigService.readSecretEntry(kubernetesClient, secretName, secretKey);
+
+        // then
+        Assertions.assertThat(actualResult).isPresent();
+        Assertions.assertThat(actualResult.get()).isEqualTo(expectedResult);
+
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #162

### Description of changes
Added value decoding when reading from kubernetes secret

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.