### PR TITLE
feat: add validity state migrations for application and keys, add one more validation rule for keys

### DIFF
--- a/local_env/docker-compose.yml
+++ b/local_env/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       METRICS_STORAGE_HOST: "http://influxdb:8086"
       METRICS_STORAGE_TOKEN: "myadmintoken"
       CORE_CLIENT_URL: "http://core:8080"
+      CORE_CONFIG_VERSION: latest
       DISABLE_SWAGGER_AUTHORIZATION: true
       H2_FILE: ./data/testdb
       H2_DATASOURCE_MASTER_KEY: t8+npcgNMiipR+kHMb8zXAjgA3IedCXC

--- a/local_env/docker-compose.yml
+++ b/local_env/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       METRICS_STORAGE_HOST: "http://influxdb:8086"
       METRICS_STORAGE_TOKEN: "myadmintoken"
       CORE_CLIENT_URL: "http://core:8080"
-      CORE_CONFIG_VERSION: latest
       DISABLE_SWAGGER_AUTHORIZATION: true
       H2_FILE: ./data/testdb
       H2_DATASOURCE_MASTER_KEY: t8+npcgNMiipR+kHMb8zXAjgA3IedCXC

--- a/src/main/java/com/epam/aidial/cfg/dao/listener/validitystate/resolver/KeyValidityStateResolver.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/listener/validitystate/resolver/KeyValidityStateResolver.java
@@ -4,18 +4,43 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.dao.model.KeyEntity;
 import com.epam.aidial.cfg.dao.model.ValidityStateEntity;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @LogExecution
 public class KeyValidityStateResolver {
 
     public ValidityStateEntity resolveValidityState(KeyEntity entity) {
-        String validityStateMessage = CollectionUtils.isEmpty(entity.getRoles()) ? "No roles assigned" : null;
-
         ValidityStateEntity validityStateEntity = new ValidityStateEntity();
-        validityStateEntity.setMessage(validityStateMessage);
-        validityStateEntity.setValid(validityStateMessage == null);
+
+        List<String> validationMessages = getValidationMessages(entity);
+
+        if (!validationMessages.isEmpty()) {
+            String validityStateMessage = String.join(", ", validationMessages);
+            validityStateEntity.setMessage(validityStateMessage);
+            validityStateEntity.setValid(false);
+        } else {
+            validityStateEntity.setValid(true);
+        }
+
         return validityStateEntity;
+    }
+
+    private List<String> getValidationMessages(KeyEntity entity) {
+        List<String> errors = new ArrayList<>(2);
+
+        if (CollectionUtils.isEmpty(entity.getRoles())) {
+            errors.add("No roles assigned");
+        }
+
+        if (StringUtils.isBlank(entity.getKey())) {
+            errors.add("Key value is missing");
+        }
+
+        return errors;
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ApplicationInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ApplicationInfoDto.java
@@ -28,4 +28,6 @@ public class ApplicationInfoDto {
     private String viewerUrl;
     private String editorUrl;
 
+    private ValidityStateDto validityState;
+
 }

--- a/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
+++ b/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
@@ -1,0 +1,218 @@
+package com.epam.aidial.cfg.migration.db;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.networknt.schema.ExecutionContext;
+import com.networknt.schema.Format;
+import com.networknt.schema.JsonMetaSchema;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.JsonType;
+import com.networknt.schema.NonValidationKeyword;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.TypeFactory;
+import com.networknt.schema.ValidationContext;
+import com.networknt.schema.ValidationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Slf4j
+//CHECKSTYLE:OFF
+public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends BaseJavaMigration {
+
+    //CHECKSTYLE:ON
+
+    private static final String SELECT_APPLICATIONS_WITH_SCHEMA = """
+            select app.deployment_name, app.application_properties,
+            app_schema.schema_id, app_schema.schema, app_schema.defs, app_schema.properties, app_schema.required
+            from application_entity app
+            join application_type_schema_entity app_schema on app_schema.schema_id = app.application_type_schema_id""";
+
+    private static final String UPDATE_APPLICATION_VALIDITY_STATE = """
+            update application_entity set validity_state_message = ?, validity_state_is_valid = ?
+            where deployment_name = ?""";
+
+    private static final JsonMetaSchema.Builder METASCHEMA_BUILDER = JsonMetaSchema.builder("https://dial.epam.com/application_type_schemas/schema#", JsonMetaSchema.getV7())
+            .keyword(new NonValidationKeyword("dial:applicationTypeEditorUrl"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeViewerUrl"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeDisplayName"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeCompletionEndpoint"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeConfigurationEndpoint"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeRateEndpoint"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeTokenizeEndpoint"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeTruncatePromptEndpoint"))
+            .keyword(new NonValidationKeyword("dial:appendApplicationPropertiesHeader"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeIconUrl"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeRoutes"))
+            .keyword(new NonValidationKeyword("dial:applicationTypePlaybackSupport"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeBucketCopy"))
+            .keyword(new NonValidationKeyword("dial:applicationTypeInterceptors"))
+            .keyword(new NonValidationKeyword("dial:propertyKind"))
+            .keyword(new NonValidationKeyword("dial:propertyOrder"))
+            .keyword(new NonValidationKeyword("$defs"))
+            .format(new DialFileFormat());
+
+    private static final JsonMetaSchema DIAL_META_SCHEMA = METASCHEMA_BUILDER
+            .keyword(new NonValidationKeyword("dial:meta"))
+            .keyword(new NonValidationKeyword("dial:file"))
+            .keyword(new NonValidationKeyword("dial:resource"))
+            .build();
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try (Statement selectStatement = connection.createStatement();
+                ResultSet result = selectStatement.executeQuery(SELECT_APPLICATIONS_WITH_SCHEMA);
+                PreparedStatement updateStatement = connection.prepareStatement(UPDATE_APPLICATION_VALIDITY_STATE)) {
+
+            while (result.next()) {
+                Application application = readApp(objectMapper, result);
+                ApplicationTypeSchema applicationTypeSchema = readAppTypeSchema(objectMapper, result);
+
+                Set<ValidationMessage> validationMessages = validateAppProperties(
+                        objectMapper,
+                        application.applicationProperties(),
+                        applicationTypeSchema
+                );
+
+                if (!validationMessages.isEmpty()) {
+                    String validityStateMessage = validationMessages.stream()
+                            .map(ValidationMessage::getMessage)
+                            .collect(Collectors.joining(", "));
+                    updateStatement.setString(1, validityStateMessage);
+                    updateStatement.setBoolean(2, false);
+                } else {
+                    updateStatement.setNull(1, java.sql.Types.VARCHAR);
+                    updateStatement.setBoolean(2, true);
+                }
+
+                updateStatement.setString(3, application.name());
+                updateStatement.addBatch();
+            }
+
+            updateStatement.executeBatch();
+        }
+    }
+
+    private Application readApp(ObjectMapper objectMapper, ResultSet result) throws SQLException, JsonProcessingException {
+        return new Application(
+                result.getString("deployment_name"),
+                map(objectMapper, result.getString("application_properties"))
+        );
+    }
+
+    private ApplicationTypeSchema readAppTypeSchema(ObjectMapper objectMapper, ResultSet result) throws SQLException, JsonProcessingException {
+        return new ApplicationTypeSchema(
+                result.getString("schema_id"),
+                result.getString("schema"),
+                map(objectMapper, result.getString("defs")),
+                map(objectMapper, result.getString("properties")),
+                readArray(result, "required")
+        );
+    }
+
+    private Object readArray(ResultSet resultSet, String columnName) throws SQLException {
+        var value = resultSet.getArray(columnName);
+        return resultSet.wasNull() ? null : value.getArray();
+    }
+
+    private <T> Map<String, T> map(ObjectMapper objectMapper, String value) throws JsonProcessingException {
+        if (value == null) {
+            return Map.of();
+        }
+        return objectMapper.readValue(value, new TypeReference<>() {
+        });
+    }
+
+    private Set<ValidationMessage> validateAppProperties(ObjectMapper objectMapper,
+                                                         Map<String, Object> appProperties,
+                                                         ApplicationTypeSchema applicationTypeSchema) throws JsonProcessingException, URISyntaxException {
+        String schemaId = applicationTypeSchema.schemaId();
+
+        Map<String, String> applicationTypeSchemas = Map.of(schemaId, objectMapper.writeValueAsString(applicationTypeSchema));
+
+        JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7, builder ->
+                builder.schemaLoaders(loaders -> loaders.schemas(applicationTypeSchemas))
+                        .metaSchema(DIAL_META_SCHEMA)
+        );
+        JsonNode applicationNode = objectMapper.valueToTree(appProperties);
+        JsonSchema schema = schemaFactory.getSchema(new URI(schemaId));
+
+        return schema.validate(applicationNode);
+    }
+
+    private record Application(String name, Map<String, Object> applicationProperties) {
+    }
+
+    private record ApplicationTypeSchema(@JsonProperty("$id")
+                                         String schemaId,
+                                         @JsonProperty("$schema")
+                                         String schema,
+                                         @JsonSerialize(using = JsonMapSerializer.class)
+                                         Map<String, String> defs,
+                                         @JsonSerialize(using = JsonMapSerializer.class)
+                                         Map<String, String> properties,
+                                         Object required) {
+    }
+
+    public static class JsonMapSerializer extends JsonSerializer<Map<String, String>> {
+
+        @Override
+        public void serialize(Map<String, String> map, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+            jsonGenerator.writeStartObject();
+
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                jsonGenerator.writeFieldName(entry.getKey());
+                jsonGenerator.writeRawValue(entry.getValue());
+            }
+
+            jsonGenerator.writeEndObject();
+        }
+    }
+
+    public static class DialFileFormat implements Format {
+
+        private static final Pattern PATTERN = Pattern.compile("^files/([a-zA-Z0-9]+)/((?:(?:[a-zA-Z0-9_\\-.~]|%[a-zA-Z0-9]{2})+/?)+)$");
+
+        @Override
+        public boolean matches(ExecutionContext executionContext, ValidationContext validationContext, JsonNode value) {
+            JsonType nodeType = TypeFactory.getValueNodeType(value, validationContext.getConfig());
+            if (nodeType != JsonType.STRING) {
+                return false;
+            }
+            String nodeValue = value.textValue();
+            Matcher matcher = PATTERN.matcher(nodeValue);
+            return matcher.matches();
+        }
+
+        @Override
+        public String getName() {
+            return "dial-file-encoded";
+        }
+    }
+
+}

--- a/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
+++ b/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
@@ -179,7 +179,7 @@ public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends 
                                          Object required) {
     }
 
-    public static class JsonMapSerializer extends JsonSerializer<Map<String, String>> {
+    private static class JsonMapSerializer extends JsonSerializer<Map<String, String>> {
 
         @Override
         public void serialize(Map<String, String> map, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
@@ -194,7 +194,7 @@ public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends 
         }
     }
 
-    public static class DialFileFormat implements Format {
+    private static class DialFileFormat implements Format {
 
         private static final Pattern PATTERN = Pattern.compile("^files/([a-zA-Z0-9]+)/((?:(?:[a-zA-Z0-9_\\-.~]|%[a-zA-Z0-9]{2})+/?)+)$");
 

--- a/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
+++ b/src/main/java/com/epam/aidial/cfg/migration/db/V1_78__MigrateValidityStateColumnsInApplicationEntityTable.java
@@ -46,7 +46,7 @@ public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends 
 
     private static final String SELECT_APPLICATIONS_WITH_SCHEMA = """
             select app.deployment_name, app.application_properties,
-            app_schema.schema_id, app_schema.schema, app_schema.defs, app_schema.properties, app_schema.required
+            app_schema.schema_id, app_schema.defs, app_schema.properties, app_schema.required
             from application_entity app
             join application_type_schema_entity app_schema on app_schema.schema_id = app.application_type_schema_id""";
 
@@ -128,7 +128,6 @@ public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends 
     private ApplicationTypeSchema readAppTypeSchema(ObjectMapper objectMapper, ResultSet result) throws SQLException, JsonProcessingException {
         return new ApplicationTypeSchema(
                 result.getString("schema_id"),
-                result.getString("schema"),
                 map(objectMapper, result.getString("defs")),
                 map(objectMapper, result.getString("properties")),
                 readArray(result, "required")
@@ -170,8 +169,6 @@ public class V1_78__MigrateValidityStateColumnsInApplicationEntityTable extends 
 
     private record ApplicationTypeSchema(@JsonProperty("$id")
                                          String schemaId,
-                                         @JsonProperty("$schema")
-                                         String schema,
                                          @JsonSerialize(using = JsonMapSerializer.class)
                                          Map<String, String> defs,
                                          @JsonSerialize(using = JsonMapSerializer.class)

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ApplicationDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ApplicationDtoMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = {
-        LimitDtoMapper.class, RoleBasedDtoMapper.class, InstantMapper.class, FeaturesDtoMapper.class, RouteDtoMapper.class
+        LimitDtoMapper.class, RoleBasedDtoMapper.class, InstantMapper.class, FeaturesDtoMapper.class, RouteDtoMapper.class, ValidityStateDtoMapper.class
 })
 public interface ApplicationDtoMapper {
 

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/KeyDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/KeyDtoMapper.java
@@ -5,7 +5,7 @@ import com.epam.aidial.cfg.dto.KeyDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = InstantMapper.class)
+@Mapper(componentModel = "spring", uses = {InstantMapper.class, ValidityStateDtoMapper.class})
 public interface KeyDtoMapper {
 
     @Mapping(target = "createdAt", ignore = true)

--- a/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ValidityStateDtoMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/mapper/ValidityStateDtoMapper.java
@@ -1,0 +1,13 @@
+package com.epam.aidial.cfg.web.facade.mapper;
+
+import com.epam.aidial.cfg.domain.model.ValidityState;
+import com.epam.aidial.cfg.dto.ValidityStateDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ValidityStateDtoMapper {
+
+    ValidityState toValidityState(ValidityStateDto validityStateDto);
+
+    ValidityStateDto toValidityStateDto(ValidityState validityState);
+}

--- a/src/main/resources/db/migration/H2/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
+++ b/src/main/resources/db/migration/H2/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
@@ -1,0 +1,24 @@
+update key_entity
+set
+  validity_state_message = case
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and trim(key_value) <> ''
+      then 'No roles assigned'
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or trim(key_value) = '')
+      then 'Key value is missing'
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or trim(key_value) = '')
+      then 'No roles assigned, Key value is missing'
+    else null
+  end,
+  validity_state_is_valid = case
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and trim(key_value) <> ''
+      then true
+    else false
+  end;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
@@ -3,22 +3,22 @@ set
   validity_state_message = case
     when not exists (
       select 1 from role_key where role_key.key_name = key_entity.name
-    ) and key_value is not null and ltrim(rtrim(key_value)) <> ''
+    ) and key_value is not null and trim(key_value) <> ''
       then 'No roles assigned'
     when exists (
       select 1 from role_key where role_key.key_name = key_entity.name
-    ) and (key_value is null or ltrim(rtrim(key_value)) = '')
+    ) and (key_value is null or trim(key_value) = '')
       then 'Key value is missing'
     when not exists (
       select 1 from role_key where role_key.key_name = key_entity.name
-    ) and (key_value is null or ltrim(rtrim(key_value)) = '')
+    ) and (key_value is null or trim(key_value) = '')
       then 'No roles assigned, Key value is missing'
     else null
   end,
   validity_state_is_valid = case
     when exists (
       select 1 from role_key where role_key.key_name = key_entity.name
-    ) and key_value is not null and ltrim(rtrim(key_value)) <> ''
+    ) and key_value is not null and trim(key_value) <> ''
       then 1
     else 0
   end;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
@@ -1,0 +1,24 @@
+update key_entity
+set
+  validity_state_message = case
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and ltrim(rtrim(key_value)) <> ''
+      then 'No roles assigned'
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or ltrim(rtrim(key_value)) = '')
+      then 'Key value is missing'
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or ltrim(rtrim(key_value)) = '')
+      then 'No roles assigned, Key value is missing'
+    else null
+  end,
+  validity_state_is_valid = case
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and ltrim(rtrim(key_value)) <> ''
+      then 1
+    else 0
+  end;

