### PR TITLE
chore: increase io.netty:netty-codec-http transitive dependency version from 4.2.4.Final to 4.2.5.Final, increase org.springframework:spring-webmvc transitive dependency version from 6.2.8 to 6.2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,12 @@ dependencies {
         implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.netty:netty-codec-http:4.2.5.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('org.springframework:spring-webmvc:6.2.10') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
- increased io.netty:netty-codec-http transitive dependency version from 4.2.4.Final to 4.2.5.Final
- increased org.springframework:spring-webmvc transitive dependency version from 6.2.8 to 6.2.10

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.