### PR TITLE
hotfix: set `parallelToolCallsSupported` to `true` if missing during core config import + minor refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,9 @@ dependencies {
         implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.netty:netty-codec:4.2.4.Final') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,12 @@ dependencies {
         implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.netty:netty-codec-http:4.2.5.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('org.springframework:spring-webmvc:6.2.10') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
         implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec:4.2.4.Final') {
+        implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/ApplicationEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/ApplicationEntityMapper.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", uses = {
-        DeploymentEntityMapper.class, MapPropertiesMapper.class, DependentRouteEntityMapper.class
+        DeploymentEntityMapper.class, MapPropertiesMapper.class, DependentRouteEntityMapper.class, FeaturesEntityMapper.class
 })
 public abstract class ApplicationEntityMapper {
 

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/AssistantsPropertyEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/AssistantsPropertyEntityMapper.java
@@ -6,7 +6,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {FeaturesEntityMapper.class})
 public abstract class AssistantsPropertyEntityMapper {
 
     public abstract AssistantsProperty toDomain(AssistantsPropertyEntity entity);

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/FeaturesEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/FeaturesEntityMapper.java
@@ -1,0 +1,13 @@
+package com.epam.aidial.cfg.dao.mapper;
+
+import com.epam.aidial.cfg.dao.model.FeaturesEntity;
+import com.epam.aidial.cfg.domain.model.Features;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface FeaturesEntityMapper {
+
+    Features toDomain(FeaturesEntity featuresEntity);
+
+    FeaturesEntity toEntity(Features features);
+}

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/ModelEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/ModelEntityMapper.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", uses = {DeploymentEntityMapper.class, MapPropertiesMapper.class,
-        UpstreamEntityMapper.class, PropertiesEntityMapper.class, AdapterEntityMapper.class})
+        UpstreamEntityMapper.class, PropertiesEntityMapper.class, AdapterEntityMapper.class, FeaturesEntityMapper.class})
 public abstract class ModelEntityMapper {
 
     @Autowired

--- a/src/main/java/com/epam/aidial/cfg/dao/model/FeaturesEntity.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/model/FeaturesEntity.java
@@ -42,5 +42,5 @@ public class FeaturesEntity {
     private Boolean cacheSupported;
     private Boolean autoCachingSupported;
     private Boolean consentRequired;
-    private Boolean parallelToolCallsSupported = true;
+    private boolean parallelToolCallsSupported = true;
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/FeatureCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/FeatureCoreMapper.java
@@ -11,4 +11,6 @@ public interface FeatureCoreMapper {
 
     @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
     Features toDomain(CoreFeatures features);
+
+    CoreFeatures toCore(Features features);
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Features.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Features.java
@@ -40,5 +40,5 @@ public class Features {
     private Boolean cacheSupported;
     private Boolean autoCachingSupported;
     private Boolean consentRequired;
-    private Boolean parallelToolCallsSupported = true;
+    private boolean parallelToolCallsSupported = true;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/FeaturesDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/FeaturesDto.java
@@ -42,5 +42,5 @@ public class FeaturesDto {
     private Boolean cacheSupported;
     private Boolean autoCachingSupported;
     private Boolean consentRequired;
-    private Boolean parallelToolCallsSupported = true;
+    private boolean parallelToolCallsSupported = true;
 }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/FileController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/FileController.java
@@ -75,7 +75,7 @@ public class FileController {
     }
 
     @PostMapping(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ImportResourcesFileResultDto uploadFiles(@RequestPart("files") @Valid @Size(max = 30, min = 1) List<MultipartFile> files,
+    public ImportResourcesFileResultDto uploadFiles(@RequestPart("files") @Valid @Size(min = 1, max = 30) List<MultipartFile> files,
                                                     @RequestPart("config") @Validated ImportResourcesDto importFilesDto) {
         var importFiles = resourceMapper.toImportResources(importFilesDto);
         var importResults = fileService.uploadFile(files, importFiles);

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ApplicationDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ApplicationDtoMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = {
-        LimitDtoMapper.class, RoleBasedDtoMapper.class, InstantMapper.class, FeaturesMapper.class, RouteDtoMapper.class, ShareResourceLimitDtoMapper.class
+        LimitDtoMapper.class, RoleBasedDtoMapper.class, InstantMapper.class, FeaturesDtoMapper.class, RouteDtoMapper.class, ShareResourceLimitDtoMapper.class
 })
 public interface ApplicationDtoMapper {
 

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/AssistantsPropertyDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/AssistantsPropertyDtoMapper.java
@@ -4,7 +4,7 @@ import com.epam.aidial.cfg.domain.model.AssistantsProperty;
 import com.epam.aidial.cfg.dto.AssistantsPropertyDto;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", uses = FeaturesMapper.class)
+@Mapper(componentModel = "spring", uses = FeaturesDtoMapper.class)
 public interface AssistantsPropertyDtoMapper {
 
     AssistantsProperty toDomain(AssistantsPropertyDto entity);

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/FeaturesDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/FeaturesDtoMapper.java
@@ -5,7 +5,7 @@ import com.epam.aidial.cfg.dto.FeaturesDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
-public interface FeaturesMapper {
+public interface FeaturesDtoMapper {
 
     Features toDomain(FeaturesDto featuresDto);
 

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ModelDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ModelDtoMapper.java
@@ -11,7 +11,7 @@ import org.mapstruct.Named;
         componentModel = "spring",
         uses = {
                 LimitDtoMapper.class, UpstreamDtoMapper.class, RoleBasedDtoMapper.class,
-                ModelEndpointDtoMapper.class, InstantMapper.class, FeaturesMapper.class,
+                ModelEndpointDtoMapper.class, InstantMapper.class, FeaturesDtoMapper.class,
                 ShareResourceLimitDtoMapper.class
         }
 )

--- a/src/main/resources/db/migration/H2/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
+++ b/src/main/resources/db/migration/H2/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
@@ -1,0 +1,8 @@
+update model_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update model_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;
+
+update application_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update application_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;
+
+update assistants_property_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update assistants_property_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
@@ -1,0 +1,8 @@
+update model_entity set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null;
+update model_entity_aud set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null and revtype != 2;
+
+update application_entity set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null;
+update application_entity_aud set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null and revtype != 2;
+
+update assistants_property_entity set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null;
+update assistants_property_entity_aud set parallel_tool_calls_supported = 1 where parallel_tool_calls_supported is null and revtype != 2;

--- a/src/main/resources/db/migration/POSTGRES/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.58__UpdateParallelToolCallsSupportedToTrueIfNull.sql
@@ -1,0 +1,8 @@
+update model_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update model_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;
+
+update application_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update application_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;
+
+update assistants_property_entity set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null;
+update assistants_property_entity_aud set parallel_tool_calls_supported = true where parallel_tool_calls_supported is null and revtype != 2;

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -26,7 +26,7 @@ import com.epam.aidial.cfg.web.facade.mapper.ApplicationDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.ApplicationTypeSchemaDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.AssistantDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.AttachmentPathDtoMapperImpl;
-import com.epam.aidial.cfg.web.facade.mapper.FeaturesMapperImpl;
+import com.epam.aidial.cfg.web.facade.mapper.FeaturesDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.ImportConfigMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.InstantMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.InterceptorDtoMapperImpl;
@@ -79,7 +79,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         AddonDtoMapperImpl.class, AssistantDtoMapperImpl.class, RouteDtoMapperImpl.class, RoleLimitDtoMapperImpl.class,
         LimitDtoMapperImpl.class, UpstreamDtoMapperImpl.class, RoleBasedDtoMapperImpl.class, ResponseDtoMapperImpl.class,
         ModelEndpointDtoMapperImpl.class, AdapterDtoMapperImpl.class, ModelEndpointUtils.class, ShareResourceLimitDtoMapperImpl.class,
-        RoleShareResourceLimitDtoMapperImpl.class, InterceptorSourceDtoMapperImpl.class, InstantMapperImpl.class, FeaturesMapperImpl.class,
+        RoleShareResourceLimitDtoMapperImpl.class, InterceptorSourceDtoMapperImpl.class, InstantMapperImpl.class, FeaturesDtoMapperImpl.class,
         AttachmentPathDtoMapperImpl.class, ToolSetDtoMapperImpl.class
 })
 class ConfigControllerTest extends AbstractControllerNoneSecureTest {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #219 

### Description of changes
1. set `parallelToolCallsSupported` to true if missing during core config import
2. refactored mappers
3. set `parallelToolCallsSupported` column value to `true` if `null` in database
4. increased io.netty:netty-codec transitive dependency version from 4.1.122.Final to 4.2.4.Final
5. increased io.netty:netty-codec transitive dependency version from 4.2.4.Final to 4.2.5.Final
6. increased io.netty:netty-codec-http transitive dependency version from 4.2.4.Final to 4.2.5.Final
7. increased org.springframework:spring-webmvc transitive dependency version from 6.2.8 to 6.2.10

Original PRs:
- #221
- #222
- #251 
- #252 
- #253 

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.