### PR TITLE
fix: adjust import/export of core role limits

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapper.java
@@ -2,12 +2,15 @@ package com.epam.aidial.cfg.domain.mapper;
 
 import com.epam.aidial.cfg.domain.model.CostLimit;
 import com.epam.aidial.core.config.CoreCostLimit;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface CostLimitCoreMapper {
 
     CoreCostLimit toCoreCostLimit(CostLimit costLimit);
 
+    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
     CostLimit toCostLimit(CoreCostLimit coreCostLimit);
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
@@ -54,10 +54,9 @@ public interface RoleCoreMapper {
                     var deploymentName = entry.getKey();
                     boolean enabled = deploymentNames.contains(deploymentName);
 
-                    var roleLimit = toLimit(entry.getValue(), coreRole.getName(), deploymentName, enabled);
-                    boolean isDisabledEmptyLimit = !roleLimit.isEnabled() && roleLimit.getLimit().isEmpty();
-
-                    return isDisabledEmptyLimit ? null : roleLimit;
+                    return entry.getValue() != null
+                            ? toLimit(entry.getValue(), coreRole.getName(), deploymentName, enabled)
+                            : null;
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -18,16 +18,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.epam.aidial.cfg.utils.NullSafeUtils.getValueOrDefault;
-import static com.epam.aidial.cfg.utils.NullSafeUtils.setIfNotNull;
 
 @Mapper(componentModel = "spring")
 @Slf4j
 public abstract class RoleLimitMapper {
     public abstract Limit toLimit(CoreLimit limit);
-
-    Long getLimit(long value) {
-        return Long.MAX_VALUE == value ? null : value;
-    }
 
     @Named("mapToCoreLimits")
     public Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits, @Context Collection<Deployment> deployments) {
@@ -44,7 +39,7 @@ public abstract class RoleLimitMapper {
                     CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
                     return new AbstractMap.SimpleEntry<>(roleLimit.getDeploymentName(), mappedLimit);
                 })
-                .filter(entry -> isLimited(entry.getValue()))
+                .filter(entry -> !entry.getValue().isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
@@ -62,27 +57,13 @@ public abstract class RoleLimitMapper {
 
         CoreLimit coreLimit = new CoreLimit();
 
-        setIfNotNull(coreLimit::setMinute, getValueOrDefault(limit, defaultLimit, Limit::getMinute));
-        setIfNotNull(coreLimit::setDay, getValueOrDefault(limit, defaultLimit, Limit::getDay));
-        setIfNotNull(coreLimit::setWeek, getValueOrDefault(limit, defaultLimit, Limit::getWeek));
-        setIfNotNull(coreLimit::setMonth, getValueOrDefault(limit, defaultLimit, Limit::getMonth));
-        setIfNotNull(coreLimit::setRequestHour, getValueOrDefault(limit, defaultLimit, Limit::getRequestHour));
-        setIfNotNull(coreLimit::setRequestDay, getValueOrDefault(limit, defaultLimit, Limit::getRequestDay));
+        coreLimit.setMinute(getValueOrDefault(limit, defaultLimit, Limit::getMinute));
+        coreLimit.setDay(getValueOrDefault(limit, defaultLimit, Limit::getDay));
+        coreLimit.setWeek(getValueOrDefault(limit, defaultLimit, Limit::getWeek));
+        coreLimit.setMonth(getValueOrDefault(limit, defaultLimit, Limit::getMonth));
+        coreLimit.setRequestHour(getValueOrDefault(limit, defaultLimit, Limit::getRequestHour));
+        coreLimit.setRequestDay(getValueOrDefault(limit, defaultLimit, Limit::getRequestDay));
 
         return coreLimit;
     }
-
-    private boolean isLimited(CoreLimit limit) {
-        return isLimited(limit.getMinute())
-                || isLimited(limit.getDay())
-                || isLimited(limit.getWeek())
-                || isLimited(limit.getMonth())
-                || isLimited(limit.getRequestHour())
-                || isLimited(limit.getRequestDay());
-    }
-
-    private boolean isLimited(Long value) {
-        return value != Long.MAX_VALUE;
-    }
-
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -45,6 +45,7 @@ public abstract class RoleLimitMapper {
                     CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
 
                     if (!mappedLimit.isEmpty()) {
+                        mappedLimit = mappedLimit.isUnlimited() ? CoreLimit.empty() : mappedLimit;
                         result.put(roleLimit.getDeploymentName(), mappedLimit);
                     }
                 });

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -10,8 +10,8 @@ import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
 
-import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -26,21 +26,30 @@ public abstract class RoleLimitMapper {
 
     @Named("mapToCoreLimits")
     public Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits, @Context Collection<Deployment> deployments) {
-        if (roleLimits == null) {
-            return Map.of();
-        }
+        Map<String, CoreLimit> result = new HashMap<>();
+
+        CollectionUtils.emptyIfNull(deployments).stream()
+                .filter(Deployment::getIsPublic)
+                .filter(deployment -> !deployment.getDefaultRoleLimit().isEmpty())
+                .forEach(deployment -> {
+                    CoreLimit mappedLimit = mapLimit(new Limit(), deployment);
+                    result.put(deployment.getName(), mappedLimit);
+                });
 
         Map<String, Deployment> deploymentsByName = CollectionUtils.emptyIfNull(deployments).stream()
                 .collect(Collectors.toMap(Deployment::getName, Function.identity()));
 
-        return roleLimits.stream()
-                .map(roleLimit -> {
+        CollectionUtils.emptyIfNull(roleLimits)
+                .forEach(roleLimit -> {
                     Deployment deployment = deploymentsByName.get(roleLimit.getDeploymentName());
                     CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
-                    return new AbstractMap.SimpleEntry<>(roleLimit.getDeploymentName(), mappedLimit);
-                })
-                .filter(entry -> !entry.getValue().isEmpty())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                    if (!mappedLimit.isEmpty()) {
+                        result.put(roleLimit.getDeploymentName(), mappedLimit);
+                    }
+                });
+
+        return result;
     }
 
     private CoreLimit mapLimit(Limit limit, Deployment deployment) {

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 @Data
@@ -10,4 +11,9 @@ public class Limit {
     private Long month;
     private Long requestHour;
     private Long requestDay;
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return minute == null && day == null && week == null && month == null && requestHour == null && requestDay == null;
+    }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Limit.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.domain.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 @Data
@@ -11,9 +10,4 @@ public class Limit {
     private Long month;
     private Long requestHour;
     private Long requestDay;
-
-    @JsonIgnore
-    public boolean isEmpty() {
-        return minute == null && day == null && week == null && month == null && requestHour == null && requestDay == null;
-    }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
@@ -6,7 +6,6 @@ import com.epam.aidial.cfg.domain.service.RoleService;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.core.config.Assistants;
 import com.epam.aidial.core.config.Config;
-import com.epam.aidial.core.config.CoreCostLimit;
 import com.epam.aidial.core.config.CoreLimit;
 import com.epam.aidial.core.config.CoreRole;
 import lombok.RequiredArgsConstructor;
@@ -44,9 +43,6 @@ public class CoreRolesMerger {
         for (String roleName : allRoleNames) {
             CoreRole coreRole = resolveCoreRole(roleName, roles, createRoleIfAbsent);
             coreRole.setName(roleName);
-            if (coreRole.getCostLimit() == null) {
-                coreRole.setCostLimit(new CoreCostLimit());
-            }
             addRoleLimitsFromUserRoles(coreRole, deploymentNamesByUserRole);
 
             Role role = roleCoreMapper.mapToRole(coreRole, deploymentNamesByUserRole);
@@ -90,11 +86,11 @@ public class CoreRolesMerger {
     }
 
     private void addRoleLimitsFromUserRoles(CoreRole coreRole, Map<String, Set<String>> deploymentNamesByUserRole) {
-        Map<String, CoreLimit> limits = new HashMap<>(coreRole.getLimits());
+        Map<String, CoreLimit> limits = new HashMap<>(MapUtils.emptyIfNull(coreRole.getLimits()));
         Set<String> deploymentNames = SetUtils.emptyIfNull(deploymentNamesByUserRole.get(coreRole.getName()));
 
         for (String deploymentName : deploymentNames) {
-            limits.putIfAbsent(deploymentName, new CoreLimit());
+            limits.putIfAbsent(deploymentName, CoreLimit.empty());
         }
 
         coreRole.setLimits(limits);

--- a/src/main/java/com/epam/aidial/core/config/CoreLimit.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreLimit.java
@@ -35,4 +35,19 @@ public class CoreLimit {
     public boolean isEmpty() {
         return minute == null && day == null && week == null && month == null && requestDay == null && requestHour == null;
     }
+
+    @JsonIgnore
+    public boolean isUnlimited() {
+        return isUnlimited(minute)
+                || isUnlimited(day)
+                || isUnlimited(week)
+                || isUnlimited(month)
+                || isUnlimited(requestHour)
+                || isUnlimited(requestDay);
+    }
+
+    @JsonIgnore
+    private boolean isUnlimited(Long value) {
+        return value != null && value == Long.MAX_VALUE;
+    }
 }

--- a/src/main/java/com/epam/aidial/core/config/CoreLimit.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreLimit.java
@@ -5,15 +5,34 @@ import lombok.Data;
 
 @Data
 public class CoreLimit {
-    private long minute = Long.MAX_VALUE;
-    private long day = Long.MAX_VALUE;
-    private long week = Long.MAX_VALUE;
-    private long month = Long.MAX_VALUE;
-    private long requestHour = Long.MAX_VALUE;
-    private long requestDay = Long.MAX_VALUE;
+    private Long minute = Long.MAX_VALUE;
+    private Long day = Long.MAX_VALUE;
+    private Long week = Long.MAX_VALUE;
+    private Long month = Long.MAX_VALUE;
+    private Long requestHour = Long.MAX_VALUE;
+    private Long requestDay = Long.MAX_VALUE;
 
     @JsonIgnore
     public boolean isPositive() {
         return minute > 0 && day > 0 && week > 0 && month > 0 && requestDay > 0 && requestHour > 0;
+    }
+
+    @JsonIgnore
+    public static CoreLimit empty() {
+        CoreLimit coreLimit = new CoreLimit();
+
+        coreLimit.setMinute(null);
+        coreLimit.setDay(null);
+        coreLimit.setWeek(null);
+        coreLimit.setMonth(null);
+        coreLimit.setRequestHour(null);
+        coreLimit.setRequestDay(null);
+
+        return coreLimit;
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return minute == null && day == null && week == null && month == null && requestDay == null && requestHour == null;
     }
 }

--- a/src/main/java/com/epam/aidial/core/config/CoreLimit.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreLimit.java
@@ -39,11 +39,11 @@ public class CoreLimit {
     @JsonIgnore
     public boolean isUnlimited() {
         return isUnlimited(minute)
-                || isUnlimited(day)
-                || isUnlimited(week)
-                || isUnlimited(month)
-                || isUnlimited(requestHour)
-                || isUnlimited(requestDay);
+                && isUnlimited(day)
+                && isUnlimited(week)
+                && isUnlimited(month)
+                && isUnlimited(requestHour)
+                && isUnlimited(requestDay);
     }
 
     @JsonIgnore

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
@@ -47,8 +47,8 @@ class RoleCoreMapperTest {
         deployment.setDefaultRoleLimit(new Limit());
         deployment.setRoleLimits(List.of(roleLimit));
 
-        CoreLimit expectedLimit = new CoreLimit();
-        expectedLimit.setDay(10);
+        CoreLimit expectedLimit = CoreLimit.empty();
+        expectedLimit.setDay(10L);
 
         CoreRole expected = new CoreRole();
         expected.setName("testRole");

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -170,22 +170,26 @@ public abstract class ConfigTransferFunctionalTest {
         Map<String, ModelDto> models = modelFacade.getAll().stream().collect(Collectors.toMap(ModelDto::getName, a -> a));
         Assertions.assertThat(models).containsOnlyKeys("testModel1", "testModel2");
         Assertions.assertThat(models.get("testModel1")).satisfies(modelDto -> {
-            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole3", "default");
+            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole2", "testRole3", "default");
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole1")).satisfies(limit1 -> {
                 Assertions.assertThat(limit1.isEnabled()).isTrue();
                 Assertions.assertThat(limit1.getDay()).isEqualTo(1);
-                Assertions.assertThat(limit1.getMinute()).isNull();
+                Assertions.assertThat(limit1.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
-            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2")).isNull();
+            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2")).satisfies(limit2 -> {
+                Assertions.assertThat(limit2.isEnabled()).isFalse();
+                Assertions.assertThat(limit2.getDay()).isEqualTo(Long.MAX_VALUE);
+                Assertions.assertThat(limit2.getMinute()).isEqualTo(Long.MAX_VALUE);
+            });
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole3")).satisfies(limit3 -> {
                 Assertions.assertThat(limit3.isEnabled()).isTrue();
-                Assertions.assertThat(limit3.getDay()).isNull();
-                Assertions.assertThat(limit3.getMinute()).isNull();
+                Assertions.assertThat(limit3.getDay()).isEqualTo(Long.MAX_VALUE);
+                Assertions.assertThat(limit3.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
             Assertions.assertThat(modelDto.getRoleLimits().get("default")).satisfies(limitDefault -> {
                 Assertions.assertThat(limitDefault.isEnabled()).isFalse();
                 Assertions.assertThat(limitDefault.getDay()).isEqualTo(3);
-                Assertions.assertThat(limitDefault.getMinute()).isNull();
+                Assertions.assertThat(limitDefault.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
             Assertions.assertThat(modelDto.getInterceptors()).isNotEmpty()
                     .hasSize(1).first().isEqualTo("testInterceptor1");
@@ -1612,7 +1616,7 @@ public abstract class ConfigTransferFunctionalTest {
         ModelDto modelDto = modelFacade.getModel("testModel1");
         Assertions.assertThat(modelDto).isNotNull().satisfies(importedModel ->
                 Assertions.assertThat(importedModel.getRoleLimits().get("testRole1")).isNotNull().satisfies(roleLimit -> {
-                    Assertions.assertThat(roleLimit.getMinute()).isNull();
+                    Assertions.assertThat(roleLimit.getMinute()).isEqualTo(Long.MAX_VALUE);
                     Assertions.assertThat(roleLimit.getDay()).isEqualTo(1L);
                 })
         );

--- a/src/test/resources/domain/config/config_only_roles.json
+++ b/src/test/resources/domain/config/config_only_roles.json
@@ -20,20 +20,12 @@
           "requestDay": 2000
         },
         "sampleDeployment2": {
-          "minute": 23,
-          "day": 9223372036854775807,
-          "week": 9223372036854775807,
-          "month": 9223372036854775807,
-          "requestHour": 9223372036854775807,
-          "requestDay": 9223372036854775807
+          "minute": 23
         },
         "sampleDeployment4": {
           "minute": 20,
           "day": 2000,
-          "week": 9223372036854775807,
-          "month": 1000,
-          "requestHour": 9223372036854775807,
-          "requestDay": 9223372036854775807
+          "month": 1000
         }
       },
       "share": {},

--- a/src/test/resources/domain/config/config_only_roles.json
+++ b/src/test/resources/domain/config/config_only_roles.json
@@ -26,7 +26,8 @@
           "minute": 20,
           "day": 2000,
           "month": 1000
-        }
+        },
+        "sampleDeployment5": {}
       },
       "share": {},
       "costLimit": {

--- a/src/test/resources/domain/model/deployments_for_roles.json
+++ b/src/test/resources/domain/model/deployments_for_roles.json
@@ -19,5 +19,9 @@
       "day": 23,
       "month": 1000
     }
+  },
+  {
+    "name": "sampleDeployment5",
+    "defaultRoleLimit": {}
   }
 ]

--- a/src/test/resources/domain/model/roles.json
+++ b/src/test/resources/domain/model/roles.json
@@ -37,6 +37,19 @@
           "minute": 20,
           "day": 2000
         }
+      },
+      {
+        "role": "admin",
+        "deploymentName": "sampleDeployment5",
+        "enabled": true,
+        "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        }
       }
     ],
     "roles": [],

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
@@ -5,13 +5,81 @@
     "testModel1": {
       "userRoles": [
         "userRole",
+        "userRoleInRolesSectionWithoutLimits",
+        "userRoleInRolesSectionWithNullLimits",
+        "userRoleInRolesSectionWithEmptyLimits",
+        "userRoleInRolesSectionWithNullLimit",
         "userRoleInRolesSectionWithEmptyLimit",
         "userRoleInRolesSectionWithNonEmptyLimit"
       ]
     }
   },
   "roles": {
+    "userRoleInRolesSectionWithoutLimits": {
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      },
+      "costLimit": {
+        "minute": "111",
+        "day": "222",
+        "week": "333",
+        "month": "444"
+      }
+    },
+    "userRoleInRolesSectionWithNullLimits": {
+      "limits": null,
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      },
+      "costLimit": {
+        "minute": "111",
+        "day": "222",
+        "week": "333",
+        "month": "444"
+      }
+    },
+    "userRoleInRolesSectionWithEmptyLimits": {
+      "limits": {},
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      },
+      "costLimit": {
+        "minute": "111",
+        "day": "222",
+        "week": "333",
+        "month": "444"
+      }
+    },
+    "userRoleInRolesSectionWithNullLimit": {
+      "limits": {
+        "testModel1": null
+      },
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      },
+      "costLimit": {
+        "minute": "111",
+        "day": "222",
+        "week": "333",
+        "month": "444"
+      }
+    },
     "userRoleInRolesSectionWithEmptyLimit": {
+      "limits": {
+        "testModel1": {}
+      },
       "share": {
         "testModel1": {
           "maxAcceptedUsers": 10,
@@ -38,7 +106,47 @@
         "month": "9223372036854775807"
       }
     },
+    "roleInRolesSectionWithoutLimits": {
+      "costLimit": {
+        "minute": "9223372036854775807",
+        "day": "9223372036854775807",
+        "week": "9223372036854775807",
+        "month": "9223372036854775807"
+      }
+    },
+    "roleInRolesSectionWithNullLimits": {
+      "limits": null,
+      "costLimit": {
+        "minute": "9223372036854775807",
+        "day": "9223372036854775807",
+        "week": "9223372036854775807",
+        "month": "9223372036854775807"
+      }
+    },
+    "roleInRolesSectionWithEmptyLimits": {
+      "limits": {},
+      "costLimit": {
+        "minute": "9223372036854775807",
+        "day": "9223372036854775807",
+        "week": "9223372036854775807",
+        "month": "9223372036854775807"
+      }
+    },
+    "roleInRolesSectionWithNullLimit": {
+      "limits": {
+        "testModel1": null
+      },
+      "costLimit": {
+        "minute": "9223372036854775807",
+        "day": "9223372036854775807",
+        "week": "9223372036854775807",
+        "month": "9223372036854775807"
+      }
+    },
     "roleInRolesSectionWithEmptyLimit": {
+      "limits": {
+        "testModel1": {}
+      },
       "costLimit": {
         "minute": "9223372036854775807",
         "day": "9223372036854775807",

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
@@ -1,4 +1,112 @@
 {
+  "userRoleInRolesSectionWithoutLimits": {
+    "name": "userRoleInRolesSectionWithoutLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithoutLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithoutLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ],
+    "costLimit": {
+      "minute": "111",
+      "day": "222",
+      "week": "333",
+      "month": "444"
+    }
+  },
+  "userRoleInRolesSectionWithNullLimits": {
+    "name": "userRoleInRolesSectionWithNullLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ],
+    "costLimit": {
+      "minute": "111",
+      "day": "222",
+      "week": "333",
+      "month": "444"
+    }
+  },
+  "userRoleInRolesSectionWithEmptyLimits": {
+    "name": "userRoleInRolesSectionWithEmptyLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithEmptyLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithEmptyLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ],
+    "costLimit": {
+      "minute": "111",
+      "day": "222",
+      "week": "333",
+      "month": "444"
+    }
+  },
+  "userRoleInRolesSectionWithNullLimit": {
+    "name": "userRoleInRolesSectionWithNullLimit",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimit",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimit",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ],
+    "costLimit": {
+      "minute": "111",
+      "day": "222",
+      "week": "333",
+      "month": "444"
+    }
+  },
   "userRoleInRolesSectionWithEmptyLimit": {
     "name": "userRoleInRolesSectionWithEmptyLimit",
     "limits": [
@@ -6,7 +114,14 @@
         "role": "userRoleInRolesSectionWithEmptyLimit",
         "deploymentName": "testModel1",
         "enabled": true,
-        "limit": {}
+        "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        }
       }
     ],
     "share": [
@@ -34,7 +149,12 @@
         "deploymentName": "testModel1",
         "enabled": true,
         "limit": {
-          "day": 5
+          "minute": 9223372036854775807,
+          "day": 5,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       }
     ],
@@ -46,9 +166,67 @@
       "month": "9223372036854775807"
     }
   },
+  "roleInRolesSectionWithoutLimits": {
+    "name": "roleInRolesSectionWithoutLimits",
+    "limits": [],
+    "share": [],
+    "costLimit": {
+      "minute": "9223372036854775807",
+      "day": "9223372036854775807",
+      "week": "9223372036854775807",
+      "month": "9223372036854775807"
+    }
+  },
+  "roleInRolesSectionWithNullLimits": {
+    "name": "roleInRolesSectionWithNullLimits",
+    "limits": [],
+    "share": [],
+    "costLimit": {
+      "minute": "9223372036854775807",
+      "day": "9223372036854775807",
+      "week": "9223372036854775807",
+      "month": "9223372036854775807"
+    }
+  },
+  "roleInRolesSectionWithEmptyLimits": {
+    "name": "roleInRolesSectionWithEmptyLimits",
+    "limits": [],
+    "share": [],
+    "costLimit": {
+      "minute": "9223372036854775807",
+      "day": "9223372036854775807",
+      "week": "9223372036854775807",
+      "month": "9223372036854775807"
+    }
+  },
+  "roleInRolesSectionWithNullLimit": {
+    "name": "roleInRolesSectionWithNullLimit",
+    "limits": [],
+    "share": [],
+    "costLimit": {
+      "minute": "9223372036854775807",
+      "day": "9223372036854775807",
+      "week": "9223372036854775807",
+      "month": "9223372036854775807"
+    }
+  },
   "roleInRolesSectionWithEmptyLimit": {
     "name": "roleInRolesSectionWithEmptyLimit",
-    "limits": [],
+    "limits": [
+      {
+        "role": "roleInRolesSectionWithEmptyLimit",
+        "deploymentName": "testModel1",
+        "enabled": false,
+        "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        }
+      }
+    ],
     "share": [],
     "costLimit": {
       "minute": "9223372036854775807",
@@ -65,8 +243,12 @@
         "deploymentName": "testModel1",
         "enabled": false,
         "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
           "week": 120,
-          "month": 500
+          "month": 500,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       }
     ],

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -13,23 +13,55 @@
           },
           {
             "role": "testRole1",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole1",
             "deploymentName": "testApplication1",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           },
           {
             "role": "testRole1",
             "deploymentName": "testModel1",
             "enabled": true,
             "limit": {
-              "day": 1
+              "minute": 9223372036854775807,
+              "day": 1,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
             }
           },
           {
             "role": "testRole1",
             "deploymentName": "testApplication2",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           },
           {
             "role": "testRole1",
@@ -60,7 +92,60 @@
       "importAction": "create",
       "value": {
         "name": "testRole2",
-        "limits": [],
+        "limits": [
+          {
+            "role": "testRole2",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testModel1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          }
+        ],
         "share": [],
         "costLimit": {
           "minute": "111",
@@ -77,9 +162,55 @@
         "limits": [
           {
             "role": "testRole3",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
             "deploymentName": "testModel1",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           }
         ],
         "share": [],
@@ -98,10 +229,54 @@
         "limits": [
           {
             "role": "default",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
             "deploymentName": "testModel1",
             "enabled": false,
             "limit": {
-              "day": 3
+              "minute": 9223372036854775807,
+              "day": 3,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
             }
           }
         ],
@@ -329,7 +504,60 @@
       "value": {
         "deployment": {
           "name": "testModel2",
-          "roleLimits": [],
+          "roleLimits": [
+            {
+              "role": "testRole1",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            }
+          ],
           "roleShareResourceLimits": [],
           "isPublic": true,
           "defaultRoleLimit": {},
@@ -389,21 +617,51 @@
               "deploymentName": "testModel1",
               "enabled": true,
               "limit": {
-                "day": 1
+                "minute": 9223372036854775807,
+                "day": 1,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testModel1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
               }
             },
             {
               "role": "testRole3",
               "deploymentName": "testModel1",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             },
             {
               "role": "default",
               "deploymentName": "testModel1",
               "enabled": false,
               "limit": {
-                "day": 3
+                "minute": 9223372036854775807,
+                "day": 3,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
               }
             }
           ],
@@ -477,7 +735,53 @@
               "role": "testRole1",
               "deploymentName": "testApplication1",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             }
           ],
           "roleShareResourceLimits": [],
@@ -530,7 +834,53 @@
               "role": "testRole1",
               "deploymentName": "testApplication2",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             }
           ],
           "roleShareResourceLimits": [],

--- a/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
@@ -3,24 +3,40 @@
     "minute": 9223372036854775807,
     "day": 10,
     "week": 9223372036854775807,
-    "month": 9223372036854775807,
-    "requestHour": 9223372036854775807,
-    "requestDay": 9223372036854775807
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
   },
   "deployment2": {
-    "minute": 9223372036854775807,
+    "minute": null,
     "day": 5,
-    "week": 9223372036854775807,
-    "month": 9223372036854775807,
-    "requestHour": 9223372036854775807,
-    "requestDay": 9223372036854775807
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "deployment3": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
   },
   "deployment5": {
-    "minute": 9223372036854775807,
+    "minute": null,
     "day": 5,
-    "week": 9223372036854775807,
-    "month": 9223372036854775807,
-    "requestHour": 9223372036854775807,
-    "requestDay": 9223372036854775807
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "deployment6": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
   }
 }

