### PR TITLE
chore: increase org.springframework.security:spring-security-core transitive dependency version from 6.5.1 to 6.5.4, increase org.springframework:spring-core transitive dependency version from 6.2.10 to 6.2.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,12 @@ dependencies {
         implementation ('org.springframework:spring-webmvc:6.2.10') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('org.springframework.security:spring-security-core:6.5.4') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('org.springframework:spring-core:6.2.11') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
- increased org.springframework.security:spring-security-core transitive dependency version from 6.5.1 to 6.5.4
- increased org.springframework:spring-core transitive dependency version from 6.2.10 to 6.2.11

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.