### PR TITLE
fix: Replaced the exact string match with an order-independent check in unstable test

### DIFF
--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
@@ -31,6 +31,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -173,13 +175,21 @@ class ApplicationControllerTest extends AbstractControllerNoneSecureTest {
 
         when(applicationFacade.updateApplication(eq("test_application"), any(ApplicationDto.class), any())).thenReturn("test");
 
+        String errorMessagePrefix = "JSON parse error: ";
+        String path0Error = "paths[0].<list element>: Invalid route path. "
+                + "Path must be a valid plain path (starting with /) or a valid regular expression pattern (starting with / or ^/)";
+        String path1Error = "paths[1].<list element>: Invalid route path. "
+                + "Path must be a valid plain path (starting with /) or a valid regular expression pattern (starting with / or ^/)";
+
         mockMvc.perform(put("/api/v1/applications/{applicationName}", "test_application")
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .content(dtoJson))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("JSON parse error: paths[0].<list element>: Invalid route path. "
-                        + "Path must be a valid plain path (starting with /) or a valid regular expression pattern (starting with / or ^/), paths[1].<list element>: "
-                        + "Invalid route path. Path must be a valid plain path (starting with /) or a valid regular expression pattern (starting with / or ^/)"));
+                .andExpect(jsonPath("$.message").value(allOf(
+                        containsString(errorMessagePrefix),
+                        containsString(path0Error),
+                        containsString(path1Error)
+                )));
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationControllerTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.json.JsonCompareMode;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -31,8 +33,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;


### PR DESCRIPTION
(ApplicationControllerTest.testUpdateApplication_appRouteWithInvalidPath_BadRequest test.)

### Description of changes

<!-- Please explain the changes you made right below this line. -->
The test now passes regardless of whether paths[0] or paths[1] appears first in the validation error message, addressing the non-deterministic ordering issue in Jakarta Bean Validation.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.