### PR TITLE
fix: fix core roles merger when config parts are null

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
@@ -4,11 +4,13 @@ import com.epam.aidial.cfg.domain.mapper.RoleCoreMapper;
 import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.domain.service.RoleService;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.core.config.Assistants;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreLimit;
 import com.epam.aidial.core.config.CoreRole;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +19,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,7 +33,7 @@ public class CoreRolesMerger {
     private final RoleCoreMapper roleCoreMapper;
 
     public Map<String, Role> mergeCoreRoles(Config config, boolean createRoleIfAbsent) {
-        Map<String, CoreRole> roles = config.getRoles();
+        Map<String, CoreRole> roles = MapUtils.emptyIfNull(config.getRoles());
         Map<String, Set<String>> deploymentNamesByUserRole = getDeploymentNamesByUserRole(config);
 
         Set<String> allRoleNames = new LinkedHashSet<>(roles.keySet());
@@ -55,8 +59,9 @@ public class CoreRolesMerger {
                         config.getApplications(),
                         config.getRoutes(),
                         config.getToolsets(),
-                        config.getAssistant().getAssistants()
+                        Optional.ofNullable(config.getAssistant()).map(Assistants::getAssistants).orElse(null)
                 )
+                .filter(Objects::nonNull)
                 .flatMap(m -> m.entrySet().stream())
                 .filter(deploymentByName -> CollectionUtils.isNotEmpty(deploymentByName.getValue().getUserRoles()))
                 .flatMap(deploymentByName -> deploymentByName.getValue().getUserRoles().stream()

--- a/src/test/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMergerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMergerTest.java
@@ -67,4 +67,23 @@ class CoreRolesMergerTest {
         Assertions.assertThat(actualResult).isEqualTo(expectedResult);
         verifyNoInteractions(roleService);
     }
+
+    @Test
+    void mergeCoreRoles_singleModelWithoutUserRolesAndRoles_shouldReturnEmptyRoles() throws JsonProcessingException {
+        // given
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Config config = objectMapper.readValue(
+                ResourceUtils.readResource("/import/core_roles_merge/single_model_without_user_roles_and_roles/config.json"),
+                Config.class
+        );
+        Map<String, Role> expectedResult = Map.of();
+
+        // when
+        Map<String, Role> actualResult = coreRolesMerger.mergeCoreRoles(config, true);
+
+        // then
+        Assertions.assertThat(actualResult).isEqualTo(expectedResult);
+        verifyNoInteractions(roleService);
+    }
 }

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
@@ -1,4 +1,6 @@
 {
+  "addons": null,
+  "assistant": null,
   "models": {
     "testModel1": {
       "userRoles": [

--- a/src/test/resources/import/core_roles_merge/single_model_without_user_roles_and_roles/config.json
+++ b/src/test/resources/import/core_roles_merge/single_model_without_user_roles_and_roles/config.json
@@ -1,0 +1,6 @@
+{
+  "models": {
+    "testModel1": {}
+  },
+  "roles": null
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #162 

### Description of changes
Added `null` handling for missing config parts when merging core roles

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.