### PR TITLE
fix: #470 Add Route.tier validation

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/UpstreamDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/UpstreamDto.java
@@ -6,6 +6,7 @@ import com.epam.aidial.core.config.databind.JsonToStringDeserializer;
 import com.epam.aidial.core.config.databind.StringToJsonSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,7 @@ public class UpstreamDto {
     @JsonSerialize(using = StringToJsonSerializer.class)
     private String extraData;
     private int weight = 1;
+    @Min(value = 0, message = "Tier must be a non-negative number")
     private int tier = 0;
 
     public String toString() {

--- a/src/main/java/com/epam/aidial/cfg/dto/UpstreamResourceDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/UpstreamResourceDto.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.dto;
 
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,5 +14,6 @@ public class UpstreamResourceDto {
     private String key;
     private String extraData;
     private int weight;
+    @Min(value = 0, message = "Tier must be a non-negative number")
     private int tier;
 }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
@@ -292,8 +292,6 @@ class RouteControllerTest extends AbstractControllerNoneSecureTest {
         dto.getUpstreams().get(0).setTier(-1);
         var invalidDtoJson = objectMapper.writeValueAsString(dto);
 
-        doNothing().when(routeFacade).createRoute(any());
-
         // when
         mockMvc.perform(post(ROUTE_BASE_API_PATH)
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -312,10 +310,6 @@ class RouteControllerTest extends AbstractControllerNoneSecureTest {
         // Set negative tier value
         dto.getUpstreams().get(0).setTier(-1);
         var invalidDtoJson = objectMapper.writeValueAsString(dto);
-
-        // Validation will fail before facade is called, but we need to mock the return value
-        when(routeFacade.updateRoute(any(String.class), any(RouteDto.class), any(String.class)))
-                .thenReturn("2");
 
         // when
         mockMvc.perform(put(ROUTE_API_PATH, TEST_ROUTE_NAME)

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/RouteControllerTest.java
@@ -10,6 +10,8 @@ import com.epam.aidial.cfg.web.facade.RouteFacade;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -278,5 +280,50 @@ class RouteControllerTest extends AbstractControllerNoneSecureTest {
         mockMvc.perform(delete(ROUTE_API_PATH, TEST_ROUTE_NAME))
                 // then
                 .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testCreateRoute_WithNegativeTier_BadRequest() throws Exception {
+        // given
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, new TypeReference<RouteDto>() {
+        });
+        // Set negative tier value
+        dto.getUpstreams().get(0).setTier(-1);
+        var invalidDtoJson = objectMapper.writeValueAsString(dto);
+
+        doNothing().when(routeFacade).createRoute(any());
+
+        // when
+        mockMvc.perform(post(ROUTE_BASE_API_PATH)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(invalidDtoJson))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(containsString("Tier must be a non-negative number")));
+    }
+
+    @Test
+    void testUpdateRoute_WithNegativeTier_BadRequest() throws Exception {
+        // given
+        var dtoJson = ResourceUtils.readResource(DTO_JSON_PATH);
+        var dto = objectMapper.readValue(dtoJson, new TypeReference<RouteDto>() {
+        });
+        // Set negative tier value
+        dto.getUpstreams().get(0).setTier(-1);
+        var invalidDtoJson = objectMapper.writeValueAsString(dto);
+
+        // Validation will fail before facade is called, but we need to mock the return value
+        when(routeFacade.updateRoute(any(String.class), any(RouteDto.class), any(String.class)))
+                .thenReturn("2");
+
+        // when
+        mockMvc.perform(put(ROUTE_API_PATH, TEST_ROUTE_NAME)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .header(HEADER_IF_MATCH, "1")
+                        .content(invalidDtoJson))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(containsString("Tier must be a non-negative number")));
     }
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #470 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
 If a negative tier value is provided, the API will return HTTP 400 Bad Request with a validation error message.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.