### PR TITLE
fix: add validation for route `paths` field

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
@@ -9,7 +9,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -31,7 +30,7 @@ public abstract class BaseRouteDto extends RoleBasedDto {
     private ResponseDto response;
     private boolean rewritePath;
     @NotEmpty
-    private List<@NotNull @Regex String> paths;
+    private List<@NotEmpty @Regex String> paths;
     private Set<@HttpMethod String> methods;
     @Valid
     private List<UpstreamDto> upstreams;

--- a/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/route/BaseRouteDto.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.dto.ResponseDto;
 import com.epam.aidial.cfg.dto.RoleBasedDto;
 import com.epam.aidial.cfg.dto.UpstreamDto;
 import com.epam.aidial.cfg.dto.validation.annotation.HttpMethod;
+import com.epam.aidial.cfg.dto.validation.annotation.Regex;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -30,7 +31,7 @@ public abstract class BaseRouteDto extends RoleBasedDto {
     private ResponseDto response;
     private boolean rewritePath;
     @NotEmpty
-    private List<@NotNull String> paths;
+    private List<@NotNull @Regex String> paths;
     private Set<@HttpMethod String> methods;
     @Valid
     private List<UpstreamDto> upstreams;

--- a/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/Regex.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/validation/annotation/Regex.java
@@ -1,25 +1,24 @@
 package com.epam.aidial.cfg.dto.validation.annotation;
 
+import com.epam.aidial.cfg.dto.validation.validator.RegexValidator;
 import jakarta.validation.Constraint;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Constraint(validatedBy = {})
+@Constraint(validatedBy = RegexValidator.class)
 @Documented
-@Pattern(regexp = "^/(?=.{1,})([a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)*/?)?$", message = "Invalid route path.")
-@NotNull
 @Retention(RUNTIME)
-@Target({TYPE_USE, FIELD})
-public @interface RoutePath {
-    String message() default "Invalid route path.";
+@Target({FIELD, PARAMETER, TYPE_USE})
+public @interface Regex {
+
+    String message() default "Invalid regular expression pattern";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidator.java
@@ -3,15 +3,19 @@ package com.epam.aidial.cfg.dto.validation.validator;
 import com.epam.aidial.cfg.dto.validation.annotation.Regex;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+@Slf4j
 public class RegexValidator implements ConstraintValidator<Regex, String> {
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        log.trace("checking if value: {} is valid regex pattern. context: {}", value, context);
+
         if (StringUtils.isEmpty(value)) {
             return true;
         }
@@ -20,6 +24,7 @@ public class RegexValidator implements ConstraintValidator<Regex, String> {
             Pattern.compile(value);
             return true;
         } catch (PatternSyntaxException e) {
+            log.trace("value: {} is invalid regex pattern", value, e);
             return false;
         }
     }

--- a/src/main/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidator.java
@@ -1,0 +1,26 @@
+package com.epam.aidial.cfg.dto.validation.validator;
+
+import com.epam.aidial.cfg.dto.validation.annotation.Regex;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class RegexValidator implements ConstraintValidator<Regex, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (StringUtils.isEmpty(value)) {
+            return true;
+        }
+
+        try {
+            Pattern.compile(value);
+            return true;
+        } catch (PatternSyntaxException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidatorTest.java
@@ -1,0 +1,31 @@
+package com.epam.aidial.cfg.dto.validation.validator;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RegexValidatorTest {
+
+    private RegexValidator validator;
+
+    @BeforeEach
+    void init() {
+        validator = new RegexValidator();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''", "' '", "[A-Za-z0-9]", "http://qwe.com"}, nullValues = "null")
+    void testIsValid_shouldReturnTrueWhenValidRegex(String regex) {
+        var result = validator.isValid(regex, null);
+        Assertions.assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"URL???", "[", "{", "(", ")"})
+    void testIsValid_shouldReturnFalseWhenInvalidRegex(String regex) {
+        var result = validator.isValid(regex, null);
+        Assertions.assertThat(result).isFalse();
+    }
+
+}

--- a/src/test/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dto/validation/validator/RegexValidatorTest.java
@@ -15,7 +15,7 @@ class RegexValidatorTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"null", "''", "' '", "[A-Za-z0-9]", "http://qwe.com"}, nullValues = "null")
+    @CsvSource(value = {"null", "''", "' '", "[A-Za-z0-9]", "http://qwe.com", "/abc/myendpoint/.*", "https?://\\S*"}, nullValues = "null")
     void testIsValid_shouldReturnTrueWhenValidRegex(String regex) {
         var result = validator.isValid(regex, null);
         Assertions.assertThat(result).isTrue();

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.json.JsonCompareMode;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = ApplicationController.class)
@@ -93,6 +95,19 @@ class ApplicationControllerTest extends AbstractControllerNoneSecureTest {
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .content(dtoJson))
                 .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testUpdateApplication_appRouteWithInvalidPath_BadRequest() throws Exception {
+        var dtoJson = ResourceUtils.readResource("/application_dto_with_invalid_app_route_path.json");
+
+        doNothing().when(applicationFacade).updateApplication(eq("test_application"), any());
+
+        mockMvc.perform(put("/api/v1/applications/{applicationName}", "test_application")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(dtoJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("JSON parse error: paths[1].<list element>: Invalid regular expression pattern"));
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = RouteController.class)
@@ -98,6 +99,22 @@ class RouteControllerTest extends AbstractControllerNoneSecureTest {
                         .content(dtoJson))
                 // then
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testCreateRoute_WithInvalidPath_BadRequest() throws Exception {
+        // given
+        var dtoJson = ResourceUtils.readResource("/route_dto_with_invalid_path.json");
+
+        doNothing().when(routeFacade).createRoute(any());
+
+        // when
+        mockMvc.perform(post("/api/v1/routes")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(dtoJson))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("paths[0].<list element>: Invalid regular expression pattern"));
     }
 
     @Test

--- a/src/test/resources/application_dto_with_invalid_app_route_path.json
+++ b/src/test/resources/application_dto_with_invalid_app_route_path.json
@@ -1,0 +1,71 @@
+{
+  "custom_property_1": "custom_value_1",
+  "custom_property_2": "custom_value_2",
+  "name": "test_application",
+  "viewerUrl": "https://viewer.test.com",
+  "editorUrl": "https://editor.test.com",
+  "endpoint": "https://endpoint.test.com/embeddings",
+  "displayName": "Test Application",
+  "description": "It is a test application",
+  "displayVersion": "1.0.0",
+  "reference": "test_reference",
+  "userRoles": [
+    "testRole1"
+  ],
+  "forwardAuthToken": true,
+  "features": {
+    "rateEndpoint": "https://endpoint.test.com/rate",
+    "tokenizeEndpoint": "https://endpoint.test.com/tokenize",
+    "truncatePromptEndpoint": "https://endpoint.test.com/truncate",
+    "configurationEndpoint": "https://endpoint.test.com/configuration",
+    "systemPromptSupported": true,
+    "toolsSupported": true,
+    "seedSupported": true,
+    "urlAttachmentsSupported": true,
+    "folderAttachmentsSupported": true,
+    "allowResume": true,
+    "accessibleByPerRequestKey": true,
+    "contentPartsSupported": true
+  },
+  "inputAttachmentTypes": [
+    "application/json"
+  ],
+  "maxInputAttachments": 10,
+  "defaults": {
+    "test_key": "test_value"
+  },
+  "interceptors": [
+    "test_interceptor"
+  ],
+  "topics": [
+    "Test Topic"
+  ],
+  "maxRetryAttempts": 10,
+  "roleLimits": {
+    "testRole1": {
+      "minute": "128000",
+      "day": "2000000"
+    }
+  },
+  "author": "test-author",
+  "createdAt": "2025-06-01T12:00:00Z",
+  "updatedAt": "2025-06-01T15:30:00Z",
+  "dependencies": [
+    "dep1",
+    "dep2"
+  ],
+  "routes": [
+    {
+      "name": "test_route",
+      "paths": [
+        "[A-Za-z0-9]",
+        "URL???"
+      ],
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "upstreams": []
+    }
+  ]
+}

--- a/src/test/resources/route_dto_with_invalid_path.json
+++ b/src/test/resources/route_dto_with_invalid_path.json
@@ -1,0 +1,45 @@
+{
+  "name": "test_route",
+  "description": "routeDescription",
+  "displayName": "routeDisplayName",
+  "response": {
+    "status": 200,
+    "body": "OK"
+  },
+  "rewritePath": true,
+  "paths": [
+    "URL???"
+  ],
+  "methods": [
+    "GET",
+    "POST"
+  ],
+  "upstreams": [
+    {
+      "endpoint": "http://upstream1.example.com",
+      "key": "upstream-key-1",
+      "extraData": "{\"custom\":\"data1\"}",
+      "weight": 1,
+      "tier": 0
+    },
+    {
+      "endpoint": "http://upstream2.example.com",
+      "key": "upstream-key-2",
+      "extraData": "{\"custom\":\"data2\"}",
+      "weight": 2,
+      "tier": 1
+    }
+  ],
+  "maxRetryAttempts": 3,
+  "roleLimits": {
+    "testRole1": {
+      "enabled": true,
+      "minute": "100",
+      "day": "500",
+      "week": "30",
+      "month": "2",
+      "requestHour": "1",
+      "requestDay": "1"
+    }
+  }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #279

### Description of changes
Added `@Regex` validation annotation to check that string is a valid regex pattern and put it to route `paths` field

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.