### PR TITLE
fix: do not fail import when container source is not deployed

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/InterceptorImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/InterceptorImporter.java
@@ -15,6 +15,7 @@ import com.epam.aidial.core.config.CoreInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -94,7 +95,8 @@ public class InterceptorImporter {
                     .formatted(containerId, newInterceptor.getName()), e);
         }
 
-        if (deploymentInfo == null) {
+        if (deploymentInfo == null || StringUtils.isBlank(deploymentInfo.getUrl())) {
+            log.debug("Container is missing or not deployed. ContainerId: {}, deploymentInfo: {}", containerId, deploymentInfo);
             newInterceptor.setSource(null);
         }
     }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ModelImporter.java
@@ -25,6 +25,7 @@ import com.epam.aidial.core.config.CoreModel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -115,7 +116,8 @@ public class ModelImporter extends DeploymentHolderImporter {
                     .formatted(containerId, newModel.getDeployment().getName()), e);
         }
 
-        if (deploymentInfo == null) {
+        if (deploymentInfo == null || StringUtils.isBlank(deploymentInfo.getUrl())) {
+            log.debug("Container is missing or not deployed. ContainerId: {}, deploymentInfo: {}", containerId, deploymentInfo);
             newModel.setSource(null);
         }
     }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ToolSetImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ToolSetImporter.java
@@ -22,6 +22,7 @@ import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -117,7 +118,8 @@ public class ToolSetImporter extends DeploymentHolderImporter {
                     .formatted(containerId, newToolSet.getDeployment().getName()), e);
         }
 
-        if (deploymentInfo == null) {
+        if (deploymentInfo == null || StringUtils.isBlank(deploymentInfo.getUrl())) {
+            log.debug("Container is missing or not deployed. ContainerId: {}, deploymentInfo: {}", containerId, deploymentInfo);
             newToolSet.setSource(null);
         }
     }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #303 

### Description of changes
Set model/interceptor/toolset `source` to `null` when container is not deployed

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.