### PR TITLE
feat: support filtering by topics for full config export request

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/model/ExportConfigComponentType.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/ExportConfigComponentType.java
@@ -55,7 +55,7 @@ public enum ExportConfigComponentType {
     INTERCEPTOR {
         @Override
         public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
-            Set<ExportConfigComponentType> result = new HashSet<>(2);
+            Set<ExportConfigComponentType> result = new HashSet<>(1);
             if (exportFormat == ExportFormat.ADMIN) {
                 result.add(INTERCEPTOR_RUNNER);
             }

--- a/src/main/java/com/epam/aidial/cfg/domain/model/ExportConfigComponentType.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/model/ExportConfigComponentType.java
@@ -1,17 +1,89 @@
 package com.epam.aidial.cfg.domain.model;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public enum ExportConfigComponentType {
 
-    MODEL,
-    APPLICATION,
-    ROUTE,
-    TOOL_SET,
+    MODEL {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            Set<ExportConfigComponentType> result = new HashSet<>(2);
+            if (exportFormat == ExportFormat.ADMIN) {
+                result.add(ADAPTER);
+            }
+            result.add(INTERCEPTOR);
+            return result;
+        }
+    },
 
-    ROLE,
-    KEY,
-    INTERCEPTOR,
-    INTERCEPTOR_RUNNER,
-    APPLICATION_TYPE_SCHEMA,
-    ADAPTER
+    APPLICATION {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of(INTERCEPTOR, APPLICATION_TYPE_SCHEMA);
+        }
+    },
+
+    ROUTE {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of();
+        }
+    },
+
+    TOOL_SET {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of();
+        }
+    },
+
+    ROLE {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of(MODEL, APPLICATION, TOOL_SET, ROUTE, APPLICATION_TYPE_SCHEMA, INTERCEPTOR);
+        }
+    },
+
+    KEY {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of(ROLE, MODEL, APPLICATION, APPLICATION_TYPE_SCHEMA, INTERCEPTOR);
+        }
+    },
+
+    INTERCEPTOR {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            Set<ExportConfigComponentType> result = new HashSet<>(2);
+            if (exportFormat == ExportFormat.ADMIN) {
+                result.add(INTERCEPTOR_RUNNER);
+            }
+            return result;
+        }
+    },
+
+    INTERCEPTOR_RUNNER {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of();
+        }
+    },
+
+    APPLICATION_TYPE_SCHEMA {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of();
+        }
+    },
+
+    ADAPTER {
+        @Override
+        public Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat) {
+            return Set.of();
+        }
+    };
+
+    public abstract Set<ExportConfigComponentType> getDependencies(ExportFormat exportFormat);
 
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ExportConfigComponentDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportConfigComponentDto.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.dto;
 
