### PR TITLE
fix: allow empty endpoint path in ToolSet

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
@@ -97,7 +97,7 @@ public class ToolSetValidator {
     }
 
     private void validateEndpointPath(String endpoint, String name) {
-        if (endpoint != null && EndpointValidator.isInvalidUrlPath(endpoint)) {
+        if (StringUtils.isNotEmpty(endpoint) && EndpointValidator.isInvalidUrlPath(endpoint)) {
             throw new IllegalArgumentException("Invalid endpoint path: '%s'. Toolset: %s".formatted(endpoint, name));
         }
     }


### PR DESCRIPTION
### Description of changes

Allowed empty endpoint path in ToolSet.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.