### PR TITLE
chore: increase io.netty:netty-codec transitive dependency version from 4.2.4.Final to 4.2.5.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ dependencies {
         implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec:4.2.4.Final') {
+        implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Increased io.netty:netty-codec transitive dependency version from 4.2.4.Final to 4.2.5.Final

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.