### PR TITLE
fix: handle `null` values in cost limit or explicit `null` cost limit for dto and core config

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapper.java
@@ -1,10 +1,9 @@
 package com.epam.aidial.cfg.domain.mapper;
 
 import com.epam.aidial.cfg.domain.model.CostLimit;
+import com.epam.aidial.cfg.utils.NullSafeUtils;
 import com.epam.aidial.core.config.CoreCostLimit;
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.NullValueMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface CostLimitCoreMapper {
@@ -24,6 +23,16 @@ public interface CostLimitCoreMapper {
         return coreCostLimit;
     }
 
-    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-    CostLimit toCostLimit(CoreCostLimit coreCostLimit);
+    default CostLimit toCostLimit(CoreCostLimit coreCostLimit) {
+        CostLimit costLimit = new CostLimit();
+
+        if (coreCostLimit != null) {
+            NullSafeUtils.setIfNotNull(costLimit::setMinute, coreCostLimit.getMinute());
+            NullSafeUtils.setIfNotNull(costLimit::setDay, coreCostLimit.getDay());
+            NullSafeUtils.setIfNotNull(costLimit::setWeek, coreCostLimit.getWeek());
+            NullSafeUtils.setIfNotNull(costLimit::setMonth, coreCostLimit.getMonth());
+        }
+
+        return costLimit;
+    }
 }

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/CostLimitDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/CostLimitDtoMapper.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.web.facade.mapper;
 
 import com.epam.aidial.cfg.domain.model.CostLimit;
 import com.epam.aidial.cfg.dto.CostLimitDto;
+import com.epam.aidial.cfg.utils.NullSafeUtils;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -9,5 +10,16 @@ public interface CostLimitDtoMapper {
 
     CostLimitDto toDto(CostLimit domain);
 
-    CostLimit toDomain(CostLimitDto dto);
+    default CostLimit toDomain(CostLimitDto dto) {
+        CostLimit costLimit = new CostLimit();
+
+        if (dto != null) {
+            NullSafeUtils.setIfNotNull(costLimit::setMinute, dto.getMinute());
+            NullSafeUtils.setIfNotNull(costLimit::setDay, dto.getDay());
+            NullSafeUtils.setIfNotNull(costLimit::setWeek, dto.getWeek());
+            NullSafeUtils.setIfNotNull(costLimit::setMonth, dto.getMonth());
+        }
+
+        return costLimit;
+    }
 }

--- a/src/test/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/mapper/CostLimitCoreMapperTest.java
@@ -1,0 +1,85 @@
+package com.epam.aidial.cfg.domain.mapper;
+
+import com.epam.aidial.cfg.domain.model.CostLimit;
+import com.epam.aidial.core.config.CoreCostLimit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        CostLimitCoreMapperImpl.class
+})
+class CostLimitCoreMapperTest {
+
+    @Autowired
+    private CostLimitCoreMapper mapper;
+
+    @Test
+    void toCostLimit_defaultCoreCostLimit() {
+        // given
+        CoreCostLimit coreCostLimit = new CoreCostLimit();
+
+        CostLimit expected = new CostLimit();
+
+        // when
+        CostLimit actual = mapper.toCostLimit(coreCostLimit);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCostLimit_allNonNullFieldsInCoreCostLimit() {
+        // given
+        CoreCostLimit coreCostLimit = new CoreCostLimit();
+        coreCostLimit.setMinute(BigDecimal.valueOf(1));
+        coreCostLimit.setDay(BigDecimal.valueOf(10));
+        coreCostLimit.setWeek(BigDecimal.valueOf(100));
+        coreCostLimit.setDay(BigDecimal.valueOf(1000));
+
+        CostLimit expected = new CostLimit();
+        expected.setMinute(BigDecimal.valueOf(1));
+        expected.setDay(BigDecimal.valueOf(10));
+        expected.setWeek(BigDecimal.valueOf(100));
+        expected.setDay(BigDecimal.valueOf(1000));
+
+        // when
+        CostLimit actual = mapper.toCostLimit(coreCostLimit);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCostLimit_nullDayInCoreCostLimit() {
+        // given
+        CoreCostLimit coreCostLimit = new CoreCostLimit();
+        coreCostLimit.setDay(null);
+
+        CostLimit expected = new CostLimit();
+        expected.setDay(BigDecimal.valueOf(Long.MAX_VALUE));
+
+        // when
+        CostLimit actual = mapper.toCostLimit(coreCostLimit);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toCostLimit_nullCoreCostLimit() {
+        // when
+        CostLimit actual = mapper.toCostLimit(null);
+
+        // then
+        assertThat(actual).isEqualTo(new CostLimit());
+    }
+
+}

--- a/src/test/java/com/epam/aidial/cfg/web/facade/mapper/CostLimitDtoMapperTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/facade/mapper/CostLimitDtoMapperTest.java
@@ -1,0 +1,84 @@
+package com.epam.aidial.cfg.web.facade.mapper;
+
+import com.epam.aidial.cfg.domain.model.CostLimit;
+import com.epam.aidial.cfg.dto.CostLimitDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        CostLimitDtoMapperImpl.class
+})
+class CostLimitDtoMapperTest {
+
+    @Autowired
+    private CostLimitDtoMapper mapper;
+
+    @Test
+    void toDomain_defaultCostLimitDto() {
+        // given
+        CostLimitDto costLimitDto = new CostLimitDto();
+
+        CostLimit expected = new CostLimit();
+
+        // when
+        CostLimit actual = mapper.toDomain(costLimitDto);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toDomain_allNonNullFieldsInCostLimitDto() {
+        // given
+        CostLimitDto costLimitDto = new CostLimitDto();
+        costLimitDto.setMinute(BigDecimal.valueOf(1));
+        costLimitDto.setDay(BigDecimal.valueOf(10));
+        costLimitDto.setWeek(BigDecimal.valueOf(100));
+        costLimitDto.setDay(BigDecimal.valueOf(1000));
+
+        CostLimit expected = new CostLimit();
+        expected.setMinute(BigDecimal.valueOf(1));
+        expected.setDay(BigDecimal.valueOf(10));
+        expected.setWeek(BigDecimal.valueOf(100));
+        expected.setDay(BigDecimal.valueOf(1000));
+
+        // when
+        CostLimit actual = mapper.toDomain(costLimitDto);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toDomain_nullDayInCostLimitDto() {
+        // given
+        CostLimitDto costLimitDto = new CostLimitDto();
+        costLimitDto.setDay(null);
+
+        CostLimit expected = new CostLimit();
+        expected.setDay(BigDecimal.valueOf(Long.MAX_VALUE));
+
+        // when
+        CostLimit actual = mapper.toDomain(costLimitDto);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void toDomain_nullCostLimitDto() {
+        // when
+        CostLimit actual = mapper.toDomain(null);
+
+        // then
+        assertThat(actual).isEqualTo(new CostLimit());
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #401 

### Description of changes
Handled `null` values in cost limit
```
{
  "name": "testRole",
  "costLimit": {
    "day": 45,
    "minute": null
  }
}
```
or explicit `null` cost limit
```
{
  "name": "testRole",
  "costLimit": null
}
```
for dto and core config


<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.