### PR TITLE
fix: #475 underscore is valid char in endpoint relative part

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/validator/EndpointValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/EndpointValidator.java
@@ -11,7 +11,7 @@ import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URL
 @UtilityClass
 public class EndpointValidator {
 
-    private static final Pattern VALID_URL_PATTERN = Pattern.compile("^[a-zA-Z0-9_.-:/\\\\]+$");
+    private static final Pattern VALID_URL_PATTERN = Pattern.compile("^[a-zA-Z0-9_.:/\\\\-]+$");
     private static final UrlValidator VALIDATOR = new CustomUrlValidator(new String[]{"http", "https"}, ALLOW_LOCAL_URLS);
 
     public static boolean isInvalidUrl(String url) {

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/EndpointValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/EndpointValidator.java
@@ -11,7 +11,7 @@ import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URL
 @UtilityClass
 public class EndpointValidator {
 
-    private static final Pattern VALID_URL_PATTERN = Pattern.compile("^[a-zA-Z0-9-.:/\\\\]+$");
+    private static final Pattern VALID_URL_PATTERN = Pattern.compile("^[a-zA-Z0-9_.-:/\\\\]+$");
     private static final UrlValidator VALIDATOR = new CustomUrlValidator(new String[]{"http", "https"}, ALLOW_LOCAL_URLS);
 
     public static boolean isInvalidUrl(String url) {

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/EndpointValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/EndpointValidatorTest.java
@@ -20,7 +20,11 @@ class EndpointValidatorTest {
             "http://127.0.0.1:8080/test",
             "https://www.google.com",
             "http://sub.example.local",
-            "http://example.dial-dev"
+            "http://example.dial-dev",
+            "http://example.com/test_endpoint",
+            "http://example.com/api/test_path",
+            "http://example.com/test_endpoint/api",
+            "http://example.local:8080/test_endpoint/api"
     })
     void isValidUrl_shouldReturnTrue(String url) {
         assertTrue(EndpointValidator.isValidUrl(url), "Expected URL to be valid: " + url);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #475 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
* Allows underscores in URL paths (RFC 3986 compliant)
* Rejects underscores in hostnames (RFC 1034/1123 compliant)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.