### PR TITLE
chore: increase io.grpc:grpc-netty-shaded transitive dependency version from 1.70.0 to 1.75.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,9 @@ dependencies {
         implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
             because("previous versions have vulnerabilities")
         }
+        implementation("io.grpc:grpc-netty-shaded:1.75.0") {
+                because("previous versions have vulnerabilities)")
+        }
         implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Increase io.grpc:grpc-netty-shaded transitive dependency version from 1.70.0 to 1.75.0

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.