### PR TITLE
fix: use incoming `enabled` flag instead of default one for deployment role limits

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/RoleBasedDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/RoleBasedDtoMapper.java
@@ -54,6 +54,7 @@ public abstract class RoleBasedDtoMapper {
                 .map(e -> {
                     Limit limit = limitDtoMapper.toLimit(e.getValue());
                     RoleLimit roleLimit = new RoleLimit();
+                    roleLimit.setEnabled(e.getValue().isEnabled());
                     roleLimit.setRole(e.getKey());
                     roleLimit.setLimit(limit);
                     return roleLimit;

--- a/src/test/java/com/epam/aidial/cfg/web/facade/mapper/RoleBasedDtoMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/facade/mapper/RoleBasedDtoMapperTest.java
@@ -1,0 +1,71 @@
+package com.epam.aidial.cfg.web.facade.mapper;
+
+import com.epam.aidial.cfg.domain.model.Limit;
+import com.epam.aidial.cfg.domain.model.RoleLimit;
+import com.epam.aidial.cfg.dto.LimitDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        RoleBasedDtoMapperImpl.class,
+        LimitDtoMapperImpl.class
+})
+class RoleBasedDtoMapperTest {
+
+    @Autowired
+    private RoleBasedDtoMapper mapper;
+
+    @Test
+    void testMapRoleLimitsToDomain() {
+        // given
+        LimitDto limitDto1 = new LimitDto();
+
+        LimitDto limitDto2 = new LimitDto();
+        limitDto2.setDay(10L);
+
+        LimitDto limitDto3 = new LimitDto();
+        limitDto3.setEnabled(false);
+        limitDto3.setDay(10L);
+
+        Map<String, LimitDto> limits = Map.of(
+                "role1", limitDto1,
+                "role2", limitDto2,
+                "role3", limitDto3
+        );
+
+        Limit expectedLimit1 = new Limit();
+        RoleLimit expectedRoleLimit1 = new RoleLimit();
+        expectedRoleLimit1.setRole("role1");
+        expectedRoleLimit1.setLimit(expectedLimit1);
+
+        Limit expectedLimit2 = new Limit();
+        expectedLimit2.setDay(10L);
+        RoleLimit expectedRoleLimit2 = new RoleLimit();
+        expectedRoleLimit2.setRole("role2");
+        expectedRoleLimit2.setLimit(expectedLimit2);
+
+        Limit expectedLimit3 = new Limit();
+        expectedLimit3.setDay(10L);
+        RoleLimit expectedRoleLimit3 = new RoleLimit();
+        expectedRoleLimit3.setRole("role3");
+        expectedRoleLimit3.setEnabled(false);
+        expectedRoleLimit3.setLimit(expectedLimit3);
+
+        List<RoleLimit> expected = List.of(expectedRoleLimit1, expectedRoleLimit2, expectedRoleLimit3);
+
+        // when
+        List<RoleLimit> actual = mapper.mapRoleLimitsToDomain(limits);
+
+        // then
+        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #385

### Description of changes
Use incoming `enabled` flag instead of default one for deployment role limits during creation/update

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.