### PR TITLE
fix: #144 Validate datasource.vendor

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/Application.java
+++ b/src/main/java/com/epam/aidial/cfg/Application.java
@@ -1,6 +1,6 @@
 package com.epam.aidial.cfg;
 
-import com.epam.aidial.cfg.configuration.DatasourceVendorProperties;
+import com.epam.aidial.cfg.configuration.DatasourceVendorValidator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 public class Application {
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication(Application.class);
-        application.addListeners(new DatasourceVendorProperties());
+        application.addListeners(new DatasourceVendorValidator());
         application.run(args);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/Application.java
+++ b/src/main/java/com/epam/aidial/cfg/Application.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg;
 
+import com.epam.aidial.cfg.configuration.DatasourceVendorProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -11,6 +12,8 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 @EnableAspectJAutoProxy
 public class Application {
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication application = new SpringApplication(Application.class);
+        application.addListeners(new DatasourceVendorProperties());
+        application.run(args);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/configuration/DatasourceVendorProperties.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/DatasourceVendorProperties.java
@@ -2,23 +2,23 @@ package com.epam.aidial.cfg.configuration;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.Environment;
 
 import java.util.Set;
-import javax.annotation.PostConstruct;
 
 @Slf4j
-@Configuration
-public class DatasourceVendorProperties {
+public class DatasourceVendorProperties implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
 
     private static final Set<String> VALID_VENDORS = Set.of("H2", "POSTGRES", "MS_SQL_SERVER");
+    private static final String DATASOURCE_VENDOR_PROPERTY = "datasource.vendor";
 
-    @Value("${datasource.vendor}")
-    private String vendor;
-
-    @PostConstruct
-    public void validateDatasourceVendor() {
+    @Override
+    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+        Environment environment = event.getEnvironment();
+        String vendor = environment.getProperty(DATASOURCE_VENDOR_PROPERTY);
+        
         log.info("Validating datasource.vendor property. Value: {}", vendor);
 
         if (StringUtils.isBlank(vendor)) {

--- a/src/main/java/com/epam/aidial/cfg/configuration/DatasourceVendorValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/DatasourceVendorValidator.java
@@ -9,7 +9,7 @@ import org.springframework.core.env.Environment;
 import java.util.Set;
 
 @Slf4j
-public class DatasourceVendorProperties implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+public class DatasourceVendorValidator implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
 
     private static final Set<String> VALID_VENDORS = Set.of("H2", "POSTGRES", "MS_SQL_SERVER");
     private static final String DATASOURCE_VENDOR_PROPERTY = "datasource.vendor";

--- a/src/test/java/com/epam/aidial/cfg/configuration/DatasourceVendorPropertiesTest.java
+++ b/src/test/java/com/epam/aidial/cfg/configuration/DatasourceVendorPropertiesTest.java
@@ -4,35 +4,42 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DatasourceVendorPropertiesTest {
 
     @ParameterizedTest
     @CsvSource({"H2", "POSTGRES", "MS_SQL_SERVER"})
-    void whenVendorIsValid_thenValidationSucceeds(String vendor) throws Exception {
+    void whenVendorIsValid_thenValidationSucceeds(String vendor) {
         DatasourceVendorProperties properties = new DatasourceVendorProperties();
-        ReflectionTestUtils.setField(properties, "vendor", vendor);
+        ApplicationEnvironmentPreparedEvent event = createEventWithVendor(vendor);
 
-        assertThatCode(() -> properties.validateDatasourceVendor())
+        assertThatCode(() -> properties.onApplicationEvent(event))
                 .doesNotThrowAnyException();
     }
 
     @ParameterizedTest
     @MethodSource("invalidVendors")
-    void whenVendorIsInvalid_thenValidationFails(String vendor, String expectedMessagePart) throws Exception {
+    void whenVendorIsInvalid_thenValidationFails(String vendor, String expectedMessagePart) {
         DatasourceVendorProperties properties = new DatasourceVendorProperties();
-        ReflectionTestUtils.setField(properties, "vendor", vendor);
+        ApplicationEnvironmentPreparedEvent event = createEventWithVendor(vendor);
 
-        assertThatThrownBy(() -> properties.validateDatasourceVendor())
+        assertThatThrownBy(() -> properties.onApplicationEvent(event))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(expectedMessagePart)
-                .hasMessageContaining("Valid values are: "); //valid values order is not guaranteed
+                .hasMessageContaining("Valid values are");
     }
 
     private static Stream<Arguments> invalidVendors() {
@@ -45,6 +52,21 @@ class DatasourceVendorPropertiesTest {
                 Arguments.of("   ", "Undefined datasource.vendor value"),
                 Arguments.of(null, "Undefined datasource.vendor value")
         );
+    }
+
+    private ApplicationEnvironmentPreparedEvent createEventWithVendor(String vendor) {
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        
+        Map<String, Object> properties = new HashMap<>();
+        if (vendor != null) {
+            properties.put("datasource.vendor", vendor);
+        }
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        
+        ApplicationEnvironmentPreparedEvent event = mock(ApplicationEnvironmentPreparedEvent.class);
+        when(event.getEnvironment()).thenReturn(environment);
+        
+        return event;
     }
 }
 

--- a/src/test/java/com/epam/aidial/cfg/configuration/DatasourceVendorValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/configuration/DatasourceVendorValidatorTest.java
@@ -18,12 +18,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class DatasourceVendorPropertiesTest {
+class DatasourceVendorValidatorTest {
 
     @ParameterizedTest
     @CsvSource({"H2", "POSTGRES", "MS_SQL_SERVER"})
     void whenVendorIsValid_thenValidationSucceeds(String vendor) {
-        DatasourceVendorProperties properties = new DatasourceVendorProperties();
+        DatasourceVendorValidator properties = new DatasourceVendorValidator();
         ApplicationEnvironmentPreparedEvent event = createEventWithVendor(vendor);
 
         assertThatCode(() -> properties.onApplicationEvent(event))
@@ -33,7 +33,7 @@ class DatasourceVendorPropertiesTest {
     @ParameterizedTest
     @MethodSource("invalidVendors")
     void whenVendorIsInvalid_thenValidationFails(String vendor, String expectedMessagePart) {
-        DatasourceVendorProperties properties = new DatasourceVendorProperties();
+        DatasourceVendorValidator properties = new DatasourceVendorValidator();
         ApplicationEnvironmentPreparedEvent event = createEventWithVendor(vendor);
 
         assertThatThrownBy(() -> properties.onApplicationEvent(event))


### PR DESCRIPTION
…pplicationEnvironmentPreparedEvent

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #144

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Validate datasource.vendor before Flyway migrations

Replace @PostConstruct validation with ApplicationListener<ApplicationEnvironmentPreparedEvent>
to ensure validation runs before Flyway auto-configuration resolves migration paths.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.