### PR TITLE
fix: save and return only unique topics

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/model/Application.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Application.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.net.URI;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ public class Application extends RoleBased {
     private List<String> inputAttachmentTypes;
     private Integer maxInputAttachments;
     private Boolean forwardAuthToken;
-    private List<String> descriptionKeywords;
+    private LinkedHashSet<String> descriptionKeywords;
     private Integer maxRetryAttempts;
     private Map<String, Object> defaults;
     private List<String> interceptors;

--- a/src/main/java/com/epam/aidial/cfg/domain/model/Model.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/Model.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -25,7 +26,7 @@ public class Model extends RoleBased {
     private Integer maxInputAttachments;
     private Map<String, Object> defaults;
     private List<String> interceptors;
-    private List<String> topics; //todo: rename to descriptionKeywords
+    private LinkedHashSet<String> topics; //todo: rename to descriptionKeywords
     private Integer maxRetryAttempts;
     private String author;
     private Long createdAt;

--- a/src/main/java/com/epam/aidial/cfg/domain/model/ToolSet.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/ToolSet.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 
 @Data
@@ -16,7 +17,7 @@ public class ToolSet extends SecuredRoleBased {
     private String iconUrl;
     private String description;
     private String displayName;
-    private List<String> descriptionKeywords;
+    private LinkedHashSet<String> descriptionKeywords;
     private Integer maxRetryAttempts;
     private ToolSetSource source;
     private String author;

--- a/src/main/java/com/epam/aidial/cfg/service/DescriptionKeywordsService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/DescriptionKeywordsService.java
@@ -33,13 +33,13 @@ public class DescriptionKeywordsService {
         var modelKeywords = modelService.getAll().stream()
                 .map(Model::getTopics)
                 .filter(Objects::nonNull)
-                .flatMap(List::stream)
+                .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
 
         var applicationKeywords = applicationService.getAllApplications().stream()
                 .map(Application::getDescriptionKeywords)
                 .filter(Objects::nonNull)
-                .flatMap(List::stream)
+                .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
 
         var appRunnerKeywords = applicationTypeSchemaService.getAll().stream()
@@ -51,7 +51,7 @@ public class DescriptionKeywordsService {
         var toolSetKeywords = toolSetService.getAll().stream()
                 .map(ToolSet::getDescriptionKeywords)
                 .filter(Objects::nonNull)
-                .flatMap(List::stream)
+                .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
 
         return combineAndSortSets(modelKeywords, applicationKeywords, appRunnerKeywords, toolSetKeywords);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createApplicationDtoWithEndpointAndLimits;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createBaseApplicationDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 
@@ -356,6 +357,18 @@ public abstract class ApplicationFunctionalTest {
                 () -> applicationFacade.updateApplication(applicationDto.getName(), applicationDto, "*")
         );
         Assertions.assertEquals("Application with display name: 'display_name_2' and display version: 'null' already exists", exception.getMessage());
+    }
+
+    @Test
+    public void shouldSaveAndReturnApplicationWithUniqueTopics() {
+        ApplicationDto applicationDto = createBaseApplicationDto("1");
+        applicationDto.setEndpoint("http://my-endpoint");
+        applicationDto.setTopics(List.of("topic1", "topic2", "topic1", "topic3", "topic2"));
+        applicationFacade.createApplication(applicationDto);
+
+        ApplicationDto actual = applicationFacade.getApplication(applicationDto.getName());
+
+        Assertions.assertEquals(List.of("topic1", "topic2", "topic3"), actual.getTopics());
     }
 
     private ApplicationDto createDtoWithDefaults(String suffix) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -362,6 +362,17 @@ public abstract class ModelFunctionalTest {
         Assertions.assertEquals("Model with display name: 'display_name_2' and display version: 'null' already exists", exception.getMessage());
     }
 
+    @Test
+    public void shouldSaveAndReturnModelWithUniqueTopics() {
+        ModelDto modelDto = createModelDto("1");
+        modelDto.setTopics(List.of("topic1", "topic2", "topic1", "topic3", "topic2"));
+        modelFacade.createModel(modelDto);
+
+        ModelDto actual = modelFacade.getModel(modelDto.getName());
+
+        Assertions.assertEquals(List.of("topic1", "topic2", "topic3"), actual.getTopics());
+    }
+
     private void assertModels(Collection<ModelDto> actual, Collection<ModelDto> expected) {
         Map<String, ModelDto> actualMap = toMap(actual);
         Map<String, ModelDto> expectedMap = toMap(expected);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
@@ -4,8 +4,6 @@ import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
 import com.epam.aidial.cfg.client.mcp.McpClientFactory;
 import com.epam.aidial.cfg.domain.model.ToolSet.Transport;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
-import com.epam.aidial.cfg.dto.LimitDto;
-import com.epam.aidial.cfg.dto.RoleDto;
 import com.epam.aidial.cfg.dto.ToolSetDto;
 import com.epam.aidial.cfg.dto.ToolSetDto.TransportDto;
 import com.epam.aidial.cfg.dto.source.ToolSetContainerSourceDto;
@@ -276,6 +274,17 @@ public abstract class ToolSetFunctionalTest {
         Assertions.assertEquals(updatedUrl + completionPath, refreshedResult.getEndpoint());
 
         Mockito.verify(deploymentManagerService, Mockito.atLeast(2)).getById(containerId);
+    }
+
+    @Test
+    public void shouldSaveAndReturnToolSetWithUniqueDescriptionKeywords() {
+        ToolSetDto toolSetDto = createToolSetDto("1");
+        toolSetDto.setDescriptionKeywords(List.of("topic1", "topic2", "topic1", "topic3", "topic2"));
+        toolSetFacade.createToolSet(toolSetDto);
+
+        ToolSetDto actual = toolSetFacade.getToolSet(toolSetDto.getName());
+
+        Assertions.assertEquals(List.of("topic1", "topic2", "topic3"), actual.getDescriptionKeywords());
     }
 
     private void assertToolSet(ToolSetDto actual, ToolSetDto expected) {

--- a/src/test/java/com/epam/aidial/cfg/service/DescriptionKeywordsServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/DescriptionKeywordsServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -73,40 +74,46 @@ class DescriptionKeywordsServiceTest {
 
     private static List<Application> getApplications() {
         Application application1 = new Application();
-        application1.setDescriptionKeywords(List.of(
-                "Accounting"));
+        LinkedHashSet<String> application1Topics = new LinkedHashSet<>(Set.of("Accounting"));
+        application1.setDescriptionKeywords(application1Topics);
+
         Application application2 = new Application();
-        application2.setDescriptionKeywords(List.of(
-                "Business Development"));
+        LinkedHashSet<String> application2Topics = new LinkedHashSet<>(Set.of("Business Development"));
+        application2.setDescriptionKeywords(application2Topics);
+
         Application application3 = new Application();
         application3.setDescriptionKeywords(null);
+
         return List.of(application1, application2, application3);
     }
 
     private static List<Model> getModels() {
         Model model1 = new Model();
-        model1.setTopics(List.of(
-                "Customer Service",
-                "Finance"));
+        LinkedHashSet<String> model1Topics = new LinkedHashSet<>(Set.of("Customer Service", "Finance"));
+        model1.setTopics(model1Topics);
+
         Model model2 = new Model();
-        model2.setTopics(List.of(
-                "Accounting",
-                "Engineering"));
+        LinkedHashSet<String> model2Topics = new LinkedHashSet<>(Set.of("Accounting", "Engineering"));
+        model2.setTopics(model2Topics);
+
         Model model3 = new Model();
         model3.setTopics(null);
+
         return List.of(model1, model2, model3);
     }
 
     private static List<ToolSet> getToolSets() {
         ToolSet toolset1 = new ToolSet();
-        toolset1.setDescriptionKeywords(List.of(
-                "MCP1"));
+        LinkedHashSet<String> toolset1Topics = new LinkedHashSet<>(Set.of("MCP1"));
+        toolset1.setDescriptionKeywords(toolset1Topics);
+
         ToolSet toolset2 = new ToolSet();
-        toolset2.setDescriptionKeywords(List.of(
-                "Engineering",
-                "MCP2"));
+        LinkedHashSet<String> toolset2Topics = new LinkedHashSet<>(Set.of("Engineering", "MCP2"));
+        toolset2.setDescriptionKeywords(toolset2Topics);
+
         ToolSet toolset3 = new ToolSet();
         toolset3.setDescriptionKeywords(null);
+
         return List.of(toolset1, toolset2, toolset3);
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #179

### Description of changes
Used LinkedHashSet for topics in order to preserve order and uniqueness

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.