### PR TITLE
fix: Upgrade tomcat-embed-core to version 11.0.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     testImplementation 'org.testcontainers:mssqlserver'
 
     constraints {
-        implementation ('org.apache.tomcat.embed:tomcat-embed-core:10.1.44') {
+        implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.13') {
             because("previous versions have vulnerabilities")
         }
         implementation ('commons-fileupload:commons-fileupload:1.6.0') {


### PR DESCRIPTION
Updated Tomcat embed core dependency to version 11.0.13 to address vulnerabilities.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #371 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.