### PR TITLE
fix: skip role limit when deployment is missing during core export

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RoleLimitMapper.java
@@ -42,10 +42,12 @@ public abstract class RoleLimitMapper {
         CollectionUtils.emptyIfNull(roleLimits)
                 .forEach(roleLimit -> {
                     Deployment deployment = deploymentsByName.get(roleLimit.getDeploymentName());
-                    CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
+                    if (deployment != null) {
+                        CoreLimit mappedLimit = mapLimit(roleLimit.getLimit(), deployment);
 
-                    if (!mappedLimit.isEmpty()) {
-                        result.put(roleLimit.getDeploymentName(), mappedLimit);
+                        if (!mappedLimit.isEmpty()) {
+                            result.put(roleLimit.getDeploymentName(), mappedLimit);
+                        }
                     }
                 });
 
@@ -53,9 +55,9 @@ public abstract class RoleLimitMapper {
     }
 
     private CoreLimit mapLimit(Limit limit, Deployment deployment) {
-        if (limit == null || deployment == null) {
-            log.warn("Limit or deployment is null. Limit: {}, deployment: {}", limit, deployment);
-            throw new IllegalStateException("Limit or deployment is null");
+        if (limit == null) {
+            log.warn("Limit is null. Deployment: {}", deployment);
+            throw new IllegalStateException("Limit is null");
         }
 
         Limit defaultLimit = deployment.getDefaultRoleLimit();

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -1131,6 +1131,47 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     @Test
+    void testExport_CoreFormatRoleWithoutDependencies_SelectedItemsExportRequest() throws IOException {
+        // given
+        String importConfig = ResourceUtils.readResource("/import_for_export.json");
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.json",
+                "application/json",
+                importConfig.getBytes()
+        );
+
+        configTransfer.importConfig(List.of(mockFile), overrideAndCreateRoleAndCreateNew());
+
+        SelectedItemsExportRequest request = new SelectedItemsExportRequest();
+        request.setExportFormat(ExportFormat.CORE);
+        request.setComponents(List.of(
+                new ExportConfigComponent("testRole1", ExportConfigComponentType.ROLE, Set.of())
+        ));
+
+        // when
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // then
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        streamingResponseBody.writeTo(outputStream);
+
+        Config result = jsonMapper.readValue(outputStream.toString(), Config.class);
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getKeys()).isEmpty();
+            Assertions.assertThat(config.getModels()).isEmpty();
+            Assertions.assertThat(config.getApplications()).isEmpty();
+            Assertions.assertThat(config.getRoutes()).isEmpty();
+            Assertions.assertThat(config.getRoles()).containsOnlyKeys("testRole1")
+                    .satisfies(roles -> {
+                        var role = roles.get("testRole1");
+                        Assertions.assertThat(role).isNotNull();
+                        Assertions.assertThat(role.getLimits()).isEmpty();
+                    });
+        });
+    }
+
+    @Test
     void testExport_CoreFormatAll_FullRequest() throws IOException, JSONException {
         // given
         String importConfig = ResourceUtils.readResource("/import_for_export.json");

--- a/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
+++ b/src/test/resources/mapper/core/role_limit/map_limits/role_limits.json
@@ -64,5 +64,12 @@
     "limit": {
       "day": 9223372036854775807
     }
+  },
+  {
+    "role": "role1",
+    "deploymentName": "missingDeployment",
+    "limit": {
+      "day": 5
+    }
   }
 ]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #327 

### Description of changes
Skipped role limit when deployment is missing during core export

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.