### PR TITLE
hotfix: adjust role limits import/export and exclude role share from core export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ buildscript {
             classpath ('org.apache.commons:commons-lang3:3.18.0') {
                 because("previous versions have vulnerabilities")
             }
+            classpath ('org.springframework:spring-core:6.2.11') {
+                because("previous versions have vulnerabilities")
+            }
         }
     }
 }
@@ -180,6 +183,9 @@ dependencies {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.springframework:spring-webmvc:6.2.10') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('org.springframework:spring-core:6.2.11') {
             because("previous versions have vulnerabilities")
         }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
@@ -52,10 +52,9 @@ public interface RoleCoreMapper {
                     var deploymentName = entry.getKey();
                     boolean enabled = deploymentNames.contains(deploymentName);
 
-                    var roleLimit = toLimit(entry.getValue(), coreRole.getName(), deploymentName, enabled);
-                    boolean isDisabledEmptyLimit = !roleLimit.isEnabled() && roleLimit.getLimit().isEmpty();
-
-                    return isDisabledEmptyLimit ? null : roleLimit;
+                    return entry.getValue() != null
+                            ? toLimit(entry.getValue(), coreRole.getName(), deploymentName, enabled)
+                            : null;
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapper.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 public interface RoleCoreMapper {
 
     @Mapping(target = "limits", qualifiedByName = "mapToCoreLimits")
+    @Mapping(target = "share", ignore = true)
     CoreRole mapRole(Role role, @Context Collection<Deployment> deployments);
 
     @Mapping(target = "keys", ignore = true)

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -4,90 +4,79 @@ import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Limit;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.core.config.CoreLimit;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
 
-import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
-public interface RoleLimitMapper {
-    Limit toLimit(CoreLimit limit);
-
-    default Long getLimit(long value) {
-        return Long.MAX_VALUE == value ? null : value;
-    }
+@Slf4j
+public abstract class RoleLimitMapper {
+    public abstract Limit toLimit(CoreLimit limit);
 
     @Named("mapToCoreLimits")
-    default Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits, @Context Collection<Deployment> deployments) {
-        if (roleLimits == null) {
-            return Map.of();
-        }
+    public Map<String, CoreLimit> mapLimits(List<RoleLimit> roleLimits, @Context Collection<Deployment> deployments) {
+        Map<String, CoreLimit> result = new HashMap<>();
+
+        CollectionUtils.emptyIfNull(deployments).stream()
+                .filter(Deployment::getIsPublic)
+                .filter(deployment -> !deployment.getDefaultRoleLimit().isEmpty())
+                .forEach(deployment -> {
+                    CoreLimit mappedLimit = mapLimit(new Limit(), deployment);
+                    result.put(deployment.getName(), mappedLimit);
+                });
 
         Map<String, Deployment> deploymentsByName = CollectionUtils.emptyIfNull(deployments).stream()
                 .collect(Collectors.toMap(Deployment::getName, Function.identity()));
 
-        return roleLimits.stream()
-                .map(roleLimit -> {
+        CollectionUtils.emptyIfNull(roleLimits)
+                .forEach(roleLimit -> {
                     Deployment deployment = deploymentsByName.get(roleLimit.getDeploymentName());
                     CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
-                    return mappedLimit != null ? new AbstractMap.SimpleEntry<>(roleLimit.getDeploymentName(), mappedLimit) : null;
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                    if (!mappedLimit.isEmpty()) {
+                        mappedLimit = mappedLimit.isUnlimited() ? CoreLimit.empty() : mappedLimit;
+                        result.put(roleLimit.getDeploymentName(), mappedLimit);
+                    }
+                });
+
+        return result;
     }
 
     private CoreLimit mapLimit(Limit limit, Deployment deployment) {
         if (limit == null || deployment == null) {
-            return null;
+            log.warn("Limit or deployment is null. Limit: {}, deployment: {}", limit, deployment);
+            throw new IllegalStateException("Limit or deployment is null");
         }
 
-        Limit defaultLimit = Optional.ofNullable(deployment.getDefaultRoleLimit()).orElse(new Limit());
-        if (isUnlimited(limit) && defaultLimit.isEmpty()) {
-            return null;
+        Limit defaultLimit = deployment.getDefaultRoleLimit();
+        if (defaultLimit == null) {
+            log.warn("Deployment default limit is null. Deployment: {}", deployment);
+            throw new IllegalStateException("Deployment default limit is null");
         }
 
         CoreLimit coreLimit = new CoreLimit();
-        setIfNotNull(coreLimit::setMinute, getLimitOrDefault(limit, defaultLimit, Limit::getMinute));
-        setIfNotNull(coreLimit::setDay, getLimitOrDefault(limit, defaultLimit, Limit::getDay));
-        setIfNotNull(coreLimit::setWeek, getLimitOrDefault(limit, defaultLimit, Limit::getWeek));
-        setIfNotNull(coreLimit::setMonth, getLimitOrDefault(limit, defaultLimit, Limit::getMonth));
-        setIfNotNull(coreLimit::setRequestHour, getLimitOrDefault(limit, defaultLimit, Limit::getRequestHour));
-        setIfNotNull(coreLimit::setRequestDay, getLimitOrDefault(limit, defaultLimit, Limit::getRequestDay));
+
+        coreLimit.setMinute(getValueOrDefault(limit, defaultLimit, Limit::getMinute));
+        coreLimit.setDay(getValueOrDefault(limit, defaultLimit, Limit::getDay));
+        coreLimit.setWeek(getValueOrDefault(limit, defaultLimit, Limit::getWeek));
+        coreLimit.setMonth(getValueOrDefault(limit, defaultLimit, Limit::getMonth));
+        coreLimit.setRequestHour(getValueOrDefault(limit, defaultLimit, Limit::getRequestHour));
+        coreLimit.setRequestDay(getValueOrDefault(limit, defaultLimit, Limit::getRequestDay));
+
         return coreLimit;
     }
 
-    private <T> void setIfNotNull(Consumer<T> setter, T value) {
-        if (value != null) {
-            setter.accept(value);
-        }
-    }
-
-    private Long getLimitOrDefault(Limit limit, Limit defaultLimit, Function<Limit, Long> limitValueGetter) {
+    private Long getValueOrDefault(Limit limit, Limit defaultLimit, Function<Limit, Long> limitValueGetter) {
         Long limitValue = limitValueGetter.apply(limit);
-        return isUnlimited(limitValue) ? limitValueGetter.apply(defaultLimit) : limitValue;
+        return limitValue == null ? limitValueGetter.apply(defaultLimit) : limitValue;
     }
-
-    private boolean isUnlimited(Limit limit) {
-        return isUnlimited(limit.getMinute())
-                && isUnlimited(limit.getDay())
-                && isUnlimited(limit.getWeek())
-                && isUnlimited(limit.getMonth())
-                && isUnlimited(limit.getRequestHour())
-                && isUnlimited(limit.getRequestDay());
-    }
-
-    private boolean isUnlimited(Long value) {
-        return value == null || value == Long.MAX_VALUE;
-    }
-
 }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMerger.java
@@ -9,6 +9,7 @@ import com.epam.aidial.core.config.CoreLimit;
 import com.epam.aidial.core.config.CoreRole;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 
@@ -81,11 +82,11 @@ public class CoreRolesMerger {
     }
 
     private void addRoleLimitsFromUserRoles(CoreRole coreRole, Map<String, Set<String>> deploymentNamesByUserRole) {
-        Map<String, CoreLimit> limits = new HashMap<>(coreRole.getLimits());
+        Map<String, CoreLimit> limits = new HashMap<>(MapUtils.emptyIfNull(coreRole.getLimits()));
         Set<String> deploymentNames = SetUtils.emptyIfNull(deploymentNamesByUserRole.get(coreRole.getName()));
 
         for (String deploymentName : deploymentNames) {
-            limits.putIfAbsent(deploymentName, new CoreLimit());
+            limits.putIfAbsent(deploymentName, CoreLimit.empty());
         }
 
         coreRole.setLimits(limits);

--- a/src/main/java/com/epam/aidial/core/config/CoreLimit.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreLimit.java
@@ -5,15 +5,49 @@ import lombok.Data;
 
 @Data
 public class CoreLimit {
-    private long minute = Long.MAX_VALUE;
-    private long day = Long.MAX_VALUE;
-    private long week = Long.MAX_VALUE;
-    private long month = Long.MAX_VALUE;
-    private long requestHour = Long.MAX_VALUE;
-    private long requestDay = Long.MAX_VALUE;
+    private Long minute = Long.MAX_VALUE;
+    private Long day = Long.MAX_VALUE;
+    private Long week = Long.MAX_VALUE;
+    private Long month = Long.MAX_VALUE;
+    private Long requestHour = Long.MAX_VALUE;
+    private Long requestDay = Long.MAX_VALUE;
 
     @JsonIgnore
     public boolean isPositive() {
         return minute > 0 && day > 0 && week > 0 && month > 0 && requestDay > 0 && requestHour > 0;
+    }
+
+    @JsonIgnore
+    public static CoreLimit empty() {
+        CoreLimit coreLimit = new CoreLimit();
+
+        coreLimit.setMinute(null);
+        coreLimit.setDay(null);
+        coreLimit.setWeek(null);
+        coreLimit.setMonth(null);
+        coreLimit.setRequestHour(null);
+        coreLimit.setRequestDay(null);
+
+        return coreLimit;
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return minute == null && day == null && week == null && month == null && requestDay == null && requestHour == null;
+    }
+
+    @JsonIgnore
+    public boolean isUnlimited() {
+        return isUnlimited(minute)
+                && isUnlimited(day)
+                && isUnlimited(week)
+                && isUnlimited(month)
+                && isUnlimited(requestHour)
+                && isUnlimited(requestDay);
+    }
+
+    @JsonIgnore
+    private boolean isUnlimited(Long value) {
+        return value != null && value == Long.MAX_VALUE;
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
@@ -1,8 +1,10 @@
 package com.epam.aidial.cfg.domain.mapper;
 
+import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Limit;
 import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
+import com.epam.aidial.core.config.CoreLimit;
 import com.epam.aidial.core.config.CoreRole;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
+import java.util.Map;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
@@ -27,19 +30,34 @@ class RoleCoreMapperTest {
     @Test
     void mapRole() {
         // given
-        Role role = new Role();
-        role.setName("testRole");
         Limit limit = new Limit();
+        limit.setDay(10L);
+
         RoleLimit roleLimit = new RoleLimit();
+        roleLimit.setRole("testRole");
         roleLimit.setDeploymentName("testModel");
         roleLimit.setLimit(limit);
+
+        Role role = new Role();
+        role.setName("testRole");
         role.setLimits(List.of(roleLimit));
+
+        Deployment deployment = new Deployment("testModel");
+        deployment.setDefaultRoleLimit(new Limit());
+        deployment.setRoleLimits(List.of(roleLimit));
+
+        CoreLimit expectedLimit = CoreLimit.empty();
+        expectedLimit.setDay(10L);
+
+        CoreRole expected = new CoreRole();
+        expected.setName("testRole");
+        expected.setLimits(Map.of("testModel", expectedLimit));
+        expected.setShare(Map.of());
+
         // when
-        CoreRole result = mapper.mapRole(role, List.of());
+        CoreRole result = mapper.mapRole(role, List.of(deployment));
+
         // then
-        Assertions.assertThat(result).isNotNull().satisfies(coreRole -> {
-            Assertions.assertThat(coreRole.getName()).isEqualTo("testRole");
-            Assertions.assertThat(coreRole.getLimits()).isEmpty();
-        });
+        Assertions.assertThat(result).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
@@ -52,7 +52,6 @@ class RoleCoreMapperTest {
         CoreRole expected = new CoreRole();
         expected.setName("testRole");
         expected.setLimits(Map.of("testModel", expectedLimit));
-        expected.setShare(Map.of());
 
         // when
         CoreRole result = mapper.mapRole(role, List.of(deployment));

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -162,22 +162,26 @@ public abstract class ConfigTransferFunctionalTest {
         Map<String, ModelDto> models = modelFacade.getAll().stream().collect(Collectors.toMap(ModelDto::getName, a -> a));
         Assertions.assertThat(models).containsOnlyKeys("testModel1", "testModel2");
         Assertions.assertThat(models.get("testModel1")).satisfies(modelDto -> {
-            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole3", "default");
+            Assertions.assertThat(modelDto.getRoleLimits()).containsOnlyKeys("testRole1", "testRole2", "testRole3", "default");
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole1")).satisfies(limit1 -> {
                 Assertions.assertThat(limit1.isEnabled()).isTrue();
                 Assertions.assertThat(limit1.getDay()).isEqualTo(1);
-                Assertions.assertThat(limit1.getMinute()).isNull();
+                Assertions.assertThat(limit1.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
-            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2")).isNull();
+            Assertions.assertThat(modelDto.getRoleLimits().get("testRole2")).satisfies(limit2 -> {
+                Assertions.assertThat(limit2.isEnabled()).isFalse();
+                Assertions.assertThat(limit2.getDay()).isEqualTo(Long.MAX_VALUE);
+                Assertions.assertThat(limit2.getMinute()).isEqualTo(Long.MAX_VALUE);
+            });
             Assertions.assertThat(modelDto.getRoleLimits().get("testRole3")).satisfies(limit3 -> {
                 Assertions.assertThat(limit3.isEnabled()).isTrue();
-                Assertions.assertThat(limit3.getDay()).isNull();
-                Assertions.assertThat(limit3.getMinute()).isNull();
+                Assertions.assertThat(limit3.getDay()).isEqualTo(Long.MAX_VALUE);
+                Assertions.assertThat(limit3.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
             Assertions.assertThat(modelDto.getRoleLimits().get("default")).satisfies(limitDefault -> {
                 Assertions.assertThat(limitDefault.isEnabled()).isFalse();
                 Assertions.assertThat(limitDefault.getDay()).isEqualTo(3);
-                Assertions.assertThat(limitDefault.getMinute()).isNull();
+                Assertions.assertThat(limitDefault.getMinute()).isEqualTo(Long.MAX_VALUE);
             });
             Assertions.assertThat(modelDto.getInterceptors()).isNotEmpty()
                     .hasSize(1).first().isEqualTo("testInterceptor1");
@@ -1552,7 +1556,7 @@ public abstract class ConfigTransferFunctionalTest {
         ModelDto modelDto = modelFacade.getModel("testModel1");
         Assertions.assertThat(modelDto).isNotNull().satisfies(importedModel ->
                 Assertions.assertThat(importedModel.getRoleLimits().get("testRole1")).isNotNull().satisfies(roleLimit -> {
-                    Assertions.assertThat(roleLimit.getMinute()).isNull();
+                    Assertions.assertThat(roleLimit.getMinute()).isEqualTo(Long.MAX_VALUE);
                     Assertions.assertThat(roleLimit.getDay()).isEqualTo(1L);
                 })
         );

--- a/src/test/resources/domain/config/config_only_roles.json
+++ b/src/test/resources/domain/config/config_only_roles.json
@@ -28,8 +28,7 @@
           "month": 1000
         },
         "sampleDeployment5": {}
-      },
-      "share": {}
+      }
     }
   },
   "retriableErrorCodes": [],

--- a/src/test/resources/domain/config/config_only_roles.json
+++ b/src/test/resources/domain/config/config_only_roles.json
@@ -19,22 +19,15 @@
           "requestHour": 500,
           "requestDay": 2000
         },
-        "sampleDeployment5": {
-          "minute": 23,
-          "day": 9223372036854775807,
-          "week": 9223372036854775807,
-          "month": 9223372036854775807,
-          "requestHour": 9223372036854775807,
-          "requestDay": 9223372036854775807
+        "sampleDeployment2": {
+          "minute": 23
         },
-        "sampleDeployment6": {
+        "sampleDeployment4": {
           "minute": 20,
           "day": 2000,
-          "week": 9223372036854775807,
-          "month": 1000,
-          "requestHour": 9223372036854775807,
-          "requestDay": 9223372036854775807
-        }
+          "month": 1000
+        },
+        "sampleDeployment5": {}
       },
       "share": {}
     }

--- a/src/test/resources/domain/model/deployments_for_roles.json
+++ b/src/test/resources/domain/model/deployments_for_roles.json
@@ -4,25 +4,24 @@
     "defaultRoleLimit": {}
   },
   {
+    "name": "sampleDeployment2",
+    "defaultRoleLimit": {
+      "minute": 23
+    }
+  },
+  {
     "name": "sampleDeployment3",
-    "defaultRoleLimit": {
-      "minute": 23
-    }
+    "defaultRoleLimit": {}
   },
   {
-    "name": "sampleDeployment4"
-  },
-  {
-    "name": "sampleDeployment5",
-    "defaultRoleLimit": {
-      "minute": 23
-    }
-  },
-  {
-    "name": "sampleDeployment6",
+    "name": "sampleDeployment4",
     "defaultRoleLimit": {
       "day": 23,
       "month": 1000
     }
+  },
+  {
+    "name": "sampleDeployment5",
+    "defaultRoleLimit": {}
   }
 ]

--- a/src/test/resources/domain/model/roles.json
+++ b/src/test/resources/domain/model/roles.json
@@ -21,39 +21,34 @@
         "role": "admin",
         "deploymentName": "sampleDeployment2",
         "enabled": true,
-        "limit": {
-          "minute": 20,
-          "day": 2000,
-          "week": 10000,
-          "month": 40000,
-          "requestHour": 200,
-          "requestDay": 1000
-        }
+        "limit": {}
       },
       {
         "role": "admin",
         "deploymentName": "sampleDeployment3",
-        "enabled": true
+        "enabled": true,
+        "limit": {}
       },
       {
         "role": "admin",
         "deploymentName": "sampleDeployment4",
         "enabled": true,
-        "limit": {}
+        "limit": {
+          "minute": 20,
+          "day": 2000
+        }
       },
       {
         "role": "admin",
         "deploymentName": "sampleDeployment5",
         "enabled": true,
-        "limit": {}
-      },
-      {
-        "role": "admin",
-        "deploymentName": "sampleDeployment6",
-        "enabled": true,
         "limit": {
-          "minute": 20,
-          "day": 2000
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       }
     ],

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/config.json
@@ -3,13 +3,57 @@
     "testModel1": {
       "userRoles": [
         "userRole",
+        "userRoleInRolesSectionWithoutLimits",
+        "userRoleInRolesSectionWithNullLimits",
+        "userRoleInRolesSectionWithEmptyLimits",
+        "userRoleInRolesSectionWithNullLimit",
         "userRoleInRolesSectionWithEmptyLimit",
         "userRoleInRolesSectionWithNonEmptyLimit"
       ]
     }
   },
   "roles": {
+    "userRoleInRolesSectionWithoutLimits": {
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    },
+    "userRoleInRolesSectionWithNullLimits": {
+      "limits": null,
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    },
+    "userRoleInRolesSectionWithEmptyLimits": {
+      "limits": {},
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    },
+    "userRoleInRolesSectionWithNullLimit": {
+      "limits": {
+        "testModel1": null
+      },
+      "share": {
+        "testModel1": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    },
     "userRoleInRolesSectionWithEmptyLimit": {
+      "limits": {
+        "testModel1": {}
+      },
       "share": {
         "testModel1": {
           "maxAcceptedUsers": 10,
@@ -24,7 +68,22 @@
         }
       }
     },
+    "roleInRolesSectionWithoutLimits": {},
+    "roleInRolesSectionWithNullLimits": {
+      "limits": null
+    },
+    "roleInRolesSectionWithEmptyLimits": {
+      "limits": {}
+    },
+    "roleInRolesSectionWithNullLimit": {
+      "limits": {
+        "testModel1": null
+      }
+    },
     "roleInRolesSectionWithEmptyLimit": {
+      "limits": {
+        "testModel1": {}
+      }
     },
     "roleInRolesSectionWithNonEmptyLimit": {
       "limits": {

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
@@ -1,4 +1,88 @@
 {
+  "userRoleInRolesSectionWithoutLimits": {
+    "name": "userRoleInRolesSectionWithoutLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithoutLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithoutLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ]
+  },
+  "userRoleInRolesSectionWithNullLimits": {
+    "name": "userRoleInRolesSectionWithNullLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ]
+  },
+  "userRoleInRolesSectionWithEmptyLimits": {
+    "name": "userRoleInRolesSectionWithEmptyLimits",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithEmptyLimits",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithEmptyLimits",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ]
+  },
+  "userRoleInRolesSectionWithNullLimit": {
+    "name": "userRoleInRolesSectionWithNullLimit",
+    "limits": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimit",
+        "deploymentName": "testModel1",
+        "enabled": true,
+        "limit": {}
+      }
+    ],
+    "share": [
+      {
+        "role": "userRoleInRolesSectionWithNullLimit",
+        "deploymentName": "testModel1",
+        "limit": {
+          "maxAcceptedUsers": 10,
+          "invitationTtl": 120
+        }
+      }
+    ]
+  },
   "userRoleInRolesSectionWithEmptyLimit": {
     "name": "userRoleInRolesSectionWithEmptyLimit",
     "limits": [
@@ -6,7 +90,14 @@
         "role": "userRoleInRolesSectionWithEmptyLimit",
         "deploymentName": "testModel1",
         "enabled": true,
-        "limit": {}
+        "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        }
       }
     ],
     "share": [
@@ -28,15 +119,54 @@
         "deploymentName": "testModel1",
         "enabled": true,
         "limit": {
-          "day": 5
+          "minute": 9223372036854775807,
+          "day": 5,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       }
     ],
     "share": []
   },
+  "roleInRolesSectionWithoutLimits": {
+    "name": "roleInRolesSectionWithoutLimits",
+    "limits": [],
+    "share": []
+  },
+  "roleInRolesSectionWithNullLimits": {
+    "name": "roleInRolesSectionWithNullLimits",
+    "limits": [],
+    "share": []
+  },
+  "roleInRolesSectionWithEmptyLimits": {
+    "name": "roleInRolesSectionWithEmptyLimits",
+    "limits": [],
+    "share": []
+  },
+  "roleInRolesSectionWithNullLimit": {
+    "name": "roleInRolesSectionWithNullLimit",
+    "limits": [],
+    "share": []
+  },
   "roleInRolesSectionWithEmptyLimit": {
     "name": "roleInRolesSectionWithEmptyLimit",
-    "limits": [],
+    "limits": [
+      {
+        "role": "roleInRolesSectionWithEmptyLimit",
+        "deploymentName": "testModel1",
+        "enabled": false,
+        "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
+          "week": 9223372036854775807,
+          "month": 9223372036854775807,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
+        }
+      }
+    ],
     "share": []
   },
   "roleInRolesSectionWithNonEmptyLimit": {
@@ -47,8 +177,12 @@
         "deploymentName": "testModel1",
         "enabled": false,
         "limit": {
+          "minute": 9223372036854775807,
+          "day": 9223372036854775807,
           "week": 120,
-          "month": 500
+          "month": 500,
+          "requestHour": 9223372036854775807,
+          "requestDay": 9223372036854775807
         }
       }
     ],

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -13,23 +13,55 @@
           },
           {
             "role": "testRole1",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole1",
             "deploymentName": "testApplication1",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           },
           {
             "role": "testRole1",
             "deploymentName": "testModel1",
             "enabled": true,
             "limit": {
-              "day": 1
+              "minute": 9223372036854775807,
+              "day": 1,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
             }
           },
           {
             "role": "testRole1",
             "deploymentName": "testApplication2",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           },
           {
             "role": "testRole1",
@@ -54,7 +86,60 @@
       "importAction": "create",
       "value": {
         "name": "testRole2",
-        "limits": [],
+        "limits": [
+          {
+            "role": "testRole2",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testModel1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole2",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          }
+        ],
         "share": []
       }
     },
@@ -65,9 +150,55 @@
         "limits": [
           {
             "role": "testRole3",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
             "deploymentName": "testModel1",
             "enabled": true,
-            "limit": {}
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "testRole3",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
           }
         ],
         "share": []
@@ -80,10 +211,54 @@
         "limits": [
           {
             "role": "default",
+            "deploymentName": "testModel2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
+            "deploymentName": "testApplication1",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
             "deploymentName": "testModel1",
             "enabled": false,
             "limit": {
-              "day": 3
+              "minute": 9223372036854775807,
+              "day": 3,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
+            }
+          },
+          {
+            "role": "default",
+            "deploymentName": "testApplication2",
+            "enabled": false,
+            "limit": {
+              "minute": 9223372036854775807,
+              "day": 9223372036854775807,
+              "week": 9223372036854775807,
+              "month": 9223372036854775807,
+              "requestHour": 9223372036854775807,
+              "requestDay": 9223372036854775807
             }
           }
         ],
@@ -272,7 +447,60 @@
       "value": {
         "deployment": {
           "name": "testModel2",
-          "roleLimits": [],
+          "roleLimits": [
+            {
+              "role": "testRole1",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testModel2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            }
+          ],
           "roleShareResourceLimits": [],
           "isPublic": true,
           "defaultRoleLimit": {},
@@ -326,21 +554,51 @@
               "deploymentName": "testModel1",
               "enabled": true,
               "limit": {
-                "day": 1
+                "minute": 9223372036854775807,
+                "day": 1,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testModel1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
               }
             },
             {
               "role": "testRole3",
               "deploymentName": "testModel1",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             },
             {
               "role": "default",
               "deploymentName": "testModel1",
               "enabled": false,
               "limit": {
-                "day": 3
+                "minute": 9223372036854775807,
+                "day": 3,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
               }
             }
           ],
@@ -408,7 +666,53 @@
               "role": "testRole1",
               "deploymentName": "testApplication1",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testApplication1",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             }
           ],
           "roleShareResourceLimits": [],
@@ -461,7 +765,53 @@
               "role": "testRole1",
               "deploymentName": "testApplication2",
               "enabled": true,
-              "limit": {}
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole2",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "testRole3",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
+            },
+            {
+              "role": "default",
+              "deploymentName": "testApplication2",
+              "enabled": false,
+              "limit": {
+                "minute": 9223372036854775807,
+                "day": 9223372036854775807,
+                "week": 9223372036854775807,
+                "month": 9223372036854775807,
+                "requestHour": 9223372036854775807,
+                "requestDay": 9223372036854775807
+              }
             }
           ],
           "roleShareResourceLimits": [],

--- a/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/core_limits.json
@@ -1,0 +1,82 @@
+{
+  "privateDeploymentWithDefaultDayForLimitWithoutDay": {
+    "minute": null,
+    "day": 10,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "privateDeploymentWithDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "privateDeploymentWithDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "privateDeploymentWithoutDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "privateDeploymentWithoutDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayWithoutLimit": {
+    "minute": null,
+    "day": 10,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithoutDefaultDayForLimitWithDay": {
+    "minute": null,
+    "day": 5,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  },
+  "publicDeploymentWithoutDefaultDayForLimitWithMaxDay": {
+    "minute": null,
+    "day": 9223372036854775807,
+    "week": null,
+    "month": null,
+    "requestHour": null,
+    "requestDay": null
+  }
+}

--- a/src/test/resources/mapper/core/role_limit/map_limits/deployments.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/deployments.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "privateDeploymentWithDefaultDayForLimitWithoutDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithoutDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
+  },
+  {
+    "name": "privateDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {},
+    "isPublic": false
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayWithoutLimit",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {
+      "day": 10
+    },
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayWithoutLimit",
+    "defaultRoleLimit": {},
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayForLimitWithDay",
+    "defaultRoleLimit": {},
+    "isPublic": true
+  },
+  {
+    "name": "publicDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "defaultRoleLimit": {},
+    "isPublic": true
+  }
+]

--- a/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
@@ -1,0 +1,68 @@
+[
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithoutDay",
+    "limit": {}
+  },
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithoutDay",
+    "limit": {}
+  },
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "privateDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithoutDefaultDayForLimitWithDay",
+    "limit": {
+      "day": 5
+    }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "publicDeploymentWithoutDefaultDayForLimitWithMaxDay",
+    "limit": {
+      "day": 9223372036854775807
+    }
+  }
+]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #302 
- fixes TBD

### Description of changes
- Max values of core role limits are saved as max values instead of nulls during import of core config
- Imaginary limits for user roles (which are not explicitly specified in config) are saved as empty role limits (all values are nulls) during import of core config
- Export of core config includes role limits for public deployments which have default limits, even if such role limits are not saved in DB
- Export of core config transforms unlimited limits (all values are Max values) to empty limits
- Export of core config excludes empty role limits (all values are nulls).
- Export of core config excludes role share
- Increase org.springframework:spring-core transitive dependency version from 6.2.10 to 6.2.11

Original PRs:

- https://github.com/epam/ai-dial-admin-backend/pull/300

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.