### PR TITLE
hotfix: populate adapter_completion_endpoint

### DIFF
--- a/src/main/resources/db/migration/H2/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
+++ b/src/main/resources/db/migration/H2/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
@@ -1,0 +1,21 @@
+-- Update model_entity
+UPDATE model_entity
+SET adapter_completion_endpoint_path =
+    COALESCE(endpoint_deployment_name, '') ||
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;
+
+-- Update model_entity_aud
+UPDATE model_entity_aud
+SET adapter_completion_endpoint_path =
+    COALESCE(endpoint_deployment_name, '') ||
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
@@ -1,0 +1,21 @@
+-- Update model_entity
+UPDATE model_entity
+SET adapter_completion_endpoint_path =
+    ISNULL(endpoint_deployment_name, '') +
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;
+
+-- Update model_entity_aud
+UPDATE model_entity_aud
+SET adapter_completion_endpoint_path =
+    ISNULL(endpoint_deployment_name, '') +
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;

--- a/src/main/resources/db/migration/POSTGRES/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
@@ -1,0 +1,19 @@
+-- Update model_entity
+UPDATE model_entity
+SET adapter_completion_endpoint_path =
+    COALESCE(endpoint_deployment_name, '') ||
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL;
+
+-- Update model_entity_aud
+UPDATE model_entity_aud
+SET adapter_completion_endpoint_path =
+    COALESCE(endpoint_deployment_name, '') ||
+    CASE
+        WHEN type = 0 THEN '/chat/completions'
+        ELSE '/embeddings'
+    END
+WHERE adapter_name IS NOT NULL;

--- a/src/main/resources/db/migration/POSTGRES/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.60__PopulateAdapterCompletionEndpointPathInModelEntity.sql
@@ -6,7 +6,8 @@ SET adapter_completion_endpoint_path =
         WHEN type = 0 THEN '/chat/completions'
         ELSE '/embeddings'
     END
-WHERE adapter_name IS NOT NULL;
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;
 
 -- Update model_entity_aud
 UPDATE model_entity_aud
@@ -16,4 +17,5 @@ SET adapter_completion_endpoint_path =
         WHEN type = 0 THEN '/chat/completions'
         ELSE '/embeddings'
     END
-WHERE adapter_name IS NOT NULL;
+WHERE adapter_name IS NOT NULL
+  AND adapter_completion_endpoint_path IS NULL;


### PR DESCRIPTION
### Applicable issues

- fixes broken models

### Description of changes

Added migration 1.60 that populates adapter_completion_endpoint_path using data from endpoint_deployment_name.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.