### PR TITLE
fix: serialize share resource limits as strings

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/LimitDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/LimitDto.java
@@ -16,7 +16,6 @@ public class LimitDto {
     @PositiveOrZero
     @JsonSerialize(using = ToStringSerializer.class)
     private Long minute;
-
     @PositiveOrZero
     @JsonSerialize(using = ToStringSerializer.class)
     private Long day;

--- a/src/main/java/com/epam/aidial/cfg/dto/ShareResourceLimitDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ShareResourceLimitDto.java
@@ -1,12 +1,16 @@
 package com.epam.aidial.cfg.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 
 @Data
 public class ShareResourceLimitDto {
     @PositiveOrZero
+    @JsonSerialize(using = ToStringSerializer.class)
     private Integer maxAcceptedUsers;
     @PositiveOrZero
+    @JsonSerialize(using = ToStringSerializer.class)
     private Long invitationTtl = 259200L; // seconds in 72 hours
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #218 

### Description of changes
Added to string serialization of share resource limits. Added due to issues with rounding of Long.MAX value number in js
<img width="295" height="142" alt="image" src="https://github.com/user-attachments/assets/e42894ab-2ab6-4f2c-bff1-dda19e709483" />


<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.