### PR TITLE
fix: filter activities with type 'SecuredResource'

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/AuditActivityService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AuditActivityService.java
@@ -64,7 +64,8 @@ public class AuditActivityService {
     private static Specification<AuditActivityEntity> defaultFilters() {
         return Specification.allOf(
                 (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("resourceType"), "RoleLimit"),
-                (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("resourceType"), "Deployment")
+                (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("resourceType"), "Deployment"),
+                (root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("resourceType"), "SecuredResource")
         );
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ActivityAuditFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ActivityAuditFunctionalTest.java
@@ -1,7 +1,5 @@
 package com.epam.aidial.cfg.functional.tests.history;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import com.epam.aidial.cfg.domain.model.page.SortDirection;
 import com.epam.aidial.cfg.dto.AuditActivityDto;
 import com.epam.aidial.cfg.dto.LimitDto;
@@ -16,7 +14,6 @@ import com.epam.aidial.cfg.web.facade.AuditActivityFacade;
 import com.epam.aidial.cfg.web.facade.ModelFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
 import com.epam.aidial.cfg.web.facade.ToolSetFacade;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class ActivityAuditFunctionalTest {
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ActivityAuditFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ActivityAuditFunctionalTest.java
@@ -1,16 +1,22 @@
 package com.epam.aidial.cfg.functional.tests.history;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import com.epam.aidial.cfg.domain.model.page.SortDirection;
 import com.epam.aidial.cfg.dto.AuditActivityDto;
 import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.dto.PageDto;
 import com.epam.aidial.cfg.dto.RoleDto;
+import com.epam.aidial.cfg.dto.ToolSetDto;
+import com.epam.aidial.cfg.dto.ToolSetDto.TransportDto;
 import com.epam.aidial.cfg.dto.page.PageRequestDto;
 import com.epam.aidial.cfg.dto.page.SortDto;
 import com.epam.aidial.cfg.web.facade.AuditActivityFacade;
 import com.epam.aidial.cfg.web.facade.ModelFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
+import com.epam.aidial.cfg.web.facade.ToolSetFacade;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +32,8 @@ public abstract class ActivityAuditFunctionalTest {
     @Autowired
     private ModelFacade modelFacade;
     @Autowired
+    private ToolSetFacade toolSetFacade;
+    @Autowired
     private AuditActivityFacade auditActivityFacade;
 
     private void initRoles() {
@@ -35,6 +43,20 @@ public abstract class ActivityAuditFunctionalTest {
         roleFacade.createRole(role1);
         roleFacade.createRole(role2);
         roleFacade.createRole(role3);
+    }
+
+    @Test
+    public void shouldLogAuditActivitiesAndNotShowDeploymentPlusSecuredResource() {
+        initRoles();
+        ModelDto modelDto = createModelDto("ActivityAudit1");
+        modelFacade.createModel(modelDto);
+
+        ToolSetDto toolSetDto = createToolSetDto();
+        toolSetFacade.createToolSet(toolSetDto);
+
+        boolean isDeploymentActivityPresent = auditActivityFacade.getAuditActivities(queryLastActivities(15)).getData().stream()
+                .anyMatch(a -> "Deployment".equals(a.getResourceType()) || "SecuredResource".equals(a.getResourceType()));
+        assertFalse(isDeploymentActivityPresent);
     }
 
     @Test
@@ -50,7 +72,7 @@ public abstract class ActivityAuditFunctionalTest {
                 new AuditActivityEntityId("Create", "Role", "roleActivityAudit1")));
 
         // create model1
-        ModelDto modelDto = createDto("ActivityAudit1");
+        ModelDto modelDto = createModelDto("ActivityAudit1");
         modelFacade.createModel(modelDto);
 
         // assert model creation
@@ -59,7 +81,7 @@ public abstract class ActivityAuditFunctionalTest {
                 new AuditActivityEntityId("Create", "Model", "modelActivityAudit1")));
 
         // update model1 description
-        ModelDto updatedModel = createDto("ActivityAudit1");
+        ModelDto updatedModel = createModelDto("ActivityAudit1");
         updatedModel.setDescription("new model description");
         updatedModel.setDefaults(Map.of());
         modelFacade.updateModel(modelDto.getName(), updatedModel, "*");
@@ -126,16 +148,15 @@ public abstract class ActivityAuditFunctionalTest {
     }
 
     private PageRequestDto queryLastActivities(int size) {
-        PageRequestDto pageRequestDto = new PageRequestDto(0, size, List.of(
+        return new PageRequestDto(0, size, List.of(
                 new SortDto("epochTimestampMs", SortDirection.DESC),
                 new SortDto("activityType", SortDirection.DESC),
                 new SortDto("resourceType", SortDirection.DESC),
                 new SortDto("resourceId", SortDirection.DESC)
         ), List.of());
-        return pageRequestDto;
     }
 
-    private ModelDto createDto(String suffix) {
+    private ModelDto createModelDto(String suffix) {
         ModelDto modelDto = new ModelDto();
         modelDto.setName("model" + suffix);
         modelDto.setDescription("description" + suffix);
@@ -143,6 +164,13 @@ public abstract class ActivityAuditFunctionalTest {
                 "role" + suffix, new LimitDto()
         ));
         return modelDto;
+    }
+
+    private ToolSetDto createToolSetDto() {
+        ToolSetDto toolSetDto = new ToolSetDto();
+        toolSetDto.setName("toolset1");
+        toolSetDto.setTransport(TransportDto.HTTP);
+        return toolSetDto;
     }
 
     private RoleDto createRoleDto(String suffix) {


### PR DESCRIPTION
### Description of changes

Added a filter for activities with resource type 'SecuredResource'.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.