### PR TITLE
fix: set model endpoint when exporting model without adapter in admin format

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -65,8 +65,7 @@ public class ModelExporter {
                 .stream()
                 .map(component -> {
                     Model model = getModel(component.getName());
-                    Model modelWithRemovedDependencies = removeDependency(model, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
-                    return resolveEndpoint(modelWithRemovedDependencies, selectedItemsExportRequest.getExportFormat());
+                    return removeDependency(model, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
                 })
                 .map(model -> removeUpstreamKey(model, addSecrets))
                 .toList();
@@ -76,7 +75,6 @@ public class ModelExporter {
         return getModels().stream()
                 .map(model -> removeUpstreamKey(model, fullExportRequest.isAddSecrets()))
                 .map(model -> removeDependency(model, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
-                .map(model -> resolveEndpoint(model, fullExportRequest.getExportFormat()))
                 .toList();
     }
 
@@ -105,12 +103,15 @@ public class ModelExporter {
         if (!componentTypes.contains(ExportConfigComponentType.INTERCEPTOR)) {
             model.setInterceptors(null);
         }
-        if (!componentTypes.contains(ExportConfigComponentType.ADAPTER)
-                && exportFormat != ExportFormat.CORE
-                && model.getSource() != null
-                && model.getSource() instanceof AdapterSource) {
-            model.setSource(null);
+
+        if (model.getSource() != null && model.getSource() instanceof AdapterSource adapterSource) {
+            if (exportFormat == ExportFormat.CORE || !componentTypes.contains(ExportConfigComponentType.ADAPTER)) {
+                var adapter = adapterService.get(adapterSource.getAdapterName());
+                model.setEndpoint(ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath()));
+                model.setSource(null);
+            }
         }
+
         return model;
     }
 
@@ -120,16 +121,6 @@ public class ModelExporter {
             for (Upstream upstream : upstreams) {
                 upstream.setKey(null);
             }
-        }
-        return model;
-    }
-
-    private Model resolveEndpoint(Model model, ExportFormat exportFormat) {
-        if (exportFormat == ExportFormat.CORE
-                && model.getSource() != null
-                && model.getSource() instanceof AdapterSource adapterSource) {
-            var adapter = adapterService.get(adapterSource.getAdapterName());
-            model.setEndpoint(ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath()));
         }
         return model;
     }

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -104,9 +104,9 @@ public class ModelExporter {
             model.setInterceptors(null);
         }
 
-        if (model.getSource() != null
-                && model.getSource() instanceof AdapterSource adapterSource
-                && (exportFormat == ExportFormat.CORE || !componentTypes.contains(ExportConfigComponentType.ADAPTER))) {
+        if ((exportFormat == ExportFormat.CORE || !componentTypes.contains(ExportConfigComponentType.ADAPTER))
+                && model.getSource() != null
+                && model.getSource() instanceof AdapterSource adapterSource) {
             var adapter = adapterService.get(adapterSource.getAdapterName());
             model.setEndpoint(ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath()));
             model.setSource(null);

--- a/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/transfer/exporter/ModelExporter.java
@@ -104,12 +104,12 @@ public class ModelExporter {
             model.setInterceptors(null);
         }
 
-        if (model.getSource() != null && model.getSource() instanceof AdapterSource adapterSource) {
-            if (exportFormat == ExportFormat.CORE || !componentTypes.contains(ExportConfigComponentType.ADAPTER)) {
-                var adapter = adapterService.get(adapterSource.getAdapterName());
-                model.setEndpoint(ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath()));
-                model.setSource(null);
-            }
+        if (model.getSource() != null
+                && model.getSource() instanceof AdapterSource adapterSource
+                && (exportFormat == ExportFormat.CORE || !componentTypes.contains(ExportConfigComponentType.ADAPTER))) {
+            var adapter = adapterService.get(adapterSource.getAdapterName());
+            model.setEndpoint(ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath()));
+            model.setSource(null);
         }
 
         return model;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -737,6 +737,47 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     @Test
+    void testExport_AdminFormatModelWithAdapter_SelectedItemsExportRequest() throws IOException {
+        // given
+        AdapterDto adapterDto = createAdapterDto("1");
+
+        String completionEndpointPath = "/chat/completions";
+        ModelDto modelDto = createModelDto("1");
+        modelDto.setSource(new AdapterSourceDto("adapter1", completionEndpointPath));
+
+        String expectedEndpoint = adapterDto.getBaseEndpoint() + completionEndpointPath;
+
+        adapterFacade.createAdapter(adapterDto);
+        modelFacade.createModel(modelDto);
+
+        SelectedItemsExportRequest request = new SelectedItemsExportRequest();
+        request.setExportFormat(ExportFormat.ADMIN);
+        request.setComponents(List.of(new ExportConfigComponent(
+                "model1",
+                ExportConfigComponentType.MODEL,
+                Set.of()
+        )));
+
+        // when
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // then
+        ExportConfig result = extractConfigFromZip(streamingResponseBody);
+
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getModels())
+                    .isNotEmpty()
+                    .containsOnlyKeys("model1")
+                    .satisfies(models -> {
+                        Model model = models.get("model1");
+                        Assertions.assertThat(model.getSource()).isNull();
+                        Assertions.assertThat(model.getEndpoint()).isEqualTo(expectedEndpoint);
+                    });
+            Assertions.assertThat(config.getAdapters()).isEmpty();
+        });
+    }
+
+    @Test
     void testExport_AdminFormatRouteWithRole_FullRequest() throws IOException {
         // given
         Set<ExportConfigComponentType> componentTypes = Set.of(ExportConfigComponentType.ROUTE,

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -737,7 +737,7 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     @Test
-    void testExport_AdminFormatModelWithAdapter_SelectedItemsExportRequest() throws IOException {
+    void testExport_AdminFormatModelWithoutAdapter_SelectedItemsExportRequest() throws IOException {
         // given
         AdapterDto adapterDto = createAdapterDto("1");
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #353 

### Description of changes
Set model endpoint when exporting model without adapter in admin format

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.