### PR TITLE
fix: support admin config import backward compatibility + improve blank display name validation message

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/model/Role.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Role.java
@@ -15,6 +15,6 @@ public class Role {
     private Long updatedAt;
     private List<RoleLimit> limits;
     private List<String> keys;
-    private CostLimit costLimit;
+    private CostLimit costLimit = new CostLimit();
     private Map<ResourceType, ShareResourceLimit> share;
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/KeyService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/KeyService.java
@@ -177,7 +177,7 @@ public class KeyService {
     }
 
     private void assertNotExistsByKeyValue(String keyValue) {
-        if (keyJpaRepository.existsByKey(keyValue)) {
+        if (keyValue != null && keyJpaRepository.existsByKey(keyValue)) {
             throw new EntityAlreadyExistsException("Key with value " + keyValue + " already exists");
         }
     }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AdapterValidator.java
@@ -35,13 +35,13 @@ public class AdapterValidator {
             throw new IllegalArgumentException("Adapter name '" + adapterName
                     + "' does not match the required pattern: " + adapterNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(adapter.getDisplayName());
+        displayFieldsValidator.validateDisplayName(adapter.getDisplayName(), "Adapter", adapterName);
     }
 
     public void validateUpdate(String adapterName, Adapter adapter) {
         if (!Objects.equals(adapterName, adapter.getName())) {
             throw new IllegalArgumentException("Adapter with name: '" + adapterName + "' can not be renamed. New adapter name: '" + adapter.getName() + "'");
         }
-        displayFieldsValidator.validateDisplayName(adapter.getDisplayName());
+        displayFieldsValidator.validateDisplayName(adapter.getDisplayName(), "Adapter", adapterName);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AddonValidator.java
@@ -34,12 +34,12 @@ public class AddonValidator {
             throw new IllegalArgumentException("Addon name '" + addonName
                     + "' does not match the required pattern: " + addonNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(addon.getDisplayName());
+        displayFieldsValidator.validateDisplayName(addon.getDisplayName(), "Addon", addonName);
     }
 
     public void validateUpdate(String addonName, Addon addon) {
         deploymentValidator.validateUpdate(addonName, addon.getDeployment(), "Addon");
-        displayFieldsValidator.validateDisplayName(addon.getDisplayName());
+        displayFieldsValidator.validateDisplayName(addon.getDisplayName(), "Addon", addonName);
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationTypeSchemaValidator.java
@@ -42,7 +42,7 @@ public class ApplicationTypeSchemaValidator {
             throw new IllegalArgumentException("ApplicationTypeSchema ID '" + schemaId
                     + "' does not match the required pattern: " + applicationTypeSchemaIdValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(applicationTypeSchema.getApplicationTypeDisplayName());
+        displayFieldsValidator.validateDisplayName(applicationTypeSchema.getApplicationTypeDisplayName(), "ApplicationTypeSchema", schemaId);
         validateRoutes(applicationTypeSchema.getApplicationTypeRoutes());
     }
 
@@ -51,7 +51,7 @@ public class ApplicationTypeSchemaValidator {
             throw new IllegalArgumentException("Schema id can not be updated for application type schema "
                     + "with schema id: '" + schemaId + "'. New schema id: '" + applicationTypeSchema.getSchemaId() + "'");
         }
-        displayFieldsValidator.validateDisplayName(applicationTypeSchema.getApplicationTypeDisplayName());
+        displayFieldsValidator.validateDisplayName(applicationTypeSchema.getApplicationTypeDisplayName(), "ApplicationTypeSchema", schemaId);
         validateRoutes(applicationTypeSchema.getApplicationTypeRoutes());
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ApplicationValidator.java
@@ -31,13 +31,13 @@ public class ApplicationValidator {
 
     public void validateCreation(Application application) {
         validateApplicationName(application);
-        displayFieldsValidator.validateDisplayNameDisplayVersion(application.getDisplayName(), application.getDisplayVersion());
+        validateDisplayNameDisplayVersion(application);
         validateApplicationFields(application);
     }
 
     public void validateUpdate(String applicationName, Application application) {
         deploymentValidator.validateUpdate(applicationName, application.getDeployment(), "Application");
-        displayFieldsValidator.validateDisplayNameDisplayVersion(application.getDisplayName(), application.getDisplayVersion());
+        validateDisplayNameDisplayVersion(application);
         validateApplicationFields(application);
     }
 
@@ -55,6 +55,16 @@ public class ApplicationValidator {
             throw new IllegalArgumentException("Application name '" + applicationName
                     + "' does not match the required pattern: " + applicationNameValidationPattern);
         }
+    }
+
+    private void validateDisplayNameDisplayVersion(Application application) {
+        String applicationName = application.getDeployment().getName();
+        displayFieldsValidator.validateDisplayNameDisplayVersion(
+                application.getDisplayName(),
+                application.getDisplayVersion(),
+                "Application",
+                applicationName
+        );
     }
 
     private void validateApplicationFields(Application application) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/AssistantValidator.java
@@ -35,12 +35,12 @@ public class AssistantValidator {
             throw new IllegalArgumentException("Assistant name '" + assistantName
                     + "' does not match the required pattern: " + assistantNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(assistant.getDisplayName());
+        displayFieldsValidator.validateDisplayName(assistant.getDisplayName(), "Assistant", assistantName);
     }
 
     public void validateUpdate(String assistantName, Assistant assistant) {
         deploymentValidator.validateUpdate(assistantName, assistant.getDeployment(), "Assistant");
-        displayFieldsValidator.validateDisplayName(assistant.getDisplayName());
+        displayFieldsValidator.validateDisplayName(assistant.getDisplayName(), "Assistant", assistantName);
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidator.java
@@ -6,20 +6,25 @@ import org.springframework.stereotype.Component;
 @Component
 public class DisplayFieldsValidator {
 
-    public void validateDisplayNameDisplayVersion(String displayName, String displayVersion) {
-        validateDisplayName(displayName);
-        validateDisplayVersion(displayVersion);
+    public void validateDisplayNameDisplayVersion(String displayName,
+                                                  String displayVersion,
+                                                  String domainObjectType,
+                                                  String id) {
+        validateDisplayName(displayName, domainObjectType, id);
+        validateDisplayVersion(displayVersion, domainObjectType, id);
     }
 
-    public void validateDisplayName(String displayName) {
+    public void validateDisplayName(String displayName, String domainObjectType, String id) {
         if (StringUtils.isBlank(displayName)) {
-            throw new IllegalArgumentException("Invalid display name: '" + displayName + "'");
+            throw new IllegalArgumentException("Display name: '%s' must not be blank for %s with id:'%s'"
+                    .formatted(displayName, domainObjectType, id));
         }
     }
 
-    private void validateDisplayVersion(String displayVersion) {
+    private void validateDisplayVersion(String displayVersion, String domainObjectType, String id) {
         if (displayVersion != null && StringUtils.isBlank(displayVersion)) {
-            throw new IllegalArgumentException("Invalid display version: '" + displayVersion + "'");
+            throw new IllegalArgumentException("Display version: '%s' must not be blank for %s with id:'%s'"
+                    .formatted(displayVersion, domainObjectType, id));
         }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/IdFieldValidator.java
@@ -21,13 +21,13 @@ public class IdFieldValidator {
         }
     }
 
-    public void validateId(String domainObjectClassName, Object id, String idFieldName) {
+    public void validateId(String domainObjectType, Object id, String idFieldName) {
         if (id == null) {
-            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectClassName, idFieldName));
+            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectType, idFieldName));
         }
 
         if (id instanceof String stringId && StringUtils.isBlank(stringId)) {
-            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectClassName, idFieldName));
+            throw new IllegalArgumentException("%s %s must not be empty".formatted(domainObjectType, idFieldName));
         }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorRunnerValidator.java
@@ -28,7 +28,7 @@ public class InterceptorRunnerValidator {
 
     public void validateCreation(InterceptorRunner runner) {
         validateInterceptorRunnerName(runner);
-        displayFieldsValidator.validateDisplayName(runner.getDisplayName());
+        displayFieldsValidator.validateDisplayName(runner.getDisplayName(), "InterceptorRunner", runner.getName());
         validateEndpoints(runner.getCompletionEndpoint(), runner.getConfigurationEndpoint(), runner.getName());
     }
 
@@ -37,7 +37,7 @@ public class InterceptorRunnerValidator {
             throw new IllegalArgumentException("Interceptor runner with name: '%s' can not be renamed. New interceptor runner name: '%s'"
                     .formatted(interceptorRunnerName, runner.getName()));
         }
-        displayFieldsValidator.validateDisplayName(runner.getDisplayName());
+        displayFieldsValidator.validateDisplayName(runner.getDisplayName(), "InterceptorRunner", runner.getName());
         validateEndpoints(runner.getCompletionEndpoint(), runner.getConfigurationEndpoint(), runner.getName());
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/InterceptorValidator.java
@@ -43,7 +43,7 @@ public class InterceptorValidator {
 
     public void validateCreation(Interceptor interceptor) {
         validateInterceptorName(interceptor);
-        displayFieldsValidator.validateDisplayName(interceptor.getDisplayName());
+        displayFieldsValidator.validateDisplayName(interceptor.getDisplayName(), "Interceptor", interceptor.getName());
         validateInterceptorSource(interceptor);
     }
 
@@ -52,7 +52,7 @@ public class InterceptorValidator {
             throw new IllegalArgumentException("Interceptor with name: '%s' can not be renamed. New interceptor name: '%s'"
                     .formatted(interceptorName, interceptor.getName()));
         }
-        displayFieldsValidator.validateDisplayName(interceptor.getDisplayName());
+        displayFieldsValidator.validateDisplayName(interceptor.getDisplayName(), "Interceptor", interceptor.getName());
         validateInterceptorSource(interceptor);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/KeyValidator.java
@@ -33,7 +33,7 @@ public class KeyValidator {
     public void validateCreation(Key key) {
         validateKeyName(key);
         validateProject(key);
-        displayFieldsValidator.validateDisplayName(key.getDisplayName());
+        displayFieldsValidator.validateDisplayName(key.getDisplayName(), "Key", key.getName());
         long now = transactionTimestampContext.getTimestamp();
         Long expiresAt = key.getExpiresAt();
         if (expiresAt != null && expiresAt <= now) {
@@ -62,7 +62,7 @@ public class KeyValidator {
             throw new IllegalArgumentException("Key with name: '" + keyName + "' can not be renamed. New key name: '" + key.getName() + "'");
         }
         validateProject(key);
-        displayFieldsValidator.validateDisplayName(key.getDisplayName());
+        displayFieldsValidator.validateDisplayName(key.getDisplayName(), "Key", key.getName());
         Long expiresAt = key.getExpiresAt();
         long createdAt = existingEntity.getCreatedAt();
         if (expiresAt != null && expiresAt <= createdAt) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
@@ -50,13 +50,13 @@ public class ModelValidator {
 
     public void validateCreation(Model model) {
         validateModelName(model);
-        displayFieldsValidator.validateDisplayNameDisplayVersion(model.getDisplayName(), model.getDisplayVersion());
+        validateDisplayNameDisplayVersion(model);
         validateModelSource(model);
     }
 
     public void validateUpdate(String modelName, Model model) {
         deploymentValidator.validateUpdate(modelName, model.getDeployment(), "Model");
-        displayFieldsValidator.validateDisplayNameDisplayVersion(model.getDisplayName(), model.getDisplayVersion());
+        validateDisplayNameDisplayVersion(model);
         validateModelSource(model);
     }
 
@@ -74,6 +74,16 @@ public class ModelValidator {
             throw new IllegalArgumentException("Model name '" + modelName
                     + "' does not match the required pattern: " + modelNameValidationPattern);
         }
+    }
+
+    private void validateDisplayNameDisplayVersion(Model model) {
+        String modelName = model.getDeployment().getName();
+        displayFieldsValidator.validateDisplayNameDisplayVersion(
+                model.getDisplayName(),
+                model.getDisplayVersion(),
+                "Model",
+                modelName
+        );
     }
 
     private void validateModelSource(Model model) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RoleValidator.java
@@ -36,14 +36,14 @@ public class RoleValidator {
             throw new IllegalArgumentException("Role name '" + roleName
                     + "' does not match the required pattern: " + roleNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(role.getDisplayName());
+        displayFieldsValidator.validateDisplayName(role.getDisplayName(), "Role", roleName);
     }
 
     public void validateRoleUpdate(String roleName, Role role) {
         if (!Objects.equals(roleName, role.getName())) {
             throw new IllegalArgumentException("Role with name: '" + roleName + "' can not be renamed. New role name: '" + role.getName() + "'");
         }
-        displayFieldsValidator.validateDisplayName(role.getDisplayName());
+        displayFieldsValidator.validateDisplayName(role.getDisplayName(), "Role", roleName);
     }
 
     public void validateRoleDeletion(String roleName) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/RouteValidator.java
@@ -37,12 +37,12 @@ public class RouteValidator {
             throw new IllegalArgumentException("Route name '" + routeName
                     + "' does not match the required pattern: " + routeNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(route.getDisplayName());
+        displayFieldsValidator.validateDisplayName(route.getDisplayName(), "Route", routeName);
     }
 
     public void validateUpdate(String routeName, Route route) {
         deploymentValidator.validateUpdate(routeName, route.getDeployment(), "Route");
-        displayFieldsValidator.validateDisplayName(route.getDisplayName());
+        displayFieldsValidator.validateDisplayName(route.getDisplayName(), "Route", routeName);
     }
 
     public void validateDependentRoute(DependentRoute dependentRoute) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
@@ -46,13 +46,13 @@ public class ToolSetValidator {
             throw new IllegalArgumentException("toolSet name '" + toolSetName
                         + "' does not match the required pattern: " + toolSetNameValidationPattern);
         }
-        displayFieldsValidator.validateDisplayName(toolSet.getDisplayName());
+        displayFieldsValidator.validateDisplayName(toolSet.getDisplayName(), "ToolSet", toolSetName);
         validateToolSetSource(toolSet);
     }
 
     public void validateUpdate(String toolSetName, ToolSet toolSet) {
         deploymentValidator.validateUpdate(toolSetName, toolSet.getDeployment(), "ToolSet");
-        displayFieldsValidator.validateDisplayName(toolSet.getDisplayName());
+        displayFieldsValidator.validateDisplayName(toolSet.getDisplayName(), "ToolSet", toolSetName);
         validateToolSetSource(toolSet);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ConfigImporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/ConfigImporter.java
@@ -5,6 +5,7 @@ import com.epam.aidial.cfg.domain.model.ExportConfig;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
 import com.epam.aidial.cfg.service.export.ConflictResolutionPolicy;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.AdminConfigImportBackwardCompatibilityHandler;
 import com.epam.aidial.cfg.service.transfer.importer.util.CoreRolesMerger;
 import com.epam.aidial.core.config.Config;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,8 @@ public class ConfigImporter {
     private final AssistantImporter assistantImporter;
     private final AdapterImporter adapterImporter;
     private final ToolSetImporter toolSetImporter;
+
+    private final AdminConfigImportBackwardCompatibilityHandler adminConfigImportBackwardCompatibilityHandler;
 
     @Transactional
     public ImportConfigPreview importPreview(Config config, ConfigImportOptions importOptions) {
@@ -87,6 +90,8 @@ public class ConfigImporter {
         // mark that transaction should be rolled back. This is a trick to get actual state of importing objects
         // with all associations but doesn't save the state into DB
         TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+
+        adminConfigImportBackwardCompatibilityHandler.transformToLatestVersion(config);
 
         var importOptions = new ConfigImportOptions(resolutionPolicy, false, false);
 
@@ -146,6 +151,8 @@ public class ConfigImporter {
 
     @Transactional
     public void importAdminConfig(ExportConfig config, ConfigImportOptions importOptions) {
+        adminConfigImportBackwardCompatibilityHandler.transformToLatestVersion(config);
+
         var resolutionPolicy = importOptions.conflictResolutionPolicy();
 
         interceptorRunnerImporter.importAdminInterceptorRunners(config.getInterceptorRunners(), resolutionPolicy);

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/AdminConfigImportBackwardCompatibilityHandler.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/AdminConfigImportBackwardCompatibilityHandler.java
@@ -1,0 +1,46 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.ExportConfig;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.AdapterToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.ApplicationToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.ApplicationTypeSchemaToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.InterceptorRunnerToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.InterceptorToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.KeyToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.ModelToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.RoleToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.RouteToLatestVersionTransformer;
+import com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer.ToolSetToLatestVersionTransformer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@LogExecution
+@RequiredArgsConstructor
+public class AdminConfigImportBackwardCompatibilityHandler {
+
+    private final RouteToLatestVersionTransformer routeToLatestVersionTransformer;
+    private final ApplicationToLatestVersionTransformer applicationToLatestVersionTransformer;
+    private final ModelToLatestVersionTransformer modelToLatestVersionTransformer;
+    private final ToolSetToLatestVersionTransformer toolSetToLatestVersionTransformer;
+    private final RoleToLatestVersionTransformer roleToLatestVersionTransformer;
+    private final KeyToLatestVersionTransformer keyToLatestVersionTransformer;
+    private final ApplicationTypeSchemaToLatestVersionTransformer applicationTypeSchemaToLatestVersionTransformer;
+    private final InterceptorToLatestVersionTransformer interceptorToLatestVersionTransformer;
+    private final InterceptorRunnerToLatestVersionTransformer interceptorRunnerToLatestVersionTransformer;
+    private final AdapterToLatestVersionTransformer adapterToLatestVersionTransformer;
+
+    public void transformToLatestVersion(ExportConfig config) {
+        routeToLatestVersionTransformer.transform(config.getRoutes());
+        applicationToLatestVersionTransformer.transform(config.getApplications());
+        modelToLatestVersionTransformer.transform(config.getModels());
+        toolSetToLatestVersionTransformer.transform(config.getToolsets());
+        roleToLatestVersionTransformer.transform(config.getRoles());
+        keyToLatestVersionTransformer.transform(config.getKeys());
+        applicationTypeSchemaToLatestVersionTransformer.transform(config.getApplicationRunners());
+        interceptorToLatestVersionTransformer.transform(config.getInterceptors());
+        interceptorRunnerToLatestVersionTransformer.transform(config.getInterceptorRunners());
+        adapterToLatestVersionTransformer.transform(config.getAdapters());
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/AdapterToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/AdapterToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Adapter;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class AdapterToLatestVersionTransformer {
+
+    public void transform(Map<String, Adapter> adapters) {
+        MapUtils.emptyIfNull(adapters).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Adapter adapter) {
+        if (StringUtils.isBlank(adapter.getDisplayName())) {
+            adapter.setDisplayName(adapter.getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ApplicationToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ApplicationToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Application;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class ApplicationToLatestVersionTransformer {
+
+    public void transform(Map<String, Application> applications) {
+        MapUtils.emptyIfNull(applications).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Application application) {
+        if (StringUtils.isBlank(application.getDisplayName())) {
+            application.setDisplayName(application.getDeployment().getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ApplicationTypeSchemaToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ApplicationTypeSchemaToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.ApplicationTypeSchema;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class ApplicationTypeSchemaToLatestVersionTransformer {
+
+    public void transform(Map<String, ApplicationTypeSchema> applicationTypeSchemas) {
+        MapUtils.emptyIfNull(applicationTypeSchemas).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(ApplicationTypeSchema applicationTypeSchema) {
+        if (StringUtils.isBlank(applicationTypeSchema.getApplicationTypeDisplayName())) {
+            applicationTypeSchema.setApplicationTypeDisplayName(applicationTypeSchema.getSchemaId());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/InterceptorRunnerToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/InterceptorRunnerToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.InterceptorRunner;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class InterceptorRunnerToLatestVersionTransformer {
+
+    public void transform(Map<String, InterceptorRunner> interceptorRunners) {
+        MapUtils.emptyIfNull(interceptorRunners).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(InterceptorRunner interceptorRunner) {
+        if (StringUtils.isBlank(interceptorRunner.getDisplayName())) {
+            interceptorRunner.setDisplayName(interceptorRunner.getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/InterceptorToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/InterceptorToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Interceptor;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class InterceptorToLatestVersionTransformer {
+
+    public void transform(Map<String, Interceptor> interceptors) {
+        MapUtils.emptyIfNull(interceptors).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Interceptor interceptor) {
+        if (StringUtils.isBlank(interceptor.getDisplayName())) {
+            interceptor.setDisplayName(interceptor.getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/KeyToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/KeyToLatestVersionTransformer.java
@@ -1,0 +1,28 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Key;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class KeyToLatestVersionTransformer {
+
+    public void transform(Map<String, Key> keys) {
+        MapUtils.emptyIfNull(keys).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Key key) {
+        if (StringUtils.isBlank(key.getDisplayName())) {
+            key.setDisplayName(key.getName());
+        }
+        if (StringUtils.isBlank(key.getProject())) {
+            key.setProject("_UNDEFINED_");
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ModelToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ModelToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Model;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class ModelToLatestVersionTransformer {
+
+    public void transform(Map<String, Model> models) {
+        MapUtils.emptyIfNull(models).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Model model) {
+        if (StringUtils.isBlank(model.getDisplayName())) {
+            model.setDisplayName(model.getDeployment().getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/RoleToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/RoleToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.Role;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class RoleToLatestVersionTransformer {
+
+    public void transform(Map<String, Role> roles) {
+        MapUtils.emptyIfNull(roles).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Role role) {
+        if (StringUtils.isBlank(role.getDisplayName())) {
+            role.setDisplayName(role.getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/RouteToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/RouteToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.route.Route;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class RouteToLatestVersionTransformer {
+
+    public void transform(Map<String, Route> routes) {
+        MapUtils.emptyIfNull(routes).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(Route route) {
+        if (StringUtils.isBlank(route.getDisplayName())) {
+            route.setDisplayName(route.getDeployment().getName());
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ToolSetToLatestVersionTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/importer/compatibility/backward/transformer/ToolSetToLatestVersionTransformer.java
@@ -1,0 +1,25 @@
+package com.epam.aidial.cfg.service.transfer.importer.compatibility.backward.transformer;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.ToolSet;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@LogExecution
+public class ToolSetToLatestVersionTransformer {
+
+    public void transform(Map<String, ToolSet> toolSets) {
+        MapUtils.emptyIfNull(toolSets).values()
+                .forEach(this::transform);
+    }
+
+    private void transform(ToolSet toolSet) {
+        if (StringUtils.isBlank(toolSet.getDisplayName())) {
+            toolSet.setDisplayName(toolSet.getDeployment().getName());
+        }
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.Limit;
 import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
+import com.epam.aidial.core.config.CoreCostLimit;
 import com.epam.aidial.core.config.CoreLimit;
 import com.epam.aidial.core.config.CoreRole;
 import org.assertj.core.api.Assertions;
@@ -53,6 +54,7 @@ class RoleCoreMapperTest {
         CoreRole expected = new CoreRole();
         expected.setName("testRole");
         expected.setLimits(Map.of("testModel", expectedLimit));
+        expected.setCostLimit(new CoreCostLimit());
 
         // when
         CoreRole result = mapper.mapRole(role, List.of(deployment));

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ApplicationValidatorTest.java
@@ -39,7 +39,7 @@ class ApplicationValidatorTest {
     void validateCreation_shouldDelegateToDisplayFieldsValidator() {
         // given
         Application application = new Application();
-        application.setDisplayName("text");
+        application.setDisplayName("display name");
         application.setDisplayVersion("1.0");
         application.setEndpoint("test");
         Deployment deployment = new Deployment("text");
@@ -49,7 +49,7 @@ class ApplicationValidatorTest {
         applicationValidator.validateCreation(application);
 
         // then
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Application", "text");
     }
 
     @ParameterizedTest
@@ -57,7 +57,7 @@ class ApplicationValidatorTest {
     void validateCreation_shouldThrowExceptionWhenEndpointIsNotNullButBlank(String endpoint) {
         // given
         Application application = new Application();
-        application.setDisplayName("text");
+        application.setDisplayName("display name");
         application.setDisplayVersion("1.0");
         application.setEndpoint(endpoint);
         Deployment deployment = new Deployment("text");
@@ -68,7 +68,7 @@ class ApplicationValidatorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid endpoint: '" + endpoint + "'. Application: text");
 
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Application", "text");
     }
 
     @ParameterizedTest
@@ -78,7 +78,7 @@ class ApplicationValidatorTest {
         URI applicationTypeSchemaId = applicationTypeSchemaIdAsString != null ? URI.create(applicationTypeSchemaIdAsString) : null;
 
         Application application = new Application();
-        application.setDisplayName("text");
+        application.setDisplayName("display name");
         application.setDisplayVersion("1.0");
         application.setEndpoint(endpoint);
         application.setApplicationTypeSchemaId(applicationTypeSchemaId);
@@ -91,7 +91,7 @@ class ApplicationValidatorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Missing endpoint and application type schema id. Only one of them should be specified. Application: deploymentName");
 
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Application", "deploymentName");
     }
 
     @Test
@@ -120,7 +120,7 @@ class ApplicationValidatorTest {
         Deployment deployment = new Deployment(deploymentName);
 
         Application application = new Application();
-        application.setDisplayName("text");
+        application.setDisplayName("display name");
         application.setDisplayVersion("1.0");
         application.setDeployment(deployment);
         application.setEndpoint("test");
@@ -130,7 +130,7 @@ class ApplicationValidatorTest {
 
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Application");
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Application", deploymentName);
     }
 
     @ParameterizedTest
@@ -138,7 +138,7 @@ class ApplicationValidatorTest {
     void validateUpdate_shouldThrowExceptionWhenEndpointIsNotNullButBlank(String endpoint) {
         // given
         Application application = new Application();
-        application.setDisplayName("text");
+        application.setDisplayName("display name");
         application.setDisplayVersion("1.0");
         application.setEndpoint(endpoint);
 
@@ -150,7 +150,7 @@ class ApplicationValidatorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid endpoint: '" + endpoint + "'. Application: deploymentName");
 
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Application", "deploymentName");
     }
 
     @ParameterizedTest

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/DisplayFieldsValidatorTest.java
@@ -20,44 +20,44 @@ class DisplayFieldsValidatorTest {
     @ParameterizedTest
     @CsvSource({"''", "' '"})
     void validateDisplayNameDisplayVersion_shouldThrowExceptionWhenDisplayNameIsBlank(String displayName) {
-        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion(displayName, null))
+        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion(displayName, null, "DomainObjectType", "name"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid display name: '" + displayName + "'");
+                .hasMessage("Display name: '" + displayName + "'" + " must not be blank for DomainObjectType with id:'name'");
 
     }
 
     @ParameterizedTest
     @CsvSource({"''", "' '"})
     void validateDisplayNameDisplayVersion_shouldThrowExceptionWhenDisplayVersionIsBlank(String displayVersion) {
-        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("test", displayVersion))
+        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("test", displayVersion, "DomainObjectType", "name"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid display version: '" + displayVersion + "'");
+                .hasMessage("Display version: '" + displayVersion + "'" + " must not be blank for DomainObjectType with id:'name'");
     }
 
     @ParameterizedTest
     @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
     void validateDisplayName_shouldThrowExceptionWhenDisplayNameIsNullOrBlank(String displayName) {
-        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayName(displayName))
+        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayName(displayName, "DomainObjectType", "name"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid display name: '" + displayName + "'");
+                .hasMessage("Display name: '" + displayName + "'" + " must not be blank for DomainObjectType with id:'name'");
     }
 
     @Test
     void validateDisplayNameDisplayVersion_shouldThrowExceptionWhenDisplayNameIsNullAndDisplayVersionIsNotNull() {
-        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion(null, "1.0"))
+        assertThatThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion(null, "1.0", "DomainObjectType", "name"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid display name: 'null'");
+                .hasMessage("Display name: 'null'" + " must not be blank for DomainObjectType with id:'name'");
 
     }
 
     @Test
     void validateDisplayNameDisplayVersion_shouldDoNothingWhenDisplayNameIsNotNullAndDisplayVersionIsNull() {
-        assertThatNoException().isThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("text", null));
+        assertThatNoException().isThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("text", null, "DomainObjectType", "name"));
     }
 
     @Test
     void validateDisplayNameDisplayVersion_shouldDoNothingWhenDisplayNameIsNotNullAndDisplayVersionIsNotNull() {
-        assertThatNoException().isThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("text", "1.0"));
+        assertThatNoException().isThrownBy(() -> displayFieldsValidator.validateDisplayNameDisplayVersion("text", "1.0", "DomainObjectType", "name"));
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
@@ -47,7 +47,7 @@ class ModelValidatorTest {
     void validateCreation_shouldDelegateToDisplayFieldsValidator() {
         // given
         Model model = new Model();
-        model.setDisplayName("text");
+        model.setDisplayName("display name");
         model.setDisplayVersion("1.0");
         Deployment deployment = new Deployment("text");
         model.setDeployment(deployment);
@@ -56,7 +56,7 @@ class ModelValidatorTest {
         modelValidator.validateCreation(model);
 
         // then
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Model", "text");
     }
 
     @Test
@@ -67,7 +67,7 @@ class ModelValidatorTest {
         Deployment deployment = new Deployment(deploymentName);
 
         Model model = new Model();
-        model.setDisplayName("text");
+        model.setDisplayName("display name");
         model.setDisplayVersion("1.0");
         model.setDeployment(deployment);
 
@@ -76,7 +76,7 @@ class ModelValidatorTest {
 
         // then
         verify(deploymentValidator).validateUpdate(deploymentName, deployment, "Model");
-        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("text", "1.0");
+        verify(displayFieldsValidator).validateDisplayNameDisplayVersion("display name", "1.0", "Model", "deploymentName");
     }
 
     @ParameterizedTest

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -1490,8 +1490,10 @@ public abstract class ConfigTransferFunctionalTest {
 
         Map<String, InterceptorDto> interceptors = interceptorFacade.getAllInterceptors().stream().collect(Collectors.toMap(InterceptorDto::getName, i -> i));
 
-        Assertions.assertThat(interceptors.get("testInterceptor1")).satisfies(i ->
-                Assertions.assertThat(i.getEntities()).containsExactlyInAnyOrder("testModel1", "testApplication1"));
+        Assertions.assertThat(interceptors.get("testInterceptor1")).satisfies(i -> {
+            Assertions.assertThat(i.getEntities()).containsExactlyInAnyOrder("testModel1", "testApplication1");
+            Assertions.assertThat(i.getDisplayName()).isEqualTo("testInterceptor1");
+        });
         Assertions.assertThat(interceptors.get("testInterceptor2")).satisfies(i ->
                 Assertions.assertThat(((InterceptorRunnerSourceDto) i.getSource()).runnerName()).isEqualTo("testRunner1")
         );
@@ -1504,9 +1506,9 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(r.getConfigurationEndpoint()).isEqualTo("https://template.test.com/conf");
         });
 
-        Collection<String> allKeys = keyFacade.getAllKeys().stream().map(KeyDto::getName).toList();
-
-        Assertions.assertThat(allKeys).containsExactlyInAnyOrder("testKey1", "testKey2");
+        Map<String, KeyDto> keys = keyFacade.getAllKeys().stream().collect(Collectors.toMap(KeyDto::getName, Function.identity()));
+        Assertions.assertThat(keys.keySet()).containsExactlyInAnyOrder("testKey1", "testKey2");
+        Assertions.assertThat(keys.get("testKey2")).satisfies(key -> Assertions.assertThat(key.getProject()).isEqualTo("_UNDEFINED_"));
 
         Map<String, AdapterDto> adapters = adapterFacade.getAllAdapters().stream().collect(Collectors.toMap(AdapterDto::getName, a -> a));
 
@@ -1584,8 +1586,10 @@ public abstract class ConfigTransferFunctionalTest {
 
         Map<String, InterceptorDto> interceptors = interceptorFacade.getAllInterceptors().stream().collect(Collectors.toMap(InterceptorDto::getName, i -> i));
 
-        Assertions.assertThat(interceptors.get("testInterceptor1")).satisfies(i ->
-                Assertions.assertThat(i.getEntities()).containsExactlyInAnyOrder("testModel1", "testApplication1"));
+        Assertions.assertThat(interceptors.get("testInterceptor1")).satisfies(i -> {
+            Assertions.assertThat(i.getEntities()).containsExactlyInAnyOrder("testModel1", "testApplication1");
+            Assertions.assertThat(i.getDisplayName()).isEqualTo("testInterceptor1");
+        });
         Assertions.assertThat(interceptors.get("testInterceptor2")).satisfies(i ->
                 Assertions.assertThat(((InterceptorRunnerSourceDto) i.getSource()).runnerName()).isEqualTo("testRunner1")
         );
@@ -1598,9 +1602,9 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(r.getConfigurationEndpoint()).isEqualTo("https://template.test.com/conf");
         });
 
-        Collection<String> allKeys = keyFacade.getAllKeys().stream().map(KeyDto::getName).toList();
-
-        Assertions.assertThat(allKeys).containsExactlyInAnyOrder("testKey1", "testKey2");
+        Map<String, KeyDto> keys = keyFacade.getAllKeys().stream().collect(Collectors.toMap(KeyDto::getName, Function.identity()));
+        Assertions.assertThat(keys.keySet()).containsExactlyInAnyOrder("testKey1", "testKey2");
+        Assertions.assertThat(keys.get("testKey2")).satisfies(key -> Assertions.assertThat(key.getProject()).isEqualTo("_UNDEFINED_"));
 
         Map<String, AdapterDto> adapters = adapterFacade.getAllAdapters().stream().collect(Collectors.toMap(AdapterDto::getName, a -> a));
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
@@ -133,6 +133,22 @@ public abstract class KeyFunctionalTest {
     }
 
     @Test
+    public void shouldSuccessfullyCreateTwoKeysWithNullKeyValue() {
+        KeyDto keyDto = createKeyDto("1");
+        keyDto.setKey(null);
+        keyFacade.createKey(keyDto);
+
+        KeyDto keyDto2 = createKeyDto("2");
+        keyDto2.setKey(null);
+        keyFacade.createKey(keyDto2);
+
+        Collection<KeyDto> actualKeys = keyFacade.getAllKeys();
+        Collection<KeyDto> expectedDtos = List.of(keyDto, keyDto2);
+        expectedDtos.forEach(dto -> dto.setRoles(List.of()));
+        assertKeys(actualKeys, expectedDtos, true);
+    }
+
+    @Test
     public void shouldThrowExceptionWhenRenameKey() {
         KeyDto keyDto = createKeyDtoWithRole("1");
         keyFacade.createKey(keyDto);

--- a/src/test/resources/config_in_admin_format.json
+++ b/src/test/resources/config_in_admin_format.json
@@ -398,7 +398,6 @@
 			"name": "testKey2",
 			"displayName": "testKey2",
 			"key": "testKey2",
-			"project": "testProject1",
 			"secured": true,
 			"roles": [
 				"testRole1"
@@ -488,7 +487,6 @@
 	"interceptors": {
 		"testInterceptor1": {
 			"name": "testInterceptor1",
-			"displayName": "Test Interceptor1",
             "endpoint": "https://endpoint.test.com/interceptor",
 			"forwardAuthToken": false,
 			"author": "test-author",

--- a/src/test/resources/import/import_zip_preview.json
+++ b/src/test/resources/import/import_zip_preview.json
@@ -184,7 +184,7 @@
         "name": "testKey2",
         "displayName": "testKey2",
         "key": "testKey2",
-        "project": "testProject1",
+        "project": "_UNDEFINED_",
         "secured": true,
         "roles": [
           "testRole1"
@@ -210,9 +210,8 @@
       "importAction": "create",
       "next": {
         "name": "testInterceptor1",
-        "displayName": "Test Interceptor1",
+        "displayName": "testInterceptor1",
         "endpoint": "https://endpoint.test.com/interceptor",
-        "displayName": "Test Interceptor1",
         "forwardAuthToken": false,
         "author": "test-author",
         "dependencies": [],


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #343 

### Description of changes
- Supported backward compatibility for admin config import:
  - Missing role `costLimit` field deserializes to default cost limit with all max values
  - Missing `displayName` field populated with entity's `name` field value
  - Missing `project` key field populated with `_UNDEFINED_` value
- Improved blank display name validation message

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.