--- a/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
@@ -1,13 +1,13 @@
 {
-  "deployment1": {
-    "minute": 9223372036854775807,
+  "privateDeploymentWithDefaultDayForLimitWithoutDay": {
+    "minute": null,
     "day": 10,
-    "week": 9223372036854775807,
+    "week": null,
     "month": null,
     "requestHour": null,
     "requestDay": null
   },
-  "deployment2": {
+  "privateDeploymentWithDefaultDayForLimitWithDay": {
     "minute": null,
     "day": 5,
     "week": null,
@@ -15,7 +15,7 @@
     "requestHour": null,
     "requestDay": null
   },
-  "deployment3": {
+  "privateDeploymentWithDefaultDayForLimitWithMaxDay": {
     "minute": null,
     "day": 9223372036854775807,
     "week": null,
@@ -23,7 +23,7 @@
     "requestHour": null,
     "requestDay": null
   },
-  "deployment5": {
+  "privateDeploymentWithoutDefaultDayForLimitWithDay": {
     "minute": null,
     "day": 5,
     "week": null,
@@ -31,7 +31,47 @@
     "requestHour": null,
     "requestDay": null
   },
-  "deployment6": {
+  "privateDeploymentWithoutDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayWithoutLimit": {
+    "minute": null,
+    "day": 10,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithoutDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithoutDefaultDayForLimitWithMaxDay": {
     "minute": null,
     "day": 9223372036854775807,
     "week": null,

--- a/src/test/resources/mapper/core/role_limit/map_limits/deployments.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/deployments.json
@@ -1,34 +1,74 @@
 [
   {
-    "name": "deployment1",
-    "defaultRoleLimit": {
-      "minute": 9223372036854775807,
-      "day": 10,
-      "week": 9223372036854775807
-    }
-  },
-  {
-    "name": "deployment2",
+    "name": "privateDeploymentWithDefaultDayForLimitWithoutDay",
     "defaultRoleLimit": {
       "day": 10
-    }
+    },
+    "isPublic": false
   },
   {
-    "name": "deployment3",
+    "name": "privateDeploymentWithDefaultDayForLimitWithDay",
     "defaultRoleLimit": {
       "day": 10
-    }
+    },
+    "isPublic": false
   },
   {
-    "name": "deployment4",
-    "defaultRoleLimit": {}
+    "name": "privateDeploymentWithDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": false
   },
   {
-    "name": "deployment5",
-    "defaultRoleLimit": {}
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithoutDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
   },
   {
-    "name": "deployment6",
-    "defaultRoleLimit": {}
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayWithoutLimit",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayWithoutLimit",
+    "defaultRoleLimit": {},
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {},
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {},
+    "isPublic": true
   }
 ]

--- a/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
@@ -1,38 +1,66 @@
 [
   {
     "role": "role1",
-    "deploymentName": "deployment1",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithoutDay",
     "limit": {}
   },
   {
     "role": "role1",
-    "deploymentName": "deployment2",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithDay",
     "limit": {
       "day": 5
     }
   },
   {
     "role": "role1",
-    "deploymentName": "deployment3",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithMaxDay",
     "limit": {
       "day": 9223372036854775807
     }
   },
   {
     "role": "role1",
-    "deploymentName": "deployment4",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithoutDay",
     "limit": {}
   },
   {
     "role": "role1",
-    "deploymentName": "deployment5",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithDay",
     "limit": {
       "day": 5
     }
   },
   {
     "role": "role1",
-    "deploymentName": "deployment6",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithoutDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithoutDefaultDayForLimitWithMaxDay",
     "limit": {
       "day": 9223372036854775807
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #302

### Description of changes
- Max values of core role limits are saved as max values instead of nulls during import of core config
- Imaginary limits for user roles (which are not explicitly specified in config) are saved as empty role limits (all values are nulls) during import of core config
- Export of core config includes role limits for public deployments which have default limits, even if such role limits are not saved in DB
- Export of core config transforms unlimited limits (all values are Max values) to empty limits
- Export of core config excludes empty role limits (all values are nulls).

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.