### PR TITLE
chore: adjust revinfo initial timestamp to UTC timezone for H2

### DIFF
--- a/src/main/resources/db/migration/H2/V1.81__UpdateIntitalRevinfoTimestampAndGlobalSettingsTimestamps.sql
+++ b/src/main/resources/db/migration/H2/V1.81__UpdateIntitalRevinfoTimestampAndGlobalSettingsTimestamps.sql
@@ -1,0 +1,14 @@
+UPDATE revinfo SET timestamp = CAST(DATEDIFF('MILLISECOND', TIMESTAMP '1970-01-01 00:00:00', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AS BIGINT)
+WHERE id = 1;
+
+UPDATE global_settings_entity
+SET created_at_ms = (SELECT timestamp FROM revinfo WHERE id = 1)
+WHERE id = 1;
+
+UPDATE global_settings_entity_aud
+SET created_at_ms = (SELECT timestamp FROM revinfo WHERE id = 1), updated_at_ms = (SELECT timestamp FROM revinfo WHERE id = 1)
+WHERE id = 1 and revtype = 0;
+
+UPDATE audit_activity_entity
+SET epoch_timestamp_ms = (SELECT timestamp FROM revinfo WHERE id = 1)
+WHERE revision = 1;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Adjusted revinfo initial timestamp to UTC timezone for H2

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.