### PR TITLE
hotfix: change maxRetryAttempts type from int to Integer to allow nulls (Route)

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/model/route/BaseRoute.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/route/BaseRoute.java
@@ -28,7 +28,7 @@ public abstract class BaseRoute extends RoleBased {
     private Set<@HttpMethod String> methods;
     @Valid
     private List<Upstream> upstreams;
-    private int maxRetryAttempts;
+    private Integer maxRetryAttempts;
     private Long createdAt;
     private Long updatedAt;
     private int order = Integer.MAX_VALUE;

--- a/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
@@ -35,7 +35,7 @@ public abstract class BaseRouteDto extends RoleBasedDto {
     @Valid
     private List<UpstreamDto> upstreams;
     @Positive(message = "Max retry attempts should be greater than 0")
-    private int maxRetryAttempts;
+    private Integer maxRetryAttempts;
     @EqualsAndHashCode.Exclude
     private Instant createdAt;
     @EqualsAndHashCode.Exclude

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/RouteHistoryFunctionalTest.java
@@ -64,6 +64,7 @@ public abstract class RouteHistoryFunctionalTest {
         expected.setDefaultRoleShareResourceLimit(new ShareResourceLimitDto());
         expected.setUpstreams(List.of());
         expected.setOrder(Integer.MAX_VALUE);
+        expected.setMaxRetryAttempts(1);
         assertRoute(actual, expected);
 
         // 3 add roles to route1
@@ -73,6 +74,7 @@ public abstract class RouteHistoryFunctionalTest {
         updatedRoute.setRoleShareResourceLimits(Map.of("role2", new ShareResourceLimitDto(), "role3", new ShareResourceLimitDto()));
         updatedRoute.setUpstreams(List.of());
         updatedRoute.setOrder(Integer.MAX_VALUE);
+        updatedRoute.setMaxRetryAttempts(1);
         routeFacade.updateRoute(routeDto.getName(), updatedRoute);
         actual = routeFacade.getRoute(routeDto.getName());
         assertRoute(actual, updatedRoute);


### PR DESCRIPTION
### Applicable issues

- related to #243 

### Description of changes

In BaseRouteDto, change the type of 'maxRetryAttempts' from int to Integer to allow NULLs & match other DTOs.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.