### PR TITLE
chore: increase com.microsoft.sqlserver:mssql-jdbc dependency version from 12.10.0.jre11 to 12.10.2.jre11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '12.10.2.jre11'
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation "com.microsoft.sqlserver:mssql-jdbc:12.10.2"
+    implementation "com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11"
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
+    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '12.10.2.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc'
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre11'
+    implementation "com.microsoft.sqlserver:mssql-jdbc:12.10.2"
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
+    implementation "com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11"
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
     implementation 'com.h2database:h2'
     implementation 'org.postgresql:postgresql:42.7.7'
-    implementation "com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11"
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.flywaydb:flyway-core:11.4.1'


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Increased com.microsoft.sqlserver:mssql-jdbc dependency version from 12.10.0.jre11 to 12.10.2.jre11

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.