### PR TITLE
fix: wrap interaction with kubernetes client into separate thread with operation timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,7 @@ Applied when: config.export.storageType=CONFIG_MAP|KUBE_SECRET
 | kubernetes-config.client.requestTimeout | KUBERNETES_CONFIG_CLIENT_REQUESTTIMEOUT | 20000 | No | - | Request timeout in milliseconds |
 | kubernetes-config.client.withWebsocketPingInterval | KUBERNETES_CONFIG_CLIENT_WITHWEBSOCKETPINGINTERVAL | 120000 | No | - | WebSocket ping interval in milliseconds |
 | kubernetes-config.client.withWatchReconnectLimit | KUBERNETES_CONFIG_CLIENT_WITHWATCHRECONNECTLIMIT | 16 | No | - | Maximum number of WebSocket watch reconnection attempts |
+| kubernetes-config.client.operationTimeoutMs | KUBERNETES_CONFIG_CLIENT_OPERATIONTIMEOUTMS | 300000 | No | - | Kubernetes operation timeout (update config map, read secret, etc.) |
 
 Additional Kubernetes client configuration options are available from the [Fabric8 Kubernetes Client documentation](https://github.com/fabric8io/kubernetes-client?tab=readme-ov-file#configuring-the-client).
 

--- a/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -91,7 +92,10 @@ public class ExportConfiguration {
     @Bean
     @ConditionalOnExpression(("'${config.export.storageType}' == 'CONFIG_MAP' OR '${config.export.storageType}' == 'KUBE_SECRET'"))
     public K8ConfigService k8ConfigService(K8sProperties k8sProperties) {
-        return new K8ConfigService(k8sProperties, Executors.newCachedThreadPool());
+        BasicThreadFactory factory = BasicThreadFactory.builder()
+                .namingPattern("k8-client-pool-%d")
+                .build();
+        return new K8ConfigService(k8sProperties, Executors.newCachedThreadPool(factory));
     }
 
     @Bean

--- a/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.vault.core.VaultTemplate;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.List;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableScheduling
@@ -90,7 +91,7 @@ public class ExportConfiguration {
     @Bean
     @ConditionalOnExpression(("'${config.export.storageType}' == 'CONFIG_MAP' OR '${config.export.storageType}' == 'KUBE_SECRET'"))
     public K8ConfigService k8ConfigService(K8sProperties k8sProperties) {
-        return new K8ConfigService(k8sProperties);
+        return new K8ConfigService(k8sProperties, Executors.newCachedThreadPool());
     }
 
     @Bean

--- a/src/main/java/com/epam/aidial/cfg/configuration/K8sProperties.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/K8sProperties.java
@@ -31,5 +31,6 @@ public class K8sProperties {
         private int requestTimeout;
         private int withWebsocketPingInterval;
         private int withWatchReconnectLimit;
+        private int operationTimeoutMs;
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
@@ -15,6 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 @Slf4j
@@ -24,8 +30,15 @@ public class K8ConfigService {
     private final K8sProperties k8sProperties;
 
     public <T> T withClient(Function<KubernetesClient, T> task) {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
         try (KubernetesClient client = createKubernetesClient(k8sProperties)) {
-            return task.apply(client);
+            Future<T> future = executorService.submit(() -> task.apply(client));
+            return future.get(k8sProperties.getClient().getRequestTimeout(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            log.warn("Exception occurred during interaction with kubernetes client.", e);
+            throw new RuntimeException(e);
+        } finally {
+            executorService.shutdownNow();
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigService.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,7 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -28,17 +28,19 @@ import java.util.function.Function;
 public class K8ConfigService {
 
     private final K8sProperties k8sProperties;
+    private final ExecutorService executorService;
 
     public <T> T withClient(Function<KubernetesClient, T> task) {
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<T> future = null;
+        int timeoutMs = k8sProperties.getClient().getOperationTimeoutMs();
+
         try (KubernetesClient client = createKubernetesClient(k8sProperties)) {
-            Future<T> future = executorService.submit(() -> task.apply(client));
-            return future.get(k8sProperties.getClient().getRequestTimeout(), TimeUnit.MILLISECONDS);
+            future = executorService.submit(() -> task.apply(client));
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
-            log.warn("Exception occurred during interaction with kubernetes client.", e);
+            log.warn("Exception occurred during interaction with kubernetes client. Timeout: {}", timeoutMs, e);
+            future.cancel(true);
             throw new RuntimeException(e);
-        } finally {
-            executorService.shutdownNow();
         }
     }
 
@@ -145,6 +147,19 @@ public class K8ConfigService {
                 .withName(secretName)
                 .edit(SecretBuilder.class, builder -> builder.getData().replace(secretKey, value));
         log.debug("updateSecretMapEntry. Updated Secret {}, key {} = {}", configMap.getFullResourceName(), secretKey, SecretUtils.mask(value));
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,7 @@ kubernetes-config.client.requestRetryBackoffLimit=10
 kubernetes-config.client.requestTimeout=20000
 kubernetes-config.client.withWebsocketPingInterval=120000
 kubernetes-config.client.withWatchReconnectLimit=16
+kubernetes-config.client.operationTimeoutMs=300000
 
 # Web-Server
 server.port=8080

--- a/src/test/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/impl/storage/K8ConfigServiceTest.java
@@ -28,7 +28,7 @@ class K8ConfigServiceTest {
         K8sProperties k8sProperties = new K8sProperties();
         k8sProperties.setNamespace(NAMESPACE);
 
-        k8ConfigService = new K8ConfigService(k8sProperties);
+        k8ConfigService = new K8ConfigService(k8sProperties, null);
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #248 

### Description of changes
Used cached thread pool to operate with kubernetes client. The pool helps to interrupt operation which takes more time than limit defined via `kubernetes-config.client.operationTimeoutMs` app property.

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.