-import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -20,8 +19,8 @@ public class ExportConfigComponentDto {
     @NotBlank
     private String name;
     @NotNull
-    private ExportConfigComponentType type;
+    private ExportConfigComponentTypeDto type;
     @Builder.Default
-    private Set<ExportConfigComponentType> dependencies = new HashSet<>();
+    private Set<ExportConfigComponentTypeDto> dependencies = new HashSet<>();
 
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ExportConfigComponentTypeDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportConfigComponentTypeDto.java
@@ -1,0 +1,15 @@
+package com.epam.aidial.cfg.dto;
+
+public enum ExportConfigComponentTypeDto {
+
+    MODEL,
+    APPLICATION,
+    ROUTE,
+    TOOL_SET,
+    ROLE,
+    KEY,
+    INTERCEPTOR,
+    INTERCEPTOR_RUNNER,
+    APPLICATION_TYPE_SCHEMA,
+    ADAPTER
+}

--- a/src/main/java/com/epam/aidial/cfg/dto/ExportFormatDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportFormatDto.java
@@ -1,0 +1,7 @@
+package com.epam.aidial.cfg.dto;
+
+public enum ExportFormatDto {
+
+    CORE,
+    ADMIN
+}

--- a/src/main/java/com/epam/aidial/cfg/dto/ExportRequestDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportRequestDto.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.dto;
 
-import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.validation.constraints.NotNull;
@@ -15,7 +14,7 @@ import lombok.Data;
 public abstract class ExportRequestDto {
 
     @NotNull
-    private ExportFormat exportFormat;
+    private ExportFormatDto exportFormat;
     private boolean addSecrets;
 
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/FullExportRequestDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/FullExportRequestDto.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.dto;
 
-import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,5 +11,6 @@ import java.util.Set;
 public class FullExportRequestDto extends ExportRequestDto {
 
     @NotEmpty
-    private Set<ExportConfigComponentType> componentTypes;
+    private Set<ExportConfigComponentTypeDto> componentTypes;
+    private Set<String> topics;
 }

--- a/src/main/java/com/epam/aidial/cfg/model/FullExportRequest.java
+++ b/src/main/java/com/epam/aidial/cfg/model/FullExportRequest.java
@@ -15,4 +15,5 @@ import java.util.Set;
 public class FullExportRequest extends ExportRequest {
 
     private Set<ExportConfigComponentType> componentTypes;
+    private Set<String> topics;
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ConfigExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ConfigExporter.java
@@ -16,7 +16,9 @@ import com.epam.aidial.cfg.domain.model.ToolSet;
 import com.epam.aidial.cfg.domain.model.route.Route;
 import com.epam.aidial.cfg.model.ExportConfigComponent;
 import com.epam.aidial.cfg.model.ExportRequest;
+import com.epam.aidial.cfg.model.FullExportRequest;
 import com.epam.aidial.cfg.model.SelectedItemsExportRequest;
+import com.epam.aidial.cfg.service.config.transfer.exporter.util.FullToSelectedItemsExportRequestTransformer;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
@@ -49,10 +51,17 @@ public class ConfigExporter {
     private final AdapterExporter adapterExporter;
     private final ToolSetExporter toolSetExporter;
 
+    private final FullToSelectedItemsExportRequestTransformer fullToSelectedItemsExportRequestTransformer;
+
     public ExportConfig getConfig(ExportRequest request) {
+        if (request instanceof FullExportRequest exportRequest && exportRequest.getTopics() != null) {
+            request = fullToSelectedItemsExportRequestTransformer.transform(exportRequest);
+        }
+
         if (request instanceof SelectedItemsExportRequest exportRequest) {
             resolveDependencies(exportRequest);
         }
+
         ExportConfig config = new ExportConfig();
         Map<String, Application> applications = applicationExporter.getApplications(request);
         config.setApplications(applications);

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtils.java
@@ -1,0 +1,14 @@
+package com.epam.aidial.cfg.service.config.transfer.exporter.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Set;
+
+@UtilityClass
+public class ExportUtils {
+
+    public static boolean hasAnyRequestedTopic(Set<String> entityTopics, Set<String> requestedTopics) {
+        return requestedTopics == null
+                || (entityTopics != null && requestedTopics.stream().anyMatch(entityTopics::contains));
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/FullToSelectedItemsExportRequestTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/FullToSelectedItemsExportRequestTransformer.java
@@ -1,0 +1,147 @@
+package com.epam.aidial.cfg.service.config.transfer.exporter.util;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.service.AdapterService;
+import com.epam.aidial.cfg.domain.service.ApplicationService;
+import com.epam.aidial.cfg.domain.service.ApplicationTypeSchemaService;
+import com.epam.aidial.cfg.domain.service.InterceptorRunnerService;
+import com.epam.aidial.cfg.domain.service.InterceptorService;
+import com.epam.aidial.cfg.domain.service.KeyService;
+import com.epam.aidial.cfg.domain.service.ModelService;
+import com.epam.aidial.cfg.domain.service.RoleService;
+import com.epam.aidial.cfg.domain.service.RouteService;
+import com.epam.aidial.cfg.domain.service.ToolSetService;
+import com.epam.aidial.cfg.model.ExportConfigComponent;
+import com.epam.aidial.cfg.model.FullExportRequest;
+import com.epam.aidial.cfg.model.SelectedItemsExportRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.ADAPTER;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.APPLICATION;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.APPLICATION_TYPE_SCHEMA;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.INTERCEPTOR;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.INTERCEPTOR_RUNNER;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.KEY;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.MODEL;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.ROLE;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.ROUTE;
+import static com.epam.aidial.cfg.domain.model.ExportConfigComponentType.TOOL_SET;
+
+@Component
+@RequiredArgsConstructor
+@LogExecution
+public class FullToSelectedItemsExportRequestTransformer {
+
+    private final ModelService modelService;
+    private final ApplicationService applicationService;
+    private final RouteService routeService;
+    private final ToolSetService toolSetService;
+    private final RoleService roleService;
+    private final KeyService keyService;
+    private final InterceptorService interceptorService;
+    private final InterceptorRunnerService interceptorRunnerService;
+    private final ApplicationTypeSchemaService applicationTypeSchemaService;
+    private final AdapterService adapterService;
+
+    public SelectedItemsExportRequest transform(FullExportRequest fullExportRequest) {
+        SelectedItemsExportRequest selectedItemsExportRequest = new SelectedItemsExportRequest();
+        selectedItemsExportRequest.setExportFormat(fullExportRequest.getExportFormat());
+        selectedItemsExportRequest.setAddSecrets(fullExportRequest.isAddSecrets());
+        selectedItemsExportRequest.setComponents(getSelectedComponents(fullExportRequest));
+        return selectedItemsExportRequest;
+    }
+
+    private List<ExportConfigComponent> getSelectedComponents(FullExportRequest fullExportRequest) {
+        return fullExportRequest.getComponentTypes().stream()
+                .map(type -> switch (type) {
+                    case MODEL -> getModelExportComponents(fullExportRequest);
+                    case APPLICATION -> getApplicationExportComponents(fullExportRequest);
+                    case ROUTE -> getRouteExportComponents(fullExportRequest);
+                    case TOOL_SET -> getToolSetExportComponents(fullExportRequest);
+                    case ROLE -> getRoleExportComponents(fullExportRequest);
+                    case KEY -> getKeyExportComponents(fullExportRequest);
+                    case INTERCEPTOR -> getInterceptorExportComponents(fullExportRequest);
+                    case INTERCEPTOR_RUNNER -> getInterceptorRunnerExportComponents(fullExportRequest);
+                    case APPLICATION_TYPE_SCHEMA -> getAppTypeSchemaExportComponents(fullExportRequest);
+                    case ADAPTER -> getAdapterExportComponents(fullExportRequest);
+                })
+                .flatMap(Collection::stream)
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getModelExportComponents(FullExportRequest fullExportRequest) {
+        return modelService.getAll().stream()
+                .filter(model -> ExportUtils.hasAnyRequestedTopic(model.getTopics(), fullExportRequest.getTopics()))
+                .map(model -> new ExportConfigComponent(model.getDeployment().getName(), MODEL, MODEL.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getApplicationExportComponents(FullExportRequest fullExportRequest) {
+        return applicationService.getAllApplications().stream()
+                .filter(app -> ExportUtils.hasAnyRequestedTopic(app.getDescriptionKeywords(), fullExportRequest.getTopics()))
+                .map(app -> new ExportConfigComponent(app.getDeployment().getName(), APPLICATION, APPLICATION.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getRouteExportComponents(FullExportRequest fullExportRequest) {
+        return routeService.getAll().stream()
+                .map(route -> new ExportConfigComponent(route.getDeployment().getName(), ROUTE, ROUTE.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getToolSetExportComponents(FullExportRequest fullExportRequest) {
+        return toolSetService.getAll().stream()
+                .filter(toolSet -> ExportUtils.hasAnyRequestedTopic(toolSet.getDescriptionKeywords(), fullExportRequest.getTopics()))
+                .map(toolSet -> new ExportConfigComponent(toolSet.getDeployment().getName(), TOOL_SET, TOOL_SET.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getRoleExportComponents(FullExportRequest fullExportRequest) {
+        return roleService.getAllRoles().stream()
+                .map(role -> new ExportConfigComponent(role.getName(), ROLE, ROLE.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getKeyExportComponents(FullExportRequest fullExportRequest) {
+        return keyService.getAllKeys().stream()
+                .map(key -> new ExportConfigComponent(key.getName(), KEY, KEY.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getInterceptorExportComponents(FullExportRequest fullExportRequest) {
+        return interceptorService.getAll().stream()
+                .map(interceptor -> new ExportConfigComponent(interceptor.getName(), INTERCEPTOR, INTERCEPTOR.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getInterceptorRunnerExportComponents(FullExportRequest fullExportRequest) {
+        return interceptorRunnerService.getAll().stream()
+                .map(interceptorRunner -> new ExportConfigComponent(
+                        interceptorRunner.getName(),
+                        INTERCEPTOR_RUNNER,
+                        INTERCEPTOR_RUNNER.getDependencies(fullExportRequest.getExportFormat())
+                ))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getAppTypeSchemaExportComponents(FullExportRequest fullExportRequest) {
+        return applicationTypeSchemaService.getAll().stream()
+                .filter(schema -> ExportUtils.hasAnyRequestedTopic(schema.getTopics(), fullExportRequest.getTopics()))
+                .map(schema -> new ExportConfigComponent(
+                        schema.getSchemaId(),
+                        APPLICATION_TYPE_SCHEMA,
+                        APPLICATION_TYPE_SCHEMA.getDependencies(fullExportRequest.getExportFormat())
+                ))
+                .toList();
+    }
+
+    private List<ExportConfigComponent> getAdapterExportComponents(FullExportRequest fullExportRequest) {
+        return adapterService.getAll().stream()
+                .map(adapter -> new ExportConfigComponent(adapter.getName(), ADAPTER, ADAPTER.getDependencies(fullExportRequest.getExportFormat())))
+                .toList();
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/FullToSelectedItemsExportRequestTransformer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/FullToSelectedItemsExportRequestTransformer.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.service.config.transfer.exporter.util;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import com.epam.aidial.cfg.domain.service.AdapterService;
 import com.epam.aidial.cfg.domain.service.ApplicationService;
 import com.epam.aidial.cfg.domain.service.ApplicationTypeSchemaService;
@@ -15,6 +16,7 @@ import com.epam.aidial.cfg.model.ExportConfigComponent;
 import com.epam.aidial.cfg.model.FullExportRequest;
 import com.epam.aidial.cfg.model.SelectedItemsExportRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -76,72 +78,75 @@ public class FullToSelectedItemsExportRequestTransformer {
     private List<ExportConfigComponent> getModelExportComponents(FullExportRequest fullExportRequest) {
         return modelService.getAll().stream()
                 .filter(model -> ExportUtils.hasAnyRequestedTopic(model.getTopics(), fullExportRequest.getTopics()))
-                .map(model -> new ExportConfigComponent(model.getDeployment().getName(), MODEL, MODEL.getDependencies(fullExportRequest.getExportFormat())))
+                .map(model -> exportConfigComponent(fullExportRequest, model.getDeployment().getName(), MODEL))
                 .toList();
     }
 
     private List<ExportConfigComponent> getApplicationExportComponents(FullExportRequest fullExportRequest) {
         return applicationService.getAllApplications().stream()
                 .filter(app -> ExportUtils.hasAnyRequestedTopic(app.getDescriptionKeywords(), fullExportRequest.getTopics()))
-                .map(app -> new ExportConfigComponent(app.getDeployment().getName(), APPLICATION, APPLICATION.getDependencies(fullExportRequest.getExportFormat())))
+                .map(app -> exportConfigComponent(fullExportRequest, app.getDeployment().getName(), APPLICATION))
                 .toList();
     }
 
     private List<ExportConfigComponent> getRouteExportComponents(FullExportRequest fullExportRequest) {
         return routeService.getAll().stream()
-                .map(route -> new ExportConfigComponent(route.getDeployment().getName(), ROUTE, ROUTE.getDependencies(fullExportRequest.getExportFormat())))
+                .map(route -> exportConfigComponent(fullExportRequest, route.getDeployment().getName(), ROUTE))
                 .toList();
     }
 
     private List<ExportConfigComponent> getToolSetExportComponents(FullExportRequest fullExportRequest) {
         return toolSetService.getAll().stream()
                 .filter(toolSet -> ExportUtils.hasAnyRequestedTopic(toolSet.getDescriptionKeywords(), fullExportRequest.getTopics()))
-                .map(toolSet -> new ExportConfigComponent(toolSet.getDeployment().getName(), TOOL_SET, TOOL_SET.getDependencies(fullExportRequest.getExportFormat())))
+                .map(toolSet -> exportConfigComponent(fullExportRequest, toolSet.getDeployment().getName(), TOOL_SET))
                 .toList();
     }
 
     private List<ExportConfigComponent> getRoleExportComponents(FullExportRequest fullExportRequest) {
         return roleService.getAllRoles().stream()
-                .map(role -> new ExportConfigComponent(role.getName(), ROLE, ROLE.getDependencies(fullExportRequest.getExportFormat())))
+                .map(role -> exportConfigComponent(fullExportRequest, role.getName(), ROLE))
                 .toList();
     }
 
     private List<ExportConfigComponent> getKeyExportComponents(FullExportRequest fullExportRequest) {
         return keyService.getAllKeys().stream()
-                .map(key -> new ExportConfigComponent(key.getName(), KEY, KEY.getDependencies(fullExportRequest.getExportFormat())))
+                .map(key -> exportConfigComponent(fullExportRequest, key.getName(), KEY))
                 .toList();
     }
 
     private List<ExportConfigComponent> getInterceptorExportComponents(FullExportRequest fullExportRequest) {
         return interceptorService.getAll().stream()
-                .map(interceptor -> new ExportConfigComponent(interceptor.getName(), INTERCEPTOR, INTERCEPTOR.getDependencies(fullExportRequest.getExportFormat())))
+                .map(interceptor -> exportConfigComponent(fullExportRequest, interceptor.getName(), INTERCEPTOR))
                 .toList();
     }
 
     private List<ExportConfigComponent> getInterceptorRunnerExportComponents(FullExportRequest fullExportRequest) {
         return interceptorRunnerService.getAll().stream()
-                .map(interceptorRunner -> new ExportConfigComponent(
-                        interceptorRunner.getName(),
-                        INTERCEPTOR_RUNNER,
-                        INTERCEPTOR_RUNNER.getDependencies(fullExportRequest.getExportFormat())
-                ))
+                .map(interceptorRunner -> exportConfigComponent(fullExportRequest, interceptorRunner.getName(), INTERCEPTOR_RUNNER))
                 .toList();
     }
 
     private List<ExportConfigComponent> getAppTypeSchemaExportComponents(FullExportRequest fullExportRequest) {
         return applicationTypeSchemaService.getAll().stream()
                 .filter(schema -> ExportUtils.hasAnyRequestedTopic(schema.getTopics(), fullExportRequest.getTopics()))
-                .map(schema -> new ExportConfigComponent(
-                        schema.getSchemaId(),
-                        APPLICATION_TYPE_SCHEMA,
-                        APPLICATION_TYPE_SCHEMA.getDependencies(fullExportRequest.getExportFormat())
-                ))
+                .map(schema -> exportConfigComponent(fullExportRequest, schema.getSchemaId(), APPLICATION_TYPE_SCHEMA))
                 .toList();
     }
 
     private List<ExportConfigComponent> getAdapterExportComponents(FullExportRequest fullExportRequest) {
         return adapterService.getAll().stream()
-                .map(adapter -> new ExportConfigComponent(adapter.getName(), ADAPTER, ADAPTER.getDependencies(fullExportRequest.getExportFormat())))
+                .map(adapter -> exportConfigComponent(fullExportRequest, adapter.getName(), ADAPTER))
                 .toList();
     }
+
+    private ExportConfigComponent exportConfigComponent(FullExportRequest fullExportRequest,
+                                                        String name,
+                                                        ExportConfigComponentType exportConfigComponentType) {
+        var dependencies = SetUtils.intersection(
+                fullExportRequest.getComponentTypes(),
+                exportConfigComponentType.getDependencies(fullExportRequest.getExportFormat())
+        );
+        return new ExportConfigComponent(name, exportConfigComponentType, dependencies);
+    }
+
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -1101,6 +1101,43 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     @Test
+    void testExport_AdminFormatApplication_FullRequestWithTopics() throws IOException, URISyntaxException {
+        // Given
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.ADMIN);
+        request.setComponentTypes(Set.of(ExportConfigComponentType.APPLICATION));
+        request.setTopics(Set.of("a", "b"));
+
+        ApplicationTypeSchemaDto typeSchemaDto = jsonMapper.readValue(getAppRunnerDto(), new TypeReference<>() {
+        });
+        typeSchemaDto.setTopics(Set.of("a", "b"));
+        applicationTypeSchemaFacade.create(typeSchemaDto);
+
+        URI customAppSchemaId = new URI("https://test-schema-id.example");
+
+        ApplicationDto applicationDto1 = createBaseApplicationDto("1");
+        applicationDto1.setCustomAppSchemaId(customAppSchemaId);
+        applicationDto1.setTopics(List.of("b", "c", "d"));
+        applicationFacade.createApplication(applicationDto1);
+
+        // When
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // Then
+        ExportConfig result = extractConfigFromZip(streamingResponseBody);
+
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getApplicationRunners()).isEmpty();
+            Assertions.assertThat(config.getApplications()).isNotEmpty()
+                    .containsOnlyKeys(applicationDto1.getName())
+                    .satisfies(apps -> {
+                        Application app = apps.get(applicationDto1.getName());
+                        Assertions.assertThat(app.getApplicationTypeSchemaId()).isNull();
+                    });
+        });
+    }
+
+    @Test
     void testExport_AdminFormatModelWithInterceptorAndRoleAndAdapter_FullRequest() throws IOException {
         // given
         Set<ExportConfigComponentType> componentTypes = Set.of(

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.functional.tests;
 import com.epam.aidial.cfg.configuration.CoreConfigVersionProperties;
 import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.domain.model.Adapter;
+import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.model.ExportApplicationTypeSchemaInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfig;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
@@ -120,6 +121,7 @@ import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createMo
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRouteDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRouteDtoWithLimits;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createToolSetDtoWithoutRoleLimits;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -1032,6 +1034,69 @@ public abstract class ConfigTransferFunctionalTest {
                                     Assertions.assertThat(upstream.getExtraData()).isEqualTo(expectedUpstream.getExtraData());
                                 });
                     });
+        });
+    }
+
+    @Test
+    void testExport_AdminFormatAll_FullRequestWithTopics() throws IOException, URISyntaxException {
+        // Given
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.ADMIN);
+        request.setComponentTypes(Arrays.stream(ExportConfigComponentType.values()).collect(Collectors.toSet()));
+        request.setTopics(Set.of("a", "b"));
+
+        ApplicationTypeSchemaDto typeSchemaDto = jsonMapper.readValue(getAppRunnerDto(), new TypeReference<>() {
+        });
+        typeSchemaDto.setTopics(Set.of("c", "d"));
+        applicationTypeSchemaFacade.create(typeSchemaDto);
+
+        URI customAppSchemaId = new URI("https://test-schema-id.example");
+
+        ApplicationDto applicationDto1 = createBaseApplicationDto("1");
+        applicationDto1.setCustomAppSchemaId(customAppSchemaId);
+        applicationDto1.setTopics(List.of("b", "c", "d"));
+        applicationFacade.createApplication(applicationDto1);
+
+        ApplicationDto applicationDto2 = createBaseApplicationDto("2");
+        applicationDto2.setCustomAppSchemaId(customAppSchemaId);
+        applicationDto2.setTopics(List.of("c", "d"));
+        applicationFacade.createApplication(applicationDto2);
+
+        ModelDto modelDto1 = createModelDto("1");
+        modelDto1.setTopics(List.of("a"));
+        modelFacade.createModel(modelDto1);
+
+        ModelDto modelDto2 = createModelDto("2");
+        modelDto2.setTopics(List.of("c"));
+        modelFacade.createModel(modelDto2);
+
+        ToolSetDto toolSetDto1 = createToolSetDtoWithoutRoleLimits("1");
+        toolSetDto1.setDescriptionKeywords(List.of("a", "b", "c"));
+        toolSetFacade.createToolSet(toolSetDto1);
+
+        ToolSetDto toolSetDto2 = createToolSetDtoWithoutRoleLimits("2");
+        toolSetDto2.setDescriptionKeywords(List.of("e", "f"));
+        toolSetFacade.createToolSet(toolSetDto2);
+
+        // When
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        // Then
+        ExportConfig result = extractConfigFromZip(streamingResponseBody);
+
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getApplicationRunners()).isNotEmpty()
+                    .containsOnlyKeys(customAppSchemaId.toString());
+            Assertions.assertThat(config.getApplications()).isNotEmpty()
+                    .containsOnlyKeys(applicationDto1.getName())
+                    .satisfies(apps -> {
+                        Application app = apps.get(applicationDto1.getName());
+                        Assertions.assertThat(app.getApplicationTypeSchemaId()).isEqualTo(customAppSchemaId);
+                    });
+            Assertions.assertThat(config.getModels()).isNotEmpty()
+                    .containsOnlyKeys(modelDto1.getName());
+            Assertions.assertThat(config.getToolsets()).isNotEmpty()
+                    .containsOnlyKeys(toolSetDto1.getName());
         });
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/utils/FunctionalTestHelper.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/utils/FunctionalTestHelper.java
@@ -63,17 +63,22 @@ public class FunctionalTestHelper {
         return adapterDto;
     }
 
-    public static ToolSetDto createToolSetDto(String suffix) {
+    public static ToolSetDto createToolSetDtoWithoutRoleLimits(String suffix) {
         ToolSetDto toolSet = new ToolSetDto();
         toolSet.setName("ToolSet" + suffix);
         toolSet.setDisplayName("ToolSet" + suffix);
         toolSet.setDescription("description" + suffix);
         toolSet.setEndpoint("https://endpoint.test.com/toolset" + suffix);
         toolSet.setTransport(ToolSetDto.TransportDto.HTTP);
+        toolSet.setMaxRetryAttempts(1);
+        return toolSet;
+    }
+
+    public static ToolSetDto createToolSetDto(String suffix) {
+        ToolSetDto toolSet = createToolSetDtoWithoutRoleLimits(suffix);
         toolSet.setRoleLimits(Map.of(
                 "role" + suffix, new LimitDto()
         ));
-        toolSet.setMaxRetryAttempts(1);
         return toolSet;
     }
 

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -7,12 +7,13 @@ import com.epam.aidial.cfg.domain.model.ExportApplicationTypeSchemaInfo;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import com.epam.aidial.cfg.domain.model.ExportConfigPreview;
-import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.ExportKeyInfo;
 import com.epam.aidial.cfg.domain.model.ImportComponent;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
 import com.epam.aidial.cfg.domain.model.Model;
 import com.epam.aidial.cfg.domain.utils.ModelEndpointUtils;
+import com.epam.aidial.cfg.dto.ExportConfigComponentTypeDto;
+import com.epam.aidial.cfg.dto.ExportFormatDto;
 import com.epam.aidial.cfg.dto.FullExportRequestDto;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
 import com.epam.aidial.cfg.service.config.ConfigSyncErrorHandler;
@@ -239,8 +240,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
     void testExport_CoreFormat() throws Exception {
         // given
         FullExportRequestDto request = new FullExportRequestDto();
-        request.setExportFormat(ExportFormat.CORE);
-        request.setComponentTypes(Set.of(ExportConfigComponentType.KEY));
+        request.setExportFormat(ExportFormatDto.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentTypeDto.KEY));
         request.setAddSecrets(true);
         var data = "exportConfig";
         StreamingResponseBody streamingResponse = outputStream -> outputStream.write(data.getBytes());
@@ -262,8 +263,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
         // given
         FullExportRequestDto request = new FullExportRequestDto();
         request.setAddSecrets(false);
-        request.setExportFormat(ExportFormat.ADMIN);
-        request.setComponentTypes(Set.of(ExportConfigComponentType.KEY));
+        request.setExportFormat(ExportFormatDto.ADMIN);
+        request.setComponentTypes(Set.of(ExportConfigComponentTypeDto.KEY));
         var data = "exportConfig";
         StreamingResponseBody streamingResponse = outputStream -> outputStream.write(data.getBytes());
         when(configTransfer.exportConfig(any())).thenReturn(streamingResponse);
@@ -283,8 +284,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
     void testExportPreview_Key_CoreFormat() throws Exception {
         // given
         FullExportRequestDto request = new FullExportRequestDto();
-        request.setExportFormat(ExportFormat.CORE);
-        request.setComponentTypes(Set.of(ExportConfigComponentType.KEY));
+        request.setExportFormat(ExportFormatDto.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentTypeDto.KEY));
         ExportKeyInfo componentInfo = ExportKeyInfo.builder()
                 .type(ExportConfigComponentType.KEY)
                 .name("keyName")
@@ -311,8 +312,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
     void testExportPreview_ApplicationTypeSchema_CoreFormat() throws Exception {
         // given
         FullExportRequestDto request = new FullExportRequestDto();
-        request.setExportFormat(ExportFormat.CORE);
-        request.setComponentTypes(Set.of(ExportConfigComponentType.APPLICATION_TYPE_SCHEMA));
+        request.setExportFormat(ExportFormatDto.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentTypeDto.APPLICATION_TYPE_SCHEMA));
         ExportApplicationTypeSchemaInfo componentInfo = ExportApplicationTypeSchemaInfo.builder()
                 .type(ExportConfigComponentType.APPLICATION_TYPE_SCHEMA)
                 .id("id")
@@ -339,8 +340,8 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
     void testExportPreview_ToolSets_CoreFormat() throws Exception {
         // given
         FullExportRequestDto request = new FullExportRequestDto();
-        request.setExportFormat(ExportFormat.CORE);
-        request.setComponentTypes(Set.of(ExportConfigComponentType.TOOL_SET));
+        request.setExportFormat(ExportFormatDto.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentTypeDto.TOOL_SET));
 
         ExportComponentInfo componentInfo = ExportComponentInfo.builder()
                 .type(ExportConfigComponentType.TOOL_SET)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #446

### Description of changes
Added `Set<String> topics` field into `FullExportRequestDto` dto to support filtering of full config export by topics
Minor dto + model refactoring

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.