### PR TITLE
feat!: Implement Detection and Prevention of Concurrent Overwrites(applications, interceptors, addons) 

### DIFF
--- a/docs/sample/http-requests/AdminPanel.http
+++ b/docs/sample/http-requests/AdminPanel.http
@@ -85,8 +85,19 @@ Authorization: Basic {{user}} {{password}}
 #@no-log
 @appName = echo
 GET http://localhost:8080/api/v1/applications/{{appName}}
+If-None-Match: {{etag}}
 Authorization: Basic {{user}} {{password}}
 #Authorization: Bearer {{$auth.token("keycloak")}}
+
+###
+
+# @name Update Application
+#@no-log
+@appName = echo
+PUT http://localhost:8080/api/v1/applications/{{appName}}
+If-Match: {{etag}}
+Authorization: Basic {{user}} {{password}}
+Content-Type: application/json
 
 ###
 
@@ -111,8 +122,19 @@ Authorization: Basic {{user}} {{password}}
 #@no-log
 @interceptorName = logging-interceptor
 GET http://localhost:8080/api/v1/interceptors/{{interceptorName}}
+If-None-Match: {{etag}}
 Authorization: Basic {{user}} {{password}}
 #Authorization: Bearer {{$auth.token("keycloak")}}
+
+###
+
+# @name Update Interceptor
+#@no-log
+@interceptorName = logging-interceptor
+PUT http://localhost:8080/api//interceptors/{{interceptorName}}
+If-Match: {{etag}}
+Authorization: Basic {{user}} {{password}}
+Content-Type: application/json
 
 ###
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
@@ -83,11 +83,11 @@ public class AddonService {
     @Transactional
     public String updateAddon(String addonName, Addon addon, String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException(
-                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+            throw new IllegalArgumentException(String.format(
+                    "Hash must not be null. Use \"*\" to skip optimistic check. Addon:%s.", addonName));
         }
-        var savedModel = performUpdate(addonName, addon, hash);
-        return calculator.calculateHash(mapper.toDomain(savedModel));
+        var savedAddon = performUpdate(addonName, addon, hash);
+        return calculator.calculateHash(mapper.toDomain(savedAddon));
     }
 
     private AddonEntity performUpdate(String addonName, Addon addon, String hash) {
@@ -132,8 +132,8 @@ public class AddonService {
         if (!expectedHash.equals(currentHash)) {
             log.debug("Optimistic lock conflict on update: addonName={}, expectedHash={}, currentHash={}",
                     entity.getDeploymentName(), expectedHash, currentHash);
-            throw new OptimisticLockConflictException("Optimistic lock conflict on update: addonName:'"
-                    + entity.getDeploymentName() + "'. Reload the data.");
+            throw new OptimisticLockConflictException(String.format("Optimistic lock conflict on update: addonName:'"
+                    + "%s'. Reload the data.", entity.getDeploymentName()));
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
@@ -4,10 +4,14 @@ import com.epam.aidial.cfg.dao.jpa.AddonJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AddonEntityMapper;
 import com.epam.aidial.cfg.dao.model.AddonEntity;
 import com.epam.aidial.cfg.domain.model.Addon;
+import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.validator.AddonValidator;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
+import com.epam.aidial.cfg.service.hashing.HashCalculator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,8 +20,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.epam.aidial.cfg.service.hashing.HashCalculator.ANY_HASH;
+
 @Service("coreAddonService")
 @RequiredArgsConstructor
+@Slf4j
 public class AddonService {
 
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Addon with name %s does not exist";
@@ -27,6 +34,7 @@ public class AddonService {
     private final DeploymentService deploymentService;
     private final AddonValidator addonValidator;
     private final HistoryService historyService;
+    private final HashCalculator calculator;
 
     @Transactional(readOnly = true)
     public Collection<Addon> getAllAddons() {
@@ -39,6 +47,12 @@ public class AddonService {
     public Addon getAddon(String addonName) {
         return tryGetAddon(addonName)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(addonName)));
+    }
+
+    @Transactional(readOnly = true)
+    public DomainObjectWithHash<Addon> getAddonWithHash(String addonName) {
+        var addon = getAddon(addonName);
+        return new DomainObjectWithHash<>(addon, calculator.calculateHash(addon));
     }
 
     @Transactional(readOnly = true)
@@ -62,13 +76,26 @@ public class AddonService {
     @FeatureFlagGate(featureFlag = "addonsSupported")
     @Transactional
     public void updateAddon(String addonName, Addon addon) {
+        performUpdate(addonName, addon, ANY_HASH);
+    }
+
+    @FeatureFlagGate(featureFlag = "addonsSupported")
+    @Transactional
+    public String updateAddon(String addonName, Addon addon, String hash) {
+        if (hash == null) {
+            throw new IllegalArgumentException(
+                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+        }
+        var savedModel = performUpdate(addonName, addon, hash);
+        return calculator.calculateHash(mapper.toDomain(savedModel));
+    }
+
+    private AddonEntity performUpdate(String addonName, Addon addon, String hash) {
         addonValidator.validateUpdate(addonName, addon);
-        AddonEntity addonEntity = addonJpaRepository.findById(addonName)
+        var addonEntity = addonJpaRepository.findById(addonName)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(addonName)));
-        Optional.of(addon)
-                .map(domainAddon -> mapper.toEntity(domainAddon, addonEntity))
-                .map(addonJpaRepository::save)
-                .orElseThrow(() -> new RuntimeException("Unable to update addon " + addon.getDeployment().getName()));
+        assertNotConcurrencyOverwrite(addonEntity, hash);
+        return addonJpaRepository.save(mapper.toEntity(addon, addonEntity));
     }
 
     @FeatureFlagGate(featureFlag = "addonsSupported")
@@ -95,6 +122,19 @@ public class AddonService {
                 .stream()
                 .map(mapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    private void assertNotConcurrencyOverwrite(AddonEntity entity, String expectedHash) {
+        if (ANY_HASH.equals(expectedHash)) {
+            return;
+        }
+        var currentHash = calculator.calculateHash(mapper.toDomain(entity));
+        if (!expectedHash.equals(currentHash)) {
+            log.debug("Optimistic lock conflict on update: addonName={}, expectedHash={}, currentHash={}",
+                    entity.getDeploymentName(), expectedHash, currentHash);
+            throw new OptimisticLockConflictException("Optimistic lock conflict on update: addonName:'"
+                    + entity.getDeploymentName() + "'. Reload the data.");
+        }
     }
 
     private void assertExists(String addonName) {

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
@@ -87,11 +87,11 @@ public class ApplicationService {
     @Transactional
     public String updateApplication(String applicationName, Application application, String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException(
-                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+            throw new IllegalArgumentException(String.format(
+                    "Hash must not be null. Use \"*\" to skip optimistic check. Application:%s.", applicationName));
         }
-        var savedModel = performUpdate(applicationName, application, hash);
-        return calculator.calculateHash(mapper.toDomain(savedModel));
+        var savedApplication = performUpdate(applicationName, application, hash);
+        return calculator.calculateHash(mapper.toDomain(savedApplication));
     }
 
     private ApplicationEntity performUpdate(String applicationName, Application application, String hash) {
@@ -132,8 +132,8 @@ public class ApplicationService {
         if (!expectedHash.equals(currentHash)) {
             log.debug("Optimistic lock conflict on update: applicationName={}, expectedHash={}, currentHash={}",
                     entity.getDeploymentName(), expectedHash, currentHash);
-            throw new OptimisticLockConflictException("Optimistic lock conflict on update: applicationName:'"
-                    + entity.getDeploymentName() + "'. Reload the data.");
+            throw new OptimisticLockConflictException(String.format("Optimistic lock conflict on update: applicationName:'"
+                    + "%s'. Reload the data.", entity.getDeploymentName()));
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
@@ -5,11 +5,15 @@ import com.epam.aidial.cfg.dao.jpa.ApplicationJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.ApplicationEntityMapper;
 import com.epam.aidial.cfg.dao.model.ApplicationEntity;
 import com.epam.aidial.cfg.domain.model.Application;
+import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.normalizer.ApplicationNormalizer;
 import com.epam.aidial.cfg.domain.validator.ApplicationValidator;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
+import com.epam.aidial.cfg.service.hashing.HashCalculator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +23,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.epam.aidial.cfg.service.hashing.HashCalculator.ANY_HASH;
+
 @Service("coreApplicationService")
 @RequiredArgsConstructor
+@Slf4j
 public class ApplicationService {
 
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Application with name %s does not exist";
@@ -31,6 +38,7 @@ public class ApplicationService {
     private final ApplicationNormalizer applicationNormalizer;
     private final ApplicationValidator applicationValidator;
     private final HistoryService historyService;
+    private final HashCalculator calculator;
 
     @Transactional(readOnly = true)
     public Collection<Application> getAllApplications() {
@@ -44,6 +52,13 @@ public class ApplicationService {
         return tryGetApplication(applicationName)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(applicationName)));
     }
+
+    @Transactional(readOnly = true)
+    public DomainObjectWithHash<Application> getApplicationWithHash(String applicationName) {
+        var application = getApplication(applicationName);
+        return new DomainObjectWithHash<>(application, calculator.calculateHash(application));
+    }
+
 
     @Transactional(readOnly = true)
     public Optional<Application> tryGetApplication(String applicationName) {
@@ -65,16 +80,29 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void updateApplication(String applicationName, Application value) {
-        applicationNormalizer.normalize(value);
-        applicationValidator.validateUpdate(applicationName, value);
-        ApplicationEntity applicationEntity = applicationJpaRepository.findById(applicationName)
+    public void updateApplication(String applicationName, Application application) {
+        performUpdate(applicationName, application, ANY_HASH);
+    }
+
+    @Transactional
+    public String updateApplication(String applicationName, Application application, String hash) {
+        if (hash == null) {
+            throw new IllegalArgumentException(
+                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+        }
+        var savedModel = performUpdate(applicationName, application, hash);
+        return calculator.calculateHash(mapper.toDomain(savedModel));
+    }
+
+    private ApplicationEntity performUpdate(String applicationName, Application application, String hash) {
+        applicationNormalizer.normalize(application);
+        applicationValidator.validateUpdate(applicationName, application);
+        var applicationEntity = applicationJpaRepository.findById(applicationName)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(applicationName)));
-        assertNewApplicationDisplayNameAndDisplayVersion(applicationEntity, value);
-        Optional.of(value)
-                .map(domainModel -> mapper.toEntity(domainModel, applicationEntity))
-                .map(applicationJpaRepository::save)
-                .orElseThrow(() -> new RuntimeException("Unable to update application " + value.getDeployment().getName()));
+
+        assertNewApplicationDisplayNameAndDisplayVersion(applicationEntity, application);
+        assertNotConcurrencyOverwrite(applicationEntity, hash);
+        return applicationJpaRepository.save(mapper.toEntity(application, applicationEntity));
     }
 
     @Transactional
@@ -95,6 +123,20 @@ public class ApplicationService {
                 .map(mapper::toDomain)
                 .collect(Collectors.toList());
     }
+
+    private void assertNotConcurrencyOverwrite(ApplicationEntity entity, String expectedHash) {
+        if (ANY_HASH.equals(expectedHash)) {
+            return;
+        }
+        var currentHash = calculator.calculateHash(mapper.toDomain(entity));
+        if (!expectedHash.equals(currentHash)) {
+            log.debug("Optimistic lock conflict on update: applicationName={}, expectedHash={}, currentHash={}",
+                    entity.getDeploymentName(), expectedHash, currentHash);
+            throw new OptimisticLockConflictException("Optimistic lock conflict on update: applicationName:'"
+                    + entity.getDeploymentName() + "'. Reload the data.");
+        }
+    }
+
 
     private void assertExists(String name) {
         boolean exists = applicationJpaRepository.existsById(name);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
@@ -79,11 +79,11 @@ public class InterceptorService {
     @Transactional
     public String update(String interceptorName, Interceptor interceptor, String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException(
-                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+            throw new IllegalArgumentException(String.format(
+                    "Hash must not be null. Use \"*\" to skip optimistic check. Interceptor:%s.", interceptorName));
         }
-        var savedModel = performUpdate(interceptorName, interceptor, hash);
-        return calculator.calculateHash(mapper.toDomain(savedModel));
+        var savedInterceptor = performUpdate(interceptorName, interceptor, hash);
+        return calculator.calculateHash(mapper.toDomain(savedInterceptor));
     }
 
     private InterceptorEntity performUpdate(String interceptorName, Interceptor interceptor, String hash) {
@@ -125,10 +125,10 @@ public class InterceptorService {
         }
         var currentHash = calculator.calculateHash(mapper.toDomain(entity));
         if (!expectedHash.equals(currentHash)) {
-            log.debug("Optimistic lock conflict on update: interceptorId={}, expectedHash={}, currentHash={}",
-                    entity.getId(), expectedHash, currentHash);
-            throw new OptimisticLockConflictException("Optimistic lock conflict on update: interceptorId:'"
-                    + entity.getId() + "'. Reload the data.");
+            log.debug("Optimistic lock conflict on update: interceptorName={}, expectedHash={}, currentHash={}",
+                    entity.getName(), expectedHash, currentHash);
+            throw new OptimisticLockConflictException(String.format("Optimistic lock conflict on update: interceptorName:'"
+                            + "%s'. Reload the data.", entity.getName()));
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
@@ -3,12 +3,15 @@ package com.epam.aidial.cfg.domain.service;
 import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.InterceptorEntityMapper;
 import com.epam.aidial.cfg.dao.model.InterceptorEntity;
+import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.model.Interceptor;
 import com.epam.aidial.cfg.domain.model.source.InterceptorContainerSource;
 import com.epam.aidial.cfg.domain.util.ContainerEndpointResolver;
 import com.epam.aidial.cfg.domain.validator.InterceptorValidator;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
+import com.epam.aidial.cfg.service.hashing.HashCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.epam.aidial.cfg.service.hashing.HashCalculator.ANY_HASH;
 
 @Slf4j
 @Service("coreInterceptorService")
@@ -33,6 +38,7 @@ public class InterceptorService {
     private final InterceptorValidator interceptorValidator;
     private final InterceptorEntityMapper mapper;
     private final HistoryService historyService;
+    private final HashCalculator calculator;
 
     @Transactional(readOnly = true)
     public Collection<Interceptor> getAll() {
@@ -49,6 +55,12 @@ public class InterceptorService {
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(interceptorName)));
     }
 
+    @Transactional(readOnly = true)
+    public DomainObjectWithHash<Interceptor> getInterceptorWithHash(String interceptorName) {
+        var interceptor = get(interceptorName);
+        return new DomainObjectWithHash<>(interceptor, calculator.calculateHash(interceptor));
+    }
+
     @Transactional
     public void create(Interceptor interceptor) {
         interceptorValidator.validateCreation(interceptor);
@@ -61,13 +73,25 @@ public class InterceptorService {
 
     @Transactional
     public void update(String interceptorName, Interceptor interceptor) {
+        performUpdate(interceptorName, interceptor, ANY_HASH);
+    }
+
+    @Transactional
+    public String update(String interceptorName, Interceptor interceptor, String hash) {
+        if (hash == null) {
+            throw new IllegalArgumentException(
+                    "Hash must not be null. Use \"*\" to skip optimistic check.");
+        }
+        var savedModel = performUpdate(interceptorName, interceptor, hash);
+        return calculator.calculateHash(mapper.toDomain(savedModel));
+    }
+
+    private InterceptorEntity performUpdate(String interceptorName, Interceptor interceptor, String hash) {
         interceptorValidator.validateUpdate(interceptorName, interceptor);
-        resolveEndpointsIfContainerSource(interceptor);
-        InterceptorEntity interceptorEntity = interceptorJpaRepository.findById(interceptorName)
+        var interceptorEntity = interceptorJpaRepository.findById(interceptorName)
                 .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(interceptorName)));
-        Optional.of(interceptor)
-                .map(domainModel -> mapper.toEntity(domainModel, interceptorEntity))
-                .ifPresent(interceptorJpaRepository::save);
+        assertNotConcurrencyOverwrite(interceptorEntity, hash);
+        return interceptorJpaRepository.save(mapper.toEntity(interceptor, interceptorEntity));
     }
 
     @Transactional
@@ -93,6 +117,19 @@ public class InterceptorService {
                 .stream()
                 .map(mapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    private void assertNotConcurrencyOverwrite(InterceptorEntity entity, String expectedHash) {
+        if (ANY_HASH.equals(expectedHash)) {
+            return;
+        }
+        var currentHash = calculator.calculateHash(mapper.toDomain(entity));
+        if (!expectedHash.equals(currentHash)) {
+            log.debug("Optimistic lock conflict on update: interceptorId={}, expectedHash={}, currentHash={}",
+                    entity.getId(), expectedHash, currentHash);
+            throw new OptimisticLockConflictException("Optimistic lock conflict on update: interceptorId:'"
+                    + entity.getId() + "'. Reload the data.");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/epam/aidial/cfg/web/controller/AddonController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/AddonController.java
@@ -2,12 +2,12 @@ package com.epam.aidial.cfg.web.controller;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.dto.AddonDto;
-import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.web.facade.AddonFacade;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,22 +36,24 @@ public class AddonController {
     }
 
     @GetMapping(produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<AddonDto> getAll(HttpServletResponse response) {
+    public Collection<AddonDto> getAll() {
         return addonFacade.getAllAddons();
     }
 
     @GetMapping(path = "/{addonName}",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public AddonDto getAddon(HttpServletResponse response,
-                             @PathVariable("addonName") String addonName) {
-        return addonFacade.getAddon(addonName);
+    public ResponseEntity<AddonDto> getAddon(@PathVariable("addonName") String addonName,
+                                             @RequestHeader(value = "If-None-Match") String previousHash) {
+        var dtoWithHash = addonFacade.getAddonWithHash(addonName);
+        return dtoWithHash.hash().equals(StringUtils.unwrap(previousHash, '"'))
+                ? ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(dtoWithHash.hash()).build()
+                : ResponseEntity.status(HttpStatus.OK).eTag(dtoWithHash.hash()).body(dtoWithHash.dto());
     }
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void createAddon(HttpServletResponse response,
-                            @RequestBody @Valid AddonDto addonDto) {
+    public void createAddon(@RequestBody @Valid AddonDto addonDto) {
         addonFacade.createAddon(addonDto);
     }
 
@@ -58,19 +61,18 @@ public class AddonController {
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteAddon(HttpServletResponse response,
-                            @PathVariable("addonName") String addonName) {
+    public void deleteAddon(@PathVariable("addonName") String addonName) {
         addonFacade.deleteAddon(addonName);
     }
 
     @PutMapping(path = "/{addonName}",
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateAddon(HttpServletResponse response,
-                            @PathVariable("addonName") String addonName,
-                            @RequestBody @Valid AddonDto addonDto) {
-        addonFacade.updateAddon(addonName, addonDto);
+    public ResponseEntity<Void> updateAddon(@PathVariable("addonName") String addonName,
+                                            @RequestBody @Valid AddonDto addonDto,
+                                            @RequestHeader(value = "If-Match") String previousHash) {
+        var newHash = addonFacade.updateAddon(addonName, addonDto, previousHash);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).eTag(newHash).build();
     }
 
     @GetMapping(path = "/{addonName}/revision/{revision}",
@@ -80,7 +82,7 @@ public class AddonController {
     }
 
     @GetMapping(path = "/revision/{revision}", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<AddonDto> getAllAtRevision(HttpServletResponse response, @PathVariable Integer revision) throws Exception {
+    public Collection<AddonDto> getAllAtRevision(@PathVariable Integer revision) {
         return addonFacade.getAllAtRevision(revision);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/AddonController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/AddonController.java
@@ -50,23 +50,19 @@ public class AddonController {
                 : ResponseEntity.status(HttpStatus.OK).eTag(dtoWithHash.hash()).body(dtoWithHash.dto());
     }
 
-    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void createAddon(@RequestBody @Valid AddonDto addonDto) {
         addonFacade.createAddon(addonDto);
     }
 
-    @DeleteMapping(path = "/{addonName}",
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(path = "/{addonName}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAddon(@PathVariable("addonName") String addonName) {
         addonFacade.deleteAddon(addonName);
     }
 
     @PutMapping(path = "/{addonName}",
-            produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateAddon(@PathVariable("addonName") String addonName,
                                             @RequestBody @Valid AddonDto addonDto,

--- a/src/main/java/com/epam/aidial/cfg/web/controller/ApplicationController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/ApplicationController.java
@@ -1,15 +1,14 @@
 package com.epam.aidial.cfg.web.controller;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
-import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationInfoDto;
-import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.web.facade.ApplicationFacade;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,37 +37,39 @@ public class ApplicationController {
     }
 
     @GetMapping(produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<ApplicationInfoDto> getAllApplications(HttpServletResponse response) {
+    public Collection<ApplicationInfoDto> getAllApplications() {
         return applicationFacade.getAllApplications();
     }
 
     @GetMapping(path = "/{applicationName}",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApplicationDto getApplication(HttpServletResponse response,
-                                         @PathVariable("applicationName") String applicationName) {
-        return applicationFacade.getApplication(applicationName);
+    public ResponseEntity<ApplicationDto> getApplication(@PathVariable("applicationName") String applicationName,
+                                                         @RequestHeader(value = "If-None-Match") String previousHash) {
+        var dtoWithHash = applicationFacade.getApplicationWithHash(applicationName);
+        return dtoWithHash.hash().equals(StringUtils.unwrap(previousHash, '"'))
+                ? ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(dtoWithHash.hash()).build()
+                : ResponseEntity.status(HttpStatus.OK).eTag(dtoWithHash.hash()).body(dtoWithHash.dto());
+
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void createApplication(HttpServletResponse response,
-                                  @RequestBody @Valid ApplicationDto applicationDto) {
+    public void createApplication(@RequestBody @Valid ApplicationDto applicationDto) {
         applicationFacade.createApplication(applicationDto);
     }
 
     @PutMapping(path = "/{applicationName}",
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateApplication(HttpServletResponse response,
-                                  @PathVariable("applicationName") String applicationName,
-                                  @RequestBody @Valid ApplicationDto applicationDto) {
-        applicationFacade.updateApplication(applicationName, applicationDto);
+    public ResponseEntity<Void> updateApplication(@PathVariable("applicationName") String applicationName,
+                                                  @RequestBody @Valid ApplicationDto applicationDto,
+                                                  @RequestHeader(value = "If-Match") String previousHash) {
+        var newHash = applicationFacade.updateApplication(applicationName, applicationDto, previousHash);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).eTag(newHash).build();
     }
 
     @DeleteMapping(path = "/{applicationName}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteApplication(HttpServletResponse response,
-                                  @PathVariable("applicationName") String applicationName) {
+    public void deleteApplication(@PathVariable("applicationName") String applicationName) {
         applicationFacade.deleteApplication(applicationName);
     }
 
@@ -78,7 +80,7 @@ public class ApplicationController {
     }
 
     @GetMapping(path = "/revision/{revision}", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<ApplicationDto> getAllAtRevision(HttpServletResponse response, @PathVariable Integer revision) throws Exception {
+    public Collection<ApplicationDto> getAllAtRevision(@PathVariable Integer revision) {
         return applicationFacade.getAllAtRevision(revision);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
@@ -2,12 +2,12 @@ package com.epam.aidial.cfg.web.controller;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.dto.InterceptorDto;
-import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,41 +36,42 @@ public class InterceptorController {
     }
 
     @GetMapping(produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<InterceptorDto> getAll(HttpServletResponse response) {
+    public Collection<InterceptorDto> getAll() {
         return interceptorFacade.getAllInterceptors();
     }
 
     @GetMapping(path = "/{interceptorName}",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public InterceptorDto getInterceptor(HttpServletResponse response,
-                                         @PathVariable("interceptorName") String interceptorName) {
-        return interceptorFacade.getInterceptor(interceptorName);
+    public ResponseEntity<InterceptorDto> getInterceptor(@PathVariable("interceptorName") String interceptorName,
+                                                         @RequestHeader(value = "If-None-Match") String previousHash) {
+        var dtoWithHash = interceptorFacade.getInterceptorWithHash(interceptorName);
+        return dtoWithHash.hash().equals(StringUtils.unwrap(previousHash, '"'))
+                ? ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(dtoWithHash.hash()).build()
+                : ResponseEntity.status(HttpStatus.OK).eTag(dtoWithHash.hash()).body(dtoWithHash.dto());
     }
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void createInterceptor(HttpServletResponse response,
-                                  @RequestBody @Valid InterceptorDto interceptorDto) {
+    public void createInterceptor(@RequestBody @Valid InterceptorDto interceptorDto) {
         interceptorFacade.createInterceptor(interceptorDto);
     }
 
     @PutMapping(path = "/{interceptorName}",
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateInterceptor(HttpServletResponse response,
-                                  @PathVariable("interceptorName") String interceptorName,
-                                  @RequestBody @Valid InterceptorDto interceptorDto) {
-        interceptorFacade.updateInterceptor(interceptorName, interceptorDto);
+    public ResponseEntity<Void> updateInterceptor(@PathVariable("interceptorName") String interceptorName,
+                                                  @RequestBody @Valid InterceptorDto interceptorDto,
+                                                  @RequestHeader(value = "If-Match") String previousHash) {
+        var newHash = interceptorFacade.updateInterceptor(interceptorName, interceptorDto, previousHash);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).eTag(newHash).build();
     }
 
     @DeleteMapping(path = "/{interceptorName}",
             produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteInterceptor(HttpServletResponse response,
-                                  @PathVariable("interceptorName") String interceptorName) {
+    public void deleteInterceptor(@PathVariable("interceptorName") String interceptorName) {
         interceptorFacade.deleteInterceptor(interceptorName);
     }
 
@@ -81,7 +83,7 @@ public class InterceptorController {
     }
 
     @GetMapping(path = "/revision/{revision}", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
-    public Collection<InterceptorDto> getAllAtRevision(HttpServletResponse response, @PathVariable Integer revision) throws Exception {
+    public Collection<InterceptorDto> getAllAtRevision(@PathVariable Integer revision) {
         return interceptorFacade.getAllAtRevision(revision);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
@@ -50,15 +50,13 @@ public class InterceptorController {
                 : ResponseEntity.status(HttpStatus.OK).eTag(dtoWithHash.hash()).body(dtoWithHash.dto());
     }
 
-    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void createInterceptor(@RequestBody @Valid InterceptorDto interceptorDto) {
         interceptorFacade.createInterceptor(interceptorDto);
     }
 
     @PutMapping(path = "/{interceptorName}",
-            produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateInterceptor(@PathVariable("interceptorName") String interceptorName,
                                                   @RequestBody @Valid InterceptorDto interceptorDto,
@@ -67,9 +65,7 @@ public class InterceptorController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).eTag(newHash).build();
     }
 
-    @DeleteMapping(path = "/{interceptorName}",
-            produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(path = "/{interceptorName}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteInterceptor(@PathVariable("interceptorName") String interceptorName) {
         interceptorFacade.deleteInterceptor(interceptorName);

--- a/src/main/java/com/epam/aidial/cfg/web/facade/AddonFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/AddonFacade.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.model.Addon;
 import com.epam.aidial.cfg.domain.service.AddonService;
 import com.epam.aidial.cfg.dto.AddonDto;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
 import com.epam.aidial.cfg.dto.ShareResourceLimitDto;
 import com.epam.aidial.cfg.web.facade.mapper.AddonDtoMapper;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,11 @@ public class AddonFacade {
         return mapper.toDto(addon);
     }
 
+    public DtoWithDomainHash<AddonDto> getAddonWithHash(String addonName) {
+        var addonWithHash = addonService.getAddonWithHash(addonName);
+        return new DtoWithDomainHash<>(mapper.toDto(addonWithHash.model()), addonWithHash.hash());
+    }
+
     public void createAddon(AddonDto addonDto) {
         setDefaultRoleShareResourceLimitIfMissing(addonDto);
         Optional.of(addonDto)
@@ -40,11 +46,10 @@ public class AddonFacade {
                 .ifPresent(addonService::createAddon);
     }
 
-    public void updateAddon(String addonName,
-                            AddonDto addonDto) {
+    public String updateAddon(String addonName, AddonDto addonDto, String hash) {
         setDefaultRoleShareResourceLimitIfMissing(addonDto);
         Addon value = mapper.toDomain(addonDto);
-        addonService.updateAddon(addonName, value);
+        return addonService.updateAddon(addonName, value, hash);
     }
 
     public void deleteAddon(String addonName) {

--- a/src/main/java/com/epam/aidial/cfg/web/facade/ApplicationFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/ApplicationFacade.java
@@ -5,6 +5,7 @@ import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.service.ApplicationService;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationInfoDto;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
 import com.epam.aidial.cfg.dto.ShareResourceLimitDto;
 import com.epam.aidial.cfg.web.facade.mapper.ApplicationDtoMapper;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,11 @@ public class ApplicationFacade {
         return mapper.toDto(application);
     }
 
+    public DtoWithDomainHash<ApplicationDto> getApplicationWithHash(String applicationName) {
+        var applicationWithHash = applicationService.getApplicationWithHash(applicationName);
+        return new DtoWithDomainHash<>(mapper.toDto(applicationWithHash.model()), applicationWithHash.hash());
+    }
+
     public void createApplication(ApplicationDto applicationDto) {
         setDefaultRoleShareResourceLimitIfMissing(applicationDto);
         Optional.of(applicationDto)
@@ -41,10 +47,10 @@ public class ApplicationFacade {
                 .ifPresent(applicationService::createApplication);
     }
 
-    public void updateApplication(String applicationName, ApplicationDto applicationDto) {
+    public String updateApplication(String applicationName, ApplicationDto applicationDto, String hash) {
         setDefaultRoleShareResourceLimitIfMissing(applicationDto);
         Application value = mapper.toDomain(applicationDto);
-        applicationService.updateApplication(applicationName, value);
+        return applicationService.updateApplication(applicationName, value, hash);
     }
 
     public void deleteApplication(String applicationName) {

--- a/src/main/java/com/epam/aidial/cfg/web/facade/InterceptorFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/InterceptorFacade.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.web.facade;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.model.Interceptor;
 import com.epam.aidial.cfg.domain.service.InterceptorService;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
 import com.epam.aidial.cfg.dto.InterceptorDto;
 import com.epam.aidial.cfg.web.facade.mapper.InterceptorDtoMapper;
 import lombok.RequiredArgsConstructor;
@@ -32,15 +33,20 @@ public class InterceptorFacade {
         return mapper.toDto(interceptor);
     }
 
+    public DtoWithDomainHash<InterceptorDto> getInterceptorWithHash(String interceptorName) {
+        var interceptorWithHash = interceptorService.getInterceptorWithHash(interceptorName);
+        return new DtoWithDomainHash<>(mapper.toDto(interceptorWithHash.model()), interceptorWithHash.hash());
+    }
+
     public void createInterceptor(InterceptorDto interceptorDto) {
         Optional.of(interceptorDto)
                 .map(mapper::toDomain)
                 .ifPresent(interceptorService::create);
     }
 
-    public void updateInterceptor(String interceptorName, InterceptorDto interceptorDto) {
+    public String updateInterceptor(String interceptorName, InterceptorDto interceptorDto, String hash) {
         Interceptor value = mapper.toDomain(interceptorDto);
-        interceptorService.update(interceptorName, value);
+        return interceptorService.update(interceptorName, value, hash);
     }
 
     public void deleteInterceptor(String interceptorName) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/AddonFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/AddonFunctionalTest.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.RoleDto;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.features.flag.aspect.FeatureFlagGateEvaluationAspect;
 import com.epam.aidial.cfg.web.facade.AddonFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
@@ -88,7 +89,7 @@ public abstract class AddonFunctionalTest {
         AddonDto addonDto = createDto("1");
         doThrow(new UnsupportedOperationException("Feature flag 'addonsSupported' is disabled.")).when(featureFlagAspect).evaluate(any(), any());
         // when
-        org.assertj.core.api.Assertions.assertThatThrownBy(() -> addonFacade.updateAddon(addonDto.getName(), addonDto))
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> addonFacade.updateAddon(addonDto.getName(), addonDto, "*"))
                 // then
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Feature flag 'addonsSupported' is disabled.");
@@ -115,7 +116,7 @@ public abstract class AddonFunctionalTest {
         AddonDto updatedAddon = createDto("1");
         updatedAddon.setDescription("new addon description");
 
-        addonFacade.updateAddon(addonDto.getName(), updatedAddon);
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*");
 
         AddonDto actual = addonFacade.getAddon(addonDto.getName());
         var expected = createDto("1");
@@ -131,7 +132,7 @@ public abstract class AddonFunctionalTest {
         AddonDto updatedAddon = createDto("1");
         updatedAddon.setDescription("new addon description");
 
-        addonFacade.updateAddon(addonDto.getName(), updatedAddon);
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*");
 
         AddonDto actual = addonFacade.getAddon(updatedAddon.getName());
 
@@ -151,9 +152,39 @@ public abstract class AddonFunctionalTest {
 
         IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> addonFacade.updateAddon(addonDto.getName(), updatedAddon)
+                () -> addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*")
         );
         Assertions.assertEquals("Addon with name: 'addon1' can not be renamed. New name: 'addon2'", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAddonConcurrencyOverwrite() {
+        initRoles();
+
+        AddonDto addonDto = createDto("1");
+        addonFacade.createAddon(addonDto);
+
+        OptimisticLockConflictException exception = Assertions.assertThrows(
+                OptimisticLockConflictException.class,
+                () -> addonFacade.updateAddon(addonDto.getName(), addonDto, "test")
+        );
+        Assertions.assertEquals("Optimistic lock conflict on update: addonName:'addon1'"
+                + ". Reload the data.", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHashIsNull() {
+        initRoles();
+
+        AddonDto addonDto = createDto("1");
+        addonFacade.createAddon(addonDto);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> addonFacade.updateAddon(addonDto.getName(), addonDto, null)
+        );
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+                exception.getMessage());
     }
 
     private void assertAddon(AddonDto actual, AddonDto expected) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/AddonFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/AddonFunctionalTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.functional.tests;
 
+import com.epam.aidial.cfg.dto.AdapterDto;
 import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.RoleDto;
@@ -158,6 +159,37 @@ public abstract class AddonFunctionalTest {
     }
 
     @Test
+    public void shouldSuccessfullyUpdateAddonWithCorrectHash() {
+        initRoles();
+        AddonDto addonDto = createDto("1");
+        addonFacade.createAddon(addonDto);
+        AddonDto updatedAddon = createDto("1");
+        updatedAddon.setDescription("new addon description");
+
+        var hash = addonFacade.getAddonWithHash(addonDto.getName()).hash();
+
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, hash);
+
+        AddonDto actual = addonFacade.getAddon(updatedAddon.getName());
+
+        var expected = createDto("1");
+        expected.setDescription("new addon description");
+        assertAddon(actual, expected);
+    }
+
+    @Test
+    public void shouldThrowWhenUpdateAddonWithIncorrectHash() {
+        initRoles();
+        AddonDto addonDto = createDto("1");
+        addonFacade.createAddon(addonDto);
+        AddonDto updatedAddon = createDto("1");
+        updatedAddon.setDescription("new addon description");
+
+        Assertions.assertThrows(OptimisticLockConflictException.class,
+                () -> addonFacade.updateAddon(addonDto.getName(), updatedAddon, "test"));
+    }
+
+    @Test
     public void shouldThrowExceptionWhenAddonConcurrencyOverwrite() {
         initRoles();
 
@@ -183,7 +215,7 @@ public abstract class AddonFunctionalTest {
                 IllegalArgumentException.class,
                 () -> addonFacade.updateAddon(addonDto.getName(), addonDto, null)
         );
-        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check. Addon:addon1.",
                 exception.getMessage());
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
@@ -154,7 +154,7 @@ public abstract class ApplicationFunctionalTest {
                 IllegalArgumentException.class,
                 () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto, null)
         );
-        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check. Application:application1.",
                 exception.getMessage());
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
@@ -7,6 +7,7 @@ import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.RoleDto;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.web.facade.ApplicationFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
@@ -79,7 +80,7 @@ public abstract class ApplicationFunctionalTest {
         ApplicationDto updatedApplication = createDto("1");
         updatedApplication.setDescription("new application description");
 
-        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication);
+        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*");
 
         ApplicationDto actual = applicationFacade.getApplication(applicationDto.getName());
         var expected = createDto("1");
@@ -105,7 +106,7 @@ public abstract class ApplicationFunctionalTest {
         updatedApplication.setDefaults(Map.of());
         updatedApplication.setInterceptors(List.of("int1"));
 
-        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication);
+        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*");
 
         ApplicationDto actual = applicationFacade.getApplication(applicationDto.getName());
 
@@ -122,9 +123,39 @@ public abstract class ApplicationFunctionalTest {
 
         IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> applicationFacade.updateApplication(applicationDto.getName(), updatedApplication)
+                () -> applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*")
         );
         Assertions.assertEquals("Application with name: 'application1' can not be renamed. New name: 'application2'", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenApplicationConcurrencyOverwrite() {
+        initRoles();
+
+        ApplicationDto applicationDto = createDto("1");
+        applicationFacade.createApplication(applicationDto);
+
+        OptimisticLockConflictException exception = Assertions.assertThrows(
+                OptimisticLockConflictException.class,
+                () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "test")
+        );
+        Assertions.assertEquals("Optimistic lock conflict on update: applicationName:'application1'"
+                + ". Reload the data.", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHashIsNull() {
+        initRoles();
+
+        ApplicationDto applicationDto = createDto("1");
+        applicationFacade.createApplication(applicationDto);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto, null)
+        );
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+                exception.getMessage());
     }
 
     @Test
@@ -164,7 +195,7 @@ public abstract class ApplicationFunctionalTest {
         Assertions.assertEquals(List.of("int1", "int2", "int1", "int1", "int2"), actualApplication.getInterceptors());
 
         applicationDto.setInterceptors(List.of("int2", "int2", "int1", "int1"));
-        applicationFacade.updateApplication(applicationDto.getName(), applicationDto);
+        applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "*");
 
         actualApplication = applicationFacade.getApplication(applicationDto.getName());
         Assertions.assertEquals(List.of("int2", "int2", "int1", "int1"), actualApplication.getInterceptors());
@@ -248,7 +279,7 @@ public abstract class ApplicationFunctionalTest {
         applicationFacade.createApplication(applicationDto2);
 
         interceptorDto1.setEntities(List.of("application2"));
-        interceptorFacade.updateInterceptor(interceptorDto1.getName(), interceptorDto1);
+        interceptorFacade.updateInterceptor(interceptorDto1.getName(), interceptorDto1, "*");
 
         ApplicationDto actualApplication1 = applicationFacade.getApplication(applicationDto1.getName());
         Assertions.assertEquals(List.of("int2"), actualApplication1.getInterceptors());
@@ -257,7 +288,7 @@ public abstract class ApplicationFunctionalTest {
         Assertions.assertEquals(List.of("int1", "int1", "int2"), actualApplication2.getInterceptors());
 
         interceptorDto2.setEntities(null);
-        interceptorFacade.updateInterceptor(interceptorDto2.getName(), interceptorDto2);
+        interceptorFacade.updateInterceptor(interceptorDto2.getName(), interceptorDto2, "*");
 
         actualApplication1 = applicationFacade.getApplication(applicationDto1.getName());
         Assertions.assertEquals(actualApplication1.getInterceptors(), List.of());
@@ -303,7 +334,7 @@ public abstract class ApplicationFunctionalTest {
 
         EntityAlreadyExistsException exception = Assertions.assertThrows(
                 EntityAlreadyExistsException.class,
-                () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto)
+                () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "*")
         );
         Assertions.assertEquals("Application with display name: 'display_name_2' and display version: 'null' already exists", exception.getMessage());
     }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.functional.tests;
 
 import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
+import com.epam.aidial.cfg.dto.AddonDto;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.InterceptorDto;
 import com.epam.aidial.cfg.dto.ModelDto;
@@ -213,7 +214,7 @@ public abstract class InterceptorFunctionalTest {
                 OptimisticLockConflictException.class,
                 () -> interceptorFacade.updateInterceptor(interceptorDto.getName(), interceptorDto, "test")
         );
-        Assertions.assertEquals("Optimistic lock conflict on update: interceptorId:'interceptor1'"
+        Assertions.assertEquals("Optimistic lock conflict on update: interceptorName:'interceptor1'"
                 + ". Reload the data.", exception.getMessage());
     }
 
@@ -228,8 +229,48 @@ public abstract class InterceptorFunctionalTest {
                 IllegalArgumentException.class,
                 () -> interceptorFacade.updateInterceptor(interceptorDto.getName(), interceptorDto, null)
         );
-        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check. Interceptor:interceptor1.",
                 exception.getMessage());
+    }
+
+    @Test
+    public void shouldSuccessfullyUpdateInterceptorWithCorrectHash() {
+        ApplicationDto applicationDto = createApplicationDto("1");
+        applicationFacade.createApplication(applicationDto);
+        ApplicationDto applicationDto2 = createApplicationDto("2");
+        applicationFacade.createApplication(applicationDto2);
+        InterceptorDto interceptorDto = createDto("1");
+        interceptorFacade.createInterceptor(interceptorDto);
+        assertAppInterceptors(applicationDto.getName(), List.of("interceptor1"));
+
+        InterceptorDto updatedInterceptor = createDto("1");
+        updatedInterceptor.setEntities(List.of("application2"));
+
+        var hash = interceptorFacade.getInterceptorWithHash(interceptorDto.getName()).hash();
+
+        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, hash);
+
+        InterceptorDto actual = interceptorFacade.getInterceptor(interceptorDto.getName());
+        var expected = createDto("1");
+        expected.setEntities(List.of("application2"));
+        assertInterceptor(actual, expected);
+    }
+
+    @Test
+    public void shouldThrowWhenUpdateInterceptorWithIncorrectHash() {
+        ApplicationDto applicationDto = createApplicationDto("1");
+        applicationFacade.createApplication(applicationDto);
+        ApplicationDto applicationDto2 = createApplicationDto("2");
+        applicationFacade.createApplication(applicationDto2);
+        InterceptorDto interceptorDto = createDto("1");
+        interceptorFacade.createInterceptor(interceptorDto);
+        assertAppInterceptors(applicationDto.getName(), List.of("interceptor1"));
+
+        InterceptorDto updatedInterceptor = createDto("1");
+        updatedInterceptor.setEntities(List.of("application2"));
+
+        Assertions.assertThrows(OptimisticLockConflictException.class,
+                () -> interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, "test"));
     }
 
     private ApplicationDto createApplicationDto(String suffix) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -8,6 +8,7 @@ import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.dto.source.InterceptorContainerSourceDto;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.web.facade.ApplicationFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
 import com.epam.aidial.cfg.web.facade.ModelFacade;
@@ -102,7 +103,7 @@ public abstract class InterceptorFunctionalTest {
         InterceptorDto updatedInterceptor = createDto("1");
         updatedInterceptor.setEntities(List.of("application2"));
 
-        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor);
+        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, "*");
 
         assertAppInterceptors(applicationDto.getName(), List.of());
         assertAppInterceptors(applicationDto2.getName(), List.of("interceptor1"));
@@ -155,7 +156,7 @@ public abstract class InterceptorFunctionalTest {
                 .containsExactlyInAnyOrderElementsOf(List.of("application1", "application2"));
 
         applicationDto1.setInterceptors(List.of("interceptor1", "interceptor1", "interceptor1"));
-        applicationFacade.updateApplication(applicationDto1.getName(), applicationDto1);
+        applicationFacade.updateApplication(applicationDto1.getName(), applicationDto1, "*");
 
         actualInterceptor = interceptorFacade.getInterceptor("interceptor1");
         org.assertj.core.api.Assertions.assertThat(actualInterceptor.getEntities())
@@ -195,10 +196,40 @@ public abstract class InterceptorFunctionalTest {
 
         IllegalArgumentException exception = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> interceptorFacade.updateInterceptor("interceptor1", interceptorDto)
+                () -> interceptorFacade.updateInterceptor("interceptor1", interceptorDto, "*")
         );
 
         Assertions.assertEquals("Interceptor with name: 'interceptor1' can not be renamed. New interceptor name: 'interceptor2'", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenInterceptorConcurrencyOverwrite() {
+        ApplicationDto applicationDto1 = createApplicationDto("1");
+        applicationFacade.createApplication(applicationDto1);
+        InterceptorDto interceptorDto = createDto("1");
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        OptimisticLockConflictException exception = Assertions.assertThrows(
+                OptimisticLockConflictException.class,
+                () -> interceptorFacade.updateInterceptor(interceptorDto.getName(), interceptorDto, "test")
+        );
+        Assertions.assertEquals("Optimistic lock conflict on update: interceptorId:'interceptor1'"
+                + ". Reload the data.", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHashIsNull() {
+        ApplicationDto applicationDto1 = createApplicationDto("1");
+        applicationFacade.createApplication(applicationDto1);
+        InterceptorDto interceptorDto = createDto("1");
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> interceptorFacade.updateInterceptor(interceptorDto.getName(), interceptorDto, null)
+        );
+        Assertions.assertEquals("Hash must not be null. Use \"*\" to skip optimistic check.",
+                exception.getMessage());
     }
 
     private ApplicationDto createApplicationDto(String suffix) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -313,7 +313,7 @@ public abstract class ModelFunctionalTest {
         modelFacade.createModel(modelDto2);
 
         interceptorDto1.setEntities(List.of("model2"));
-        interceptorFacade.updateInterceptor(interceptorDto1.getName(), interceptorDto1);
+        interceptorFacade.updateInterceptor(interceptorDto1.getName(), interceptorDto1, "*");
 
         ModelDto actualModel1 = modelFacade.getModel(modelDto1.getName());
         Assertions.assertEquals(List.of("int2"), actualModel1.getInterceptors());
@@ -322,7 +322,7 @@ public abstract class ModelFunctionalTest {
         Assertions.assertEquals(List.of("int1", "int1", "int2"), actualModel2.getInterceptors());
 
         interceptorDto2.setEntities(null);
-        interceptorFacade.updateInterceptor(interceptorDto2.getName(), interceptorDto2);
+        interceptorFacade.updateInterceptor(interceptorDto2.getName(), interceptorDto2, "*");
 
         actualModel1 = modelFacade.getModel(modelDto1.getName());
         Assertions.assertNull(actualModel1.getInterceptors());

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/AddonHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/AddonHistoryFunctionalTest.java
@@ -51,7 +51,7 @@ public abstract class AddonHistoryFunctionalTest {
         // 2 update addon1 description
         AddonDto updatedAddon = createDto("1");
         updatedAddon.setDescription("new addon description");
-        addonFacade.updateAddon(addonDto.getName(), updatedAddon);
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*");
 
         // verify addon1
         AddonDto actual = addonFacade.getAddon(addonDto.getName());
@@ -66,7 +66,7 @@ public abstract class AddonHistoryFunctionalTest {
         updatedAddon.setDefaultRoleShareResourceLimit(new ShareResourceLimitDto());
         updatedAddon.setRoleLimits(Map.of("role2", new LimitDto(), "role3", new LimitDto()));
         updatedAddon.setRoleShareResourceLimits(Map.of("role2", new ShareResourceLimitDto(), "role3", new ShareResourceLimitDto()));
-        addonFacade.updateAddon(addonDto.getName(), updatedAddon);
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*");
         actual = addonFacade.getAddon(addonDto.getName());
         assertAddon(actual, updatedAddon);
 
@@ -77,7 +77,7 @@ public abstract class AddonHistoryFunctionalTest {
         shareResourceLimitDto.setInvitationTtl(20L);
         updatedAddon.setRoleLimits(Map.of("role3", limitDto));
         updatedAddon.setRoleShareResourceLimits(Map.of("role3", shareResourceLimitDto));
-        addonFacade.updateAddon(addonDto.getName(), updatedAddon);
+        addonFacade.updateAddon(addonDto.getName(), updatedAddon, "*");
         var actualAtRevision = addonFacade.getAddon(addonDto.getName());
         assertAddon(actualAtRevision, updatedAddon);
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationHistoryFunctionalTest.java
@@ -63,7 +63,7 @@ public abstract class ApplicationHistoryFunctionalTest {
         ApplicationDto updatedApplication = createDto("1");
         updatedApplication.setDescription("new application description");
         updatedApplication.setEndpoint("endpoint2");
-        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication);
+        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*");
 
         // verify application1
         ApplicationDto actual = applicationFacade.getApplication(applicationDto.getName());
@@ -89,7 +89,7 @@ public abstract class ApplicationHistoryFunctionalTest {
         updatedApplication.setRoleLimits(Map.of("role2", new LimitDto(), "role3", new LimitDto()));
         updatedApplication.setRoleShareResourceLimits(Map.of("role2", new ShareResourceLimitDto(), "role3", new ShareResourceLimitDto()));
         updatedApplication.setRoutes(List.of());
-        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication);
+        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*");
         actual = applicationFacade.getApplication(applicationDto.getName());
         assertApplication(actual, updatedApplication);
 
@@ -100,7 +100,7 @@ public abstract class ApplicationHistoryFunctionalTest {
         shareResourceLimitDto.setInvitationTtl(20L);
         updatedApplication.setRoleLimits(Map.of("role3", limitDto));
         updatedApplication.setRoleShareResourceLimits(Map.of("role3", shareResourceLimitDto));
-        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication);
+        applicationFacade.updateApplication(applicationDto.getName(), updatedApplication, "*");
         var actualAtOldRevision = applicationFacade.getAllApplications();
         actual = applicationFacade.getApplication(applicationDto.getName());
         assertApplication(actual, updatedApplication);
@@ -165,7 +165,7 @@ public abstract class ApplicationHistoryFunctionalTest {
 
         // update application
         applicationDto.setInterceptors(List.of(interceptor2.getName()));
-        applicationFacade.updateApplication(applicationDto.getName(), applicationDto);
+        applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "*");
 
         List<ConfigRevisionDto> revisionsListBeforeRollback = historyFacade.getRevisionsList();
         historyFacade.rollbackToRevision(revNumberToRollback);
@@ -201,7 +201,7 @@ public abstract class ApplicationHistoryFunctionalTest {
 
         // update application
         applicationDto.setCustomAppSchemaId(URI.create(applicationTypeSchemaDto2.getId()));
-        applicationFacade.updateApplication(applicationDto.getName(), applicationDto);
+        applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "*");
 
         List<ConfigRevisionDto> revisionsListBeforeRollback = historyFacade.getRevisionsList();
         historyFacade.rollbackToRevision(revNumberToRollback);
@@ -234,7 +234,7 @@ public abstract class ApplicationHistoryFunctionalTest {
 
         application1Dto.setCustomAppSchemaId(null);
         application1Dto.setEndpoint("endpoint");
-        applicationFacade.updateApplication(application1Dto.getName(), application1Dto);
+        applicationFacade.updateApplication(application1Dto.getName(), application1Dto, "*");
 
         ApplicationDto application2Dto = createDto("2");
         application2Dto.setCustomAppSchemaId(URI.create(applicationTypeSchemaDto.getId()));

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
@@ -43,7 +43,7 @@ public abstract class InterceptorHistoryFunctionalTest {
         // update interceptor1 description
         InterceptorDto updatedInterceptor = createDto("1");
         updatedInterceptor.setDescription("new interceptor description");
-        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor);
+        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, "*");
 
         // verify interceptor1
         InterceptorDto actual = interceptorFacade.getInterceptor(interceptorDto.getName());
@@ -58,7 +58,7 @@ public abstract class InterceptorHistoryFunctionalTest {
 
         updatedInterceptor.setDescription("new new interceptor description");
         updatedInterceptor.setDefaults(Map.of("key1", "val1"));
-        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor);
+        interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, "*");
 
         // delete interceptor 1
         interceptorFacade.deleteInterceptor(interceptorDto.getName());
@@ -100,7 +100,7 @@ public abstract class InterceptorHistoryFunctionalTest {
 
         // update interceptor
         interceptor1.setEntities(List.of(model2.getName()));
-        interceptorFacade.updateInterceptor(interceptor1.getName(), interceptor1);
+        interceptorFacade.updateInterceptor(interceptor1.getName(), interceptor1, "*");
 
         List<ConfigRevisionDto> revisionsListBeforeRollback = historyFacade.getRevisionsList();
         historyFacade.rollbackToRevision(revNumberToRollback);
@@ -134,7 +134,7 @@ public abstract class InterceptorHistoryFunctionalTest {
 
         // update interceptor
         interceptor1.setEntities(List.of(application2.getName()));
-        interceptorFacade.updateInterceptor(interceptor1.getName(), interceptor1);
+        interceptorFacade.updateInterceptor(interceptor1.getName(), interceptor1, "*");
 
         List<ConfigRevisionDto> revisionsListBeforeRollback = historyFacade.getRevisionsList();
         historyFacade.rollbackToRevision(revNumberToRollback);

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/AddonControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/AddonControllerTest.java
@@ -1,0 +1,151 @@
+package com.epam.aidial.cfg.web.controller.none;
+
+import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
+import com.epam.aidial.cfg.dto.AddonDto;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
+import com.epam.aidial.cfg.utils.ResourceUtils;
+import com.epam.aidial.cfg.web.controller.AddonController;
+import com.epam.aidial.cfg.web.facade.AddonFacade;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AddonController.class)
+@Import({
+        JsonMapperConfiguration.class,
+})
+public class AddonControllerTest extends AbstractControllerNoneSecureTest {
+    private static final String DTO_JSON_PATH = "/addon_dto.json";
+    private static final String DTOS_JSON_PATH = "/addon_dtos.json";
+    private static final String TEST_ADDON_NAME = "test_addon";
+    private static final String ADDON_BASE_API_PATH = "/api/v1/addons";
+    private static final String ADDON_API_PATH = ADDON_BASE_API_PATH + "/{addonName}";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AddonFacade addonFacade;
+
+    @Test
+    void testGetAllAddons() throws Exception {
+        var dtosJson = ResourceUtils.readResource(DTOS_JSON_PATH);
+        var dtos = objectMapper.readValue(dtosJson, new TypeReference<List<AddonDto>>() {
+        });
+
+        when(addonFacade.getAllAddons()).thenReturn(dtos);
+
+        mockMvc.perform(get(ADDON_BASE_API_PATH))
+                .andExpect(status().isOk())
+                .andExpect(content().json(dtosJson, JsonCompareMode.LENIENT));
+    }
+
+    @Test
+    void testGetAddonWithoutHeaderIfNoneMatch() throws Exception {
+        mockMvc.perform(get(ADDON_API_PATH, TEST_ADDON_NAME))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("Required request header 'If-None-Match' for method parameter type String is not present"));
+    }
+
+    @Test
+    void testGetAddonWithSameHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, AddonDto.class);
+
+        when(addonFacade.getAddonWithHash(eq(TEST_ADDON_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "1"));
+
+        mockMvc.perform(get(ADDON_API_PATH, TEST_ADDON_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isNotModified())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"1\""));
+    }
+
+    @Test
+    void testGetAddonWithDifferentHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, AddonDto.class);
+
+        when(addonFacade.getAddonWithHash(eq(TEST_ADDON_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "2"));
+
+        mockMvc.perform(get(ADDON_API_PATH, TEST_ADDON_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"2\""))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+    }
+
+    @Test
+    void testUpdateAddon() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, AddonDto.class);
+
+        when(addonFacade.updateAddon(eq(TEST_ADDON_NAME), any(), eq("1")))
+                .thenReturn("2");
+
+        mockMvc.perform(put(ADDON_API_PATH, TEST_ADDON_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(dtoJson))
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"2\""));
+        verify(addonFacade).updateAddon(eq(TEST_ADDON_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateAddonWithNotMatchHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, AddonDto.class);
+
+        doThrow(new OptimisticLockConflictException("Conflict Exception"))
+                .when(addonFacade).updateAddon(eq(TEST_ADDON_NAME), any(), eq("1"));
+
+        mockMvc.perform(put(ADDON_API_PATH, TEST_ADDON_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(dtoJson))
+                .andExpect(status().isPreconditionFailed())
+                .andExpect(jsonPath("$.message").value("Conflict Exception"));
+        verify(addonFacade).updateAddon(eq(TEST_ADDON_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateAddonWithoutHeaderIfMatch() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+
+        mockMvc.perform(put(ADDON_API_PATH, TEST_ADDON_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(dtoJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("Required request header 'If-Match' for method parameter type String is not present"));
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/AddonControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/AddonControllerTest.java
@@ -22,9 +22,11 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -147,5 +149,12 @@ public class AddonControllerTest extends AbstractControllerNoneSecureTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message")
                         .value("Required request header 'If-Match' for method parameter type String is not present"));
+    }
+
+    @Test
+    void testDeleteAddon() throws Exception {
+        doNothing().when(addonFacade).deleteAddon(eq(TEST_ADDON_NAME));
+        mockMvc.perform(delete(ADDON_API_PATH, TEST_ADDON_NAME))
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
@@ -3,6 +3,8 @@ package com.epam.aidial.cfg.web.controller.none;
 import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationInfoDto;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.utils.ResourceUtils;
 import com.epam.aidial.cfg.web.controller.ApplicationController;
 import com.epam.aidial.cfg.web.facade.ApplicationFacade;
@@ -19,14 +21,19 @@ import org.springframework.test.json.JsonCompareMode;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = ApplicationController.class)
@@ -34,6 +41,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         JsonMapperConfiguration.class,
 })
 class ApplicationControllerTest extends AbstractControllerNoneSecureTest {
+    private static final String DTO_APPLICATION_PATH = "/application_dto.json";
+    private static final String DTOS_JSON_PATH = "/application_info_dtos.json";
+    private static final String TEST_APPLICATION_NAME = "test_application";
+    private static final String APPLICATION_BASE_API_PATH = "/api/v1/applications";
+    private static final String APPLICATION_API_PATH = APPLICATION_BASE_API_PATH + "/{applicationName}";
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -43,39 +55,67 @@ class ApplicationControllerTest extends AbstractControllerNoneSecureTest {
 
     @Test
     void testGetAllApplications() throws Exception {
-        var dtosJson = ResourceUtils.readResource("/application_info_dtos.json");
+        var dtosJson = ResourceUtils.readResource(DTOS_JSON_PATH);
         var dtos = objectMapper.readValue(dtosJson, new TypeReference<List<ApplicationInfoDto>>() {
         });
 
         when(applicationFacade.getAllApplications()).thenReturn(dtos);
 
-        mockMvc.perform(get("/api/v1/applications"))
+        mockMvc.perform(get(APPLICATION_BASE_API_PATH))
                 .andExpect(status().isOk())
                 .andExpect(content().json(dtosJson, JsonCompareMode.LENIENT));
     }
 
     @Test
-    void testGetApplication() throws Exception {
-        var dtoJson = ResourceUtils.readResource("/application_dto.json");
-        var dto = objectMapper.readValue(dtoJson, new TypeReference<ApplicationDto>() {
-        });
-
-        when(applicationFacade.getApplication(eq("test_application"))).thenReturn(dto);
-
-        mockMvc.perform(get("/api/v1/applications/{applicationName}", "test_application"))
-                .andExpect(status().isOk())
-                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+    void testGetApplicationWithoutHeaderIfNoneMatch() throws Exception {
+        mockMvc.perform(get(APPLICATION_API_PATH, TEST_APPLICATION_NAME))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("Required request header 'If-None-Match' for method parameter type String is not present"));
     }
 
     @Test
+    void testGetApplicationWithSameHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
+        var dto = objectMapper.readValue(dtoJson, ApplicationDto.class);
+
+        when(applicationFacade.getApplicationWithHash(eq(TEST_APPLICATION_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "1"));
+
+        mockMvc.perform(get(APPLICATION_API_PATH, TEST_APPLICATION_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isNotModified())
+                .andExpect(header().exists("eTag"))
+                .andExpect(header().string("eTag", "\"1\""));
+    }
+
+    @Test
+    void testGetApplicationWithDifferentHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
+        var dto = objectMapper.readValue(dtoJson, ApplicationDto.class);
+
+        when(applicationFacade.getApplicationWithHash(eq(TEST_APPLICATION_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "2"));
+
+        mockMvc.perform(get(APPLICATION_API_PATH, TEST_APPLICATION_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("eTag"))
+                .andExpect(header().string("eTag", "\"2\""))
+                .andExpect(content().contentType("application/json"))
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+    }
+
+
+    @Test
     void testCreateApplication() throws Exception {
-        var dtoJson = ResourceUtils.readResource("/application_dto.json");
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
         var dto = objectMapper.readValue(dtoJson, new TypeReference<ApplicationDto>() {
         });
 
         doNothing().when(applicationFacade).createApplication(eq(dto));
 
-        mockMvc.perform(post("/api/v1/applications")
+        mockMvc.perform(post(APPLICATION_BASE_API_PATH)
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .content(dtoJson))
                 .andExpect(status().isNoContent());
@@ -83,24 +123,57 @@ class ApplicationControllerTest extends AbstractControllerNoneSecureTest {
 
     @Test
     void testUpdateApplication() throws Exception {
-        var dtoJson = ResourceUtils.readResource("/application_dto.json");
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
         var dto = objectMapper.readValue(dtoJson, new TypeReference<ApplicationDto>() {
         });
 
-        doNothing().when(applicationFacade).updateApplication(eq("test_application"), eq(dto));
+        when(applicationFacade.updateApplication(eq(TEST_APPLICATION_NAME), eq(dto), eq("1")))
+                .thenReturn("2");
 
-        mockMvc.perform(put("/api/v1/applications/{applicationName}", "test_application")
+        mockMvc.perform(put(APPLICATION_API_PATH, TEST_APPLICATION_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(dtoJson))
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists("eTag"))
+                .andExpect(header().string("eTag", "\"2\""));
+        verify(applicationFacade).updateApplication(eq(TEST_APPLICATION_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateApplicationWithNotMatchHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
+        var dto = objectMapper.readValue(dtoJson, ApplicationDto.class);
+
+        doThrow(new OptimisticLockConflictException("Conflict Exception"))
+                .when(applicationFacade).updateApplication(eq(TEST_APPLICATION_NAME), any(), eq("1"));
+
+        mockMvc.perform(put(APPLICATION_API_PATH, TEST_APPLICATION_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header("If-Match", "1")
+                        .content(dtoJson))
+                .andExpect(status().isPreconditionFailed())
+                .andExpect(jsonPath("$.message").value("Conflict Exception"));
+        verify(applicationFacade).updateApplication(eq(TEST_APPLICATION_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateApplicationWithoutHeaderIfMatch() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_APPLICATION_PATH);
+
+        mockMvc.perform(put(APPLICATION_API_PATH, TEST_APPLICATION_NAME)
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .content(dtoJson))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isBadRequest());
     }
+
 
     @Test
     void testDeleteApplication() throws Exception {
 
-        doNothing().when(applicationFacade).deleteApplication(eq("test_application"));
+        doNothing().when(applicationFacade).deleteApplication(eq(TEST_APPLICATION_NAME));
 
-        mockMvc.perform(delete("/api/v1/applications/{applicationName}", "test_application"))
+        mockMvc.perform(delete(APPLICATION_API_PATH, TEST_APPLICATION_NAME))
                 .andExpect(status().isNoContent());
     }
 

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
@@ -22,9 +22,11 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -148,6 +150,11 @@ public class InterceptorControllerTest extends AbstractControllerNoneSecureTest 
                 .andExpect(jsonPath("$.message")
                         .value("Required request header 'If-Match' for method parameter type String is not present"));
     }
+
+    @Test
+    void testDeleteInterceptor() throws Exception {
+        doNothing().when(interceptorFacade).deleteInterceptor(eq(TEST_INTERCEPTOR_NAME));
+        mockMvc.perform(delete(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME))
+                .andExpect(status().isNoContent());
+    }
 }
-
-

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
@@ -1,0 +1,153 @@
+package com.epam.aidial.cfg.web.controller.none;
+
+import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
+import com.epam.aidial.cfg.dto.DtoWithDomainHash;
+import com.epam.aidial.cfg.dto.InterceptorDto;
+import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
+import com.epam.aidial.cfg.utils.ResourceUtils;
+import com.epam.aidial.cfg.web.controller.InterceptorController;
+import com.epam.aidial.cfg.web.facade.InterceptorFacade;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InterceptorController.class)
+@Import({
+        JsonMapperConfiguration.class,
+})
+public class InterceptorControllerTest extends AbstractControllerNoneSecureTest {
+    private static final String DTO_JSON_PATH = "/interceptor_dto.json";
+    private static final String DTOS_JSON_PATH = "/interceptor_dtos.json";
+    private static final String TEST_INTERCEPTOR_NAME = "test_interceptor";
+    private static final String INTERCEPTOR_BASE_API_PATH = "/api/v1/interceptors";
+    private static final String INTERCEPTOR_API_PATH = INTERCEPTOR_BASE_API_PATH + "/{interceptorName}";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private InterceptorFacade interceptorFacade;
+
+    @Test
+    void testGetAllInterceptors() throws Exception {
+        var dtosJson = ResourceUtils.readResource(DTOS_JSON_PATH);
+        var dtos = objectMapper.readValue(dtosJson, new TypeReference<List<InterceptorDto>>() {
+        });
+
+        when(interceptorFacade.getAllInterceptors()).thenReturn(dtos);
+
+        mockMvc.perform(get(INTERCEPTOR_BASE_API_PATH))
+                .andExpect(status().isOk())
+                .andExpect(content().json(dtosJson, JsonCompareMode.LENIENT));
+    }
+
+    @Test
+    void testGetInterceptorWithoutHeaderIfNoneMatch() throws Exception {
+        mockMvc.perform(get(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("Required request header 'If-None-Match' for method parameter type String is not present"));
+    }
+
+    @Test
+    void testGetInterceptorWithSameHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, InterceptorDto.class);
+
+        when(interceptorFacade.getInterceptorWithHash(eq(TEST_INTERCEPTOR_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "1"));
+
+        mockMvc.perform(get(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isNotModified())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"1\""));
+    }
+
+    @Test
+    void testGetInterceptorWithDifferentHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, InterceptorDto.class);
+
+        when(interceptorFacade.getInterceptorWithHash(eq(TEST_INTERCEPTOR_NAME))).thenReturn(
+                new DtoWithDomainHash<>(dto, "2"));
+
+        mockMvc.perform(get(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME)
+                        .header(HEADER_IF_NONE_MATCH, "1"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"2\""))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(dtoJson, JsonCompareMode.LENIENT));
+    }
+
+    @Test
+    void testUpdateInterceptor() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, InterceptorDto.class);
+
+        when(interceptorFacade.updateInterceptor(eq(TEST_INTERCEPTOR_NAME), any(), eq("1")))
+                .thenReturn("2");
+
+        mockMvc.perform(put(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(dtoJson))
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists(HEADER_ETAG))
+                .andExpect(header().string(HEADER_ETAG, "\"2\""));
+        verify(interceptorFacade).updateInterceptor(eq(TEST_INTERCEPTOR_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateInterceptorWithNotMatchHash() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, InterceptorDto.class);
+
+        doThrow(new OptimisticLockConflictException("Conflict Exception"))
+                .when(interceptorFacade).updateInterceptor(eq(TEST_INTERCEPTOR_NAME), any(), eq("1"));
+
+        mockMvc.perform(put(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(dtoJson))
+                .andExpect(status().isPreconditionFailed())
+                .andExpect(jsonPath("$.message").value("Conflict Exception"));
+        verify(interceptorFacade).updateInterceptor(eq(TEST_INTERCEPTOR_NAME), eq(dto), eq("1"));
+    }
+
+    @Test
+    void testUpdateInterceptorWithoutHeaderIfMatch() throws Exception {
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+
+        mockMvc.perform(put(INTERCEPTOR_API_PATH, TEST_INTERCEPTOR_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(dtoJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("Required request header 'If-Match' for method parameter type String is not present"));
+    }
+}
+
+

--- a/src/test/resources/addon_dtos.json
+++ b/src/test/resources/addon_dtos.json
@@ -1,0 +1,13 @@
+[{
+  "name": "test_addon",
+  "endpoint": "https://endpoint.test.com/embeddings",
+  "iconUrl": "https://test.com/icon",
+  "description": "It is a test addon",
+  "displayName": "Test Addon",
+  "forwardAuthToken": false,
+  "roleLimits": {},
+  "author": "test-author",
+  "createdAt": "2025-06-01T12:00:00Z",
+  "updatedAt": "2025-06-01T15:30:00Z",
+  "dependencies": ["dep1", "dep2"]
+}]

--- a/src/test/resources/interceptor_dtos.json
+++ b/src/test/resources/interceptor_dtos.json
@@ -1,0 +1,11 @@
+[{
+  "name": "test_interceptor",
+  "displayName": "Test Interceptor",
+  "description": "It is a test interceptor",
+  "endpoint": "https://endpoint.test.com/embeddings",
+  "forwardAuthToken": false,
+  "author": "test-author",
+  "createdAt": "2025-06-01T12:00:00Z",
+  "updatedAt": "2025-06-01T15:30:00Z",
+  "dependencies": []
+}]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
-  fixes # https://github.com/epam/ai-dial-admin-backend/issues/53

Implemented ETag-based optimistic locking for the Addons, Interseptors, Applications API.
GET /api/v1/applications/{applicationName} now requires If-None-Match header to support conditional responses.
PUT/api/v1/applications/{applicationName} now requires If-Match header to ensure safe concurrent updates.

GET /api/v1/interceptors/{interceptorName} now requires If-None-Match header to support conditional responses.
PUT /api/v1/interceptors/{interceptorName} now requires If-Match header to ensure safe concurrent updates.

GET /api/v1/addons/{addonName} now requires If-None-Match header to support conditional responses.
PUT /api/v1/addons/{addonName} now requires If-Match header to ensure safe concurrent updates.
<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.