### PR TITLE
fix: #409 interceptor should inherit completion&configuration endpoint from teplate/runner if exist

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/InterceptorEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/InterceptorEntityMapper.java
@@ -9,6 +9,7 @@ import com.epam.aidial.cfg.dao.model.InterceptorContainerEntity;
 import com.epam.aidial.cfg.dao.model.InterceptorEntity;
 import com.epam.aidial.cfg.dao.model.InterceptorRunnerEntity;
 import com.epam.aidial.cfg.dao.model.ModelEntity;
+import com.epam.aidial.cfg.domain.model.Features;
 import com.epam.aidial.cfg.domain.model.Interceptor;
 import com.epam.aidial.cfg.domain.model.source.InterceptorContainerSource;
 import com.epam.aidial.cfg.domain.model.source.InterceptorEndpointsSource;
@@ -20,6 +21,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -85,6 +87,18 @@ public abstract class InterceptorEntityMapper {
         }
 
         return new InterceptorEndpointsSource();
+    }
+
+    @AfterMapping
+    protected void populateEndpointsFromRunner(@MappingTarget Interceptor interceptor, InterceptorEntity entity) {
+        InterceptorRunnerEntity runnerEntity = entity.getInterceptorRunner();
+        if (runnerEntity != null) {
+            interceptor.setEndpoint(runnerEntity.getCompletionEndpoint());
+            if (interceptor.getFeatures() == null) {
+                interceptor.setFeatures(new Features());
+            }
+            interceptor.getFeatures().setConfigurationEndpoint(runnerEntity.getConfigurationEndpoint());
+        }
     }
 
     private <T> Stream<String> getNames(Collection<T> entities, Function<T, String> modelEntityStringFunction) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorRunnerFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorRunnerFunctionalTest.java
@@ -9,6 +9,7 @@ import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorRunnerFacade;
+import com.epam.aidial.core.config.CoreInterceptor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +62,24 @@ public abstract class InterceptorRunnerFunctionalTest {
 
         Assertions.assertThrows(EntityNotFoundException.class, () -> interceptorRunnerFacade.getInterceptorRunner(interceptorRunnerDto.getName()));
         Assertions.assertTrue(interceptorRunnerFacade.getAllInterceptorRunners().isEmpty());
+    }
+
+    @Test
+    public void shouldSuccessfullyPopulateCoreInterceptorPropertiesFromTemplate() {
+        // Step 1: Create interceptorRunner
+        InterceptorRunnerDto runnerDto = createDto("template");
+        interceptorRunnerFacade.createInterceptorRunner(runnerDto);
+        
+        // Step 2: Create Interceptor with runner as source
+        InterceptorDto interceptorDto = createInterceptorDto("test", runnerDto.getName());
+        interceptorFacade.createInterceptor(interceptorDto);
+        
+        // Step 3: Get interceptor in core format
+        CoreInterceptor coreInterceptor = interceptorFacade.getCoreInterceptorWithHash(interceptorDto.getName()).core();
+        
+        // Step 4: Validate endpoints inherited from runner
+        Assertions.assertEquals(runnerDto.getCompletionEndpoint(), coreInterceptor.getEndpoint());
+        Assertions.assertEquals(runnerDto.getConfigurationEndpoint(), coreInterceptor.getFeatures().getConfigurationEndpoint());
     }
     
     @Test

--- a/src/test/resources/import/import_zip_preview.json
+++ b/src/test/resources/import/import_zip_preview.json
@@ -245,6 +245,7 @@
       "next": {
         "name": "testInterceptor2",
         "displayName": "Test Interceptor2",
+        "endpoint": "https://template.test.com/api",
         "forwardAuthToken": false,
         "author": "test-author",
         "dependencies": [],
@@ -261,7 +262,8 @@
           "cacheSupported": false,
           "autoCachingSupported": true,
           "consentRequired": false,
-          "parallelToolCallsSupported": true
+          "parallelToolCallsSupported": true,
+          "configurationEndpoint": "https://template.test.com/conf"
         },
         "defaults": {},
         "entities": [],


### PR DESCRIPTION

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #409

### Description of changes

<!-- Please explain the changes you made right below this line. -->
completion&configuration endpoints populated in interceptor from interceptorRunner (if source is runner)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.