--- a/src/main/resources/db/migration/POSTGRES/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.77__UpdateValidityStateColumnsInKeyEntityTable.sql
@@ -1,0 +1,24 @@
+update key_entity
+set
+  validity_state_message = case
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and trim(key_value) <> ''
+      then 'No roles assigned'
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or trim(key_value) = '')
+      then 'Key value is missing'
+    when not exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and (key_value is null or trim(key_value) = '')
+      then 'No roles assigned, Key value is missing'
+    else null
+  end,
+  validity_state_is_valid = case
+    when exists (
+      select 1 from role_key where role_key.key_name = key_entity.name
+    ) and key_value is not null and trim(key_value) <> ''
+      then true
+    else false
+  end;

--- a/src/test/java/com/epam/aidial/cfg/dao/listener/validitystate/resolver/KeyValidityStateResolverTest.java
+++ b/src/test/java/com/epam/aidial/cfg/dao/listener/validitystate/resolver/KeyValidityStateResolverTest.java
@@ -19,12 +19,13 @@ class KeyValidityStateResolverTest {
     }
 
     @Test
-    void resolveValidityState_shouldReturnValidStateWhenKeyHasRoles() {
+    void resolveValidityState_shouldReturnValidStateWhenKeyHasRolesAndKeyValue() {
         // given
         RoleEntity roleEntity = new RoleEntity();
 
         KeyEntity keyEntity = new KeyEntity();
         keyEntity.setRoles(List.of(roleEntity));
+        keyEntity.setKey("key");
 
         ValidityStateEntity expected = new ValidityStateEntity();
         expected.setValid(true);
@@ -40,9 +41,45 @@ class KeyValidityStateResolverTest {
     void resolveValidityState_shouldReturnInvalidStateWhenKeyDoesNotHaveRoles() {
         // given
         KeyEntity keyEntity = new KeyEntity();
+        keyEntity.setKey("key");
 
         ValidityStateEntity expected = new ValidityStateEntity();
         expected.setMessage("No roles assigned");
+        expected.setValid(false);
+
+        // when
+        ValidityStateEntity actual = keyValidityStateResolver.resolveValidityState(keyEntity);
+
+        // then
+        Assertions.assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void resolveValidityState_shouldReturnInvalidStateWhenKeyDoesNotHaveKeyValue() {
+        // given
+        RoleEntity roleEntity = new RoleEntity();
+
+        KeyEntity keyEntity = new KeyEntity();
+        keyEntity.setRoles(List.of(roleEntity));
+
+        ValidityStateEntity expected = new ValidityStateEntity();
+        expected.setMessage("Key value is missing");
+        expected.setValid(false);
+
+        // when
+        ValidityStateEntity actual = keyValidityStateResolver.resolveValidityState(keyEntity);
+
+        // then
+        Assertions.assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void resolveValidityState_shouldReturnInvalidStateWhenKeyDoesNotHaveRolesAndKeyValue() {
+        // given
+        KeyEntity keyEntity = new KeyEntity();
+
+        ValidityStateEntity expected = new ValidityStateEntity();
+        expected.setMessage("No roles assigned, Key value is missing");
         expected.setValid(false);
 
         // when

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
@@ -160,7 +160,7 @@ public abstract class KeyFunctionalTest {
         Collection<KeyDto> expectedDtos = List.of(keyDto, keyDto2);
         expectedDtos.forEach(dto -> {
             dto.setRoles(List.of());
-            dto.setValidityState(invalidState("No roles assigned"));
+            dto.setValidityState(invalidState("No roles assigned, Key value is missing"));
         });
         assertKeys(actualKeys, expectedDtos, true);
     }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -48,6 +48,7 @@ import com.epam.aidial.cfg.web.facade.mapper.ShareResourceLimitDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.ToolSetDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.ToolSetSourceDtoMapperImpl;
 import com.epam.aidial.cfg.web.facade.mapper.UpstreamDtoMapperImpl;
+import com.epam.aidial.cfg.web.facade.mapper.ValidityStateDtoMapperImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,7 +86,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         AdapterDtoMapperImpl.class, ModelEndpointUtils.class, ShareResourceLimitDtoMapperImpl.class,
         InterceptorSourceDtoMapperImpl.class, InstantMapperImpl.class, FeaturesDtoMapperImpl.class, AttachmentPathDtoMapperImpl.class,
         ToolSetDtoMapperImpl.class, ModelSourceDtoMapperImpl.class, ResourceAuthSettingsDtoMapperImpl.class, CostLimitDtoMapperImpl.class,
-        ToolSetSourceDtoMapperImpl.class
+        ToolSetSourceDtoMapperImpl.class, ValidityStateDtoMapperImpl.class
 })
 class ConfigControllerTest extends AbstractControllerNoneSecureTest {
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #122 

### Description of changes
- Added DB migrations to calculate actual validity state for existing applications and keys
- Added rule that keys without key value become invalid

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.