### PR TITLE
hotfix: add conversion. ShareResource.invitationTtl in core uses hours as time unit.

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/ShareResourceLimitCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/ShareResourceLimitCoreMapper.java
@@ -3,12 +3,14 @@ package com.epam.aidial.cfg.domain.mapper;
 import com.epam.aidial.cfg.domain.model.ShareResourceLimit;
 import com.epam.aidial.core.config.CoreShareResourceLimit;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {TimeMapper.class})
 public interface ShareResourceLimitCoreMapper {
 
+    @Mapping(target = "invitationTtl", source = "invitationTtl", qualifiedByName = "hoursToMs")
     ShareResourceLimit toShareResourceLimit(CoreShareResourceLimit limit);
 
+    @Mapping(target = "invitationTtl", source = "invitationTtl", qualifiedByName = "msToHoursWithTruncation")
     CoreShareResourceLimit toCoreShareResourceLimit(ShareResourceLimit limit);
-
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/TimeMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/TimeMapper.java
@@ -1,0 +1,37 @@
+package com.epam.aidial.cfg.domain.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+
+import java.util.concurrent.TimeUnit;
+
+@Mapper(componentModel = "spring")
+public abstract class TimeMapper {
+
+    private static final long MS_IN_HOUR = TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
+
+    @Named("msToHours")
+    public Double msToHours(Long milliseconds) {
+        if (milliseconds == null) {
+            return null;
+        }
+        return ((double) milliseconds) / MS_IN_HOUR;
+    }
+
+    @Named("msToHoursWithTruncation")
+    public Long msToHoursWithTruncation(Long milliseconds) {
+        Double hours = msToHours(milliseconds);
+        if (hours == null) {
+            return null;
+        }
+        return hours.longValue();
+    }
+
+    @Named("hoursToMs")
+    public Long hoursToMs(Long hours) {
+        if (hours == null) {
+            return null;
+        }
+        return hours * MS_IN_HOUR;
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/RoleCoreMapperTest.java
@@ -21,7 +21,8 @@ import java.util.Map;
         RoleLimitMapperImpl.class,
         ShareResourceLimitCoreMapperImpl.class,
         RoleCoreMapperImpl.class,
-        CostLimitCoreMapperImpl.class
+        CostLimitCoreMapperImpl.class,
+        TimeMapperImpl.class
 })
 class RoleCoreMapperTest {
 

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/TimeMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/TimeMapperTest.java
@@ -1,0 +1,113 @@
+package com.epam.aidial.cfg.domain.mapper;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.stream.Stream;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TimeMapperImpl.class})
+class TimeMapperTest {
+
+    @Autowired
+    private TimeMapper mapper;
+
+    private static final long MS_IN_HOUR = 3600000L; // 1 hour in milliseconds
+
+    // Tests for msToHours() method
+    @ParameterizedTest
+    @MethodSource("msToHoursTestData")
+    void testMsToHours(Long milliseconds, Double expectedHours) {
+        // when
+        Double result = mapper.msToHours(milliseconds);
+
+        // then
+        Assertions.assertThat(result).isEqualTo(expectedHours);
+    }
+
+    static Stream<Arguments> msToHoursTestData() {
+        return Stream.of(
+                Arguments.of(3600000L, 1.0),        // 1 hour
+                Arguments.of(null, null),           // null input
+                Arguments.of(0L, 0.0),              // zero input
+                Arguments.of(86400000L, 24.0),      // 24 hours
+                Arguments.of(1800000L, 0.5)         // 0.5 hours
+        );
+    }
+
+    // Tests for msToHoursWithTruncation() method
+    @ParameterizedTest
+    @MethodSource("msToHoursWithTruncationTestData")
+    void testMsToHoursWithTruncation(Long milliseconds, Long expectedHours) {
+        // when
+        Long result = mapper.msToHoursWithTruncation(milliseconds);
+
+        // then
+        Assertions.assertThat(result).isEqualTo(expectedHours);
+    }
+
+    static Stream<Arguments> msToHoursWithTruncationTestData() {
+        return Stream.of(
+                Arguments.of(3600000L, 1L),         // 1 hour
+                Arguments.of(null, null),           // null input
+                Arguments.of(5400000L, 1L),         // 1.5 hours -> truncated to 1
+                Arguments.of(0L, 0L),               // zero input
+                Arguments.of(7199000L, 1L)          // 1.9997... hours -> truncated to 1
+        );
+    }
+
+    // Tests for hoursToMs() method
+    @ParameterizedTest
+    @MethodSource("hoursToMsTestData")
+    void testHoursToMs(Long hours, Long expectedMilliseconds) {
+        // when
+        Long result = mapper.hoursToMs(hours);
+
+        // then
+        Assertions.assertThat(result).isEqualTo(expectedMilliseconds);
+    }
+
+    static Stream<Arguments> hoursToMsTestData() {
+        return Stream.of(
+                Arguments.of(1L, 3600000L),         // 1 hour
+                Arguments.of(null, null),           // null input
+                Arguments.of(0L, 0L),               // zero input
+                Arguments.of(24L, 86400000L)        // 24 hours
+        );
+    }
+
+    // Bidirectional consistency tests
+    @Test
+    void testBidirectionalConsistency_HoursToMsToHours() {
+        // given
+        Long originalHours = 5L;
+
+        // when
+        Long milliseconds = mapper.hoursToMs(originalHours);
+        Double convertedBackHours = mapper.msToHours(milliseconds);
+
+        // then
+        Assertions.assertThat(convertedBackHours).isEqualTo(originalHours.doubleValue());
+    }
+
+    @Test
+    void testBidirectionalConsistency_MsToHoursToMs() {
+        // given
+        Long originalMs = MS_IN_HOUR * 3; // 3 hours in milliseconds
+
+        // when
+        Double hours = mapper.msToHours(originalMs);
+        Long convertedBackMs = mapper.hoursToMs(hours.longValue());
+
+        // then
+        Assertions.assertThat(convertedBackMs).isEqualTo(originalMs);
+    }
+}
+

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -232,7 +232,7 @@ public abstract class ConfigTransferFunctionalTest {
 
         Assertions.assertThat(roleFacade.getRole("testRole1").getShare()).hasSize(1).satisfies(share -> {
             ShareResourceLimitDto shareResourceLimit = share.get(ResourceTypeDto.APPLICATION);
-            Assertions.assertThat(shareResourceLimit.getInvitationTtl()).isEqualTo(120);
+            Assertions.assertThat(shareResourceLimit.getInvitationTtl()).isEqualTo(432000000);
             Assertions.assertThat(shareResourceLimit.getMaxAcceptedUsers()).isEqualTo(10);
         });
 

--- a/src/test/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMergerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/transfer/importer/util/CoreRolesMergerTest.java
@@ -5,6 +5,7 @@ import com.epam.aidial.cfg.domain.mapper.RoleCoreMapper;
 import com.epam.aidial.cfg.domain.mapper.RoleCoreMapperImpl;
 import com.epam.aidial.cfg.domain.mapper.RoleLimitMapperImpl;
 import com.epam.aidial.cfg.domain.mapper.ShareResourceLimitCoreMapperImpl;
+import com.epam.aidial.cfg.domain.mapper.TimeMapperImpl;
 import com.epam.aidial.cfg.domain.model.Role;
 import com.epam.aidial.cfg.domain.service.RoleService;
 import com.epam.aidial.cfg.utils.ResourceUtils;
@@ -30,7 +31,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
         RoleLimitMapperImpl.class,
         ShareResourceLimitCoreMapperImpl.class,
         RoleCoreMapperImpl.class,
-        CostLimitCoreMapperImpl.class
+        CostLimitCoreMapperImpl.class,
+        TimeMapperImpl.class
 })
 class CoreRolesMergerTest {
 

--- a/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
+++ b/src/test/resources/import/core_roles_merge/single_model_with_user_roles_and_roles/merged_roles.json
@@ -13,7 +13,7 @@
     "share": {
       "APPLICATION": {
         "maxAcceptedUsers": 10,
-        "invitationTtl": 120
+        "invitationTtl": 432000000
       }
     },
     "costLimit": {
@@ -37,7 +37,7 @@
     "share": {
       "APPLICATION": {
         "maxAcceptedUsers": 10,
-        "invitationTtl": 120
+        "invitationTtl": 432000000
       }
     },
     "costLimit": {
@@ -61,7 +61,7 @@
     "share": {
       "APPLICATION": {
         "maxAcceptedUsers": 10,
-        "invitationTtl": 120
+        "invitationTtl": 432000000
       }
     },
     "costLimit": {
@@ -85,7 +85,7 @@
     "share": {
       "APPLICATION": {
         "maxAcceptedUsers": 10,
-        "invitationTtl": 120
+        "invitationTtl": 432000000
       }
     },
     "costLimit": {
@@ -116,7 +116,7 @@
     "share": {
       "APPLICATION": {
         "maxAcceptedUsers": 10,
-        "invitationTtl": 120
+        "invitationTtl": 432000000
       }
     },
     "costLimit": {

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -74,7 +74,7 @@
         "share": {
           "APPLICATION": {
             "maxAcceptedUsers": 10,
-            "invitationTtl": 120
+            "invitationTtl": 432000000
           }
         },
         "costLimit": {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #355

### Description of changes
add missing conversion for core ShareResource.invitationTtl (core uses hours as time unit.)

Original PRs:
- #356

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.