### PR TITLE
fix: support missing auth provider URL; use request body instead of params for token request

### DIFF
--- a/docs/azure-s2s-config.md
+++ b/docs/azure-s2s-config.md
@@ -64,7 +64,7 @@ Before proceeding with the implementation, ensure the following pre-requirements
    backend:
      env:
        ENABLE_CONFIG_AUTO_RELOAD: true
-       CORE_AUTH_TOKEN_PROVIDER_URL: "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token"
+       CORE_AUTH_TOKEN_PROVIDER_URL: "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0"
        CORE_AUTH_TOKEN_PROVIDER_CLIENT_ID: <app_registration_client_id> # Created in Step 1
        CORE_AUTH_TOKEN_PROVIDER_SCOPE: <dial_core_application_scope>
      secrets:

--- a/src/main/java/com/epam/aidial/cfg/client/CoreAuthTokenProviderClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/CoreAuthTokenProviderClient.java
@@ -4,8 +4,8 @@ import com.epam.aidial.cfg.client.dto.TokenResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
         name = "coreAuthTokenProviderClient",
@@ -16,9 +16,6 @@ public interface CoreAuthTokenProviderClient {
     @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     TokenResponseDto getToken(
             @RequestHeader("Content-Type") String contentType,
-            @RequestParam("grant_type") String grantType,
-            @RequestParam("client_id") String clientId,
-            @RequestParam("client_secret") String clientSecret,
-            @RequestParam(value = "scope", required = false) String scope
+            @RequestBody String body
     );
 }

--- a/src/main/java/com/epam/aidial/cfg/security/CoreAuthTokenProvider.java
+++ b/src/main/java/com/epam/aidial/cfg/security/CoreAuthTokenProvider.java
@@ -3,9 +3,13 @@ package com.epam.aidial.cfg.security;
 import com.epam.aidial.cfg.client.CoreAuthTokenProviderClient;
 import com.epam.aidial.cfg.utils.SecretUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 public class CoreAuthTokenProvider implements AuthTokenProvider {
@@ -25,13 +29,8 @@ public class CoreAuthTokenProvider implements AuthTokenProvider {
     @Override
     public AuthToken getAuthToken() {
         try {
-            var token = AuthToken.from(client.getToken(
-                    MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                    AuthorizationGrantType.CLIENT_CREDENTIALS.getValue(),
-                    clientId,
-                    clientSecret,
-                    scope
-            ));
+            var token = AuthToken.from(client.getToken(MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+                    toTokenRequest(clientId, clientSecret, scope)));
             if (token == null) {
                 log.warn("Failed to obtain access token: Token is null for getToken(clientId={}, clientSecret='{}', scope='{}')",
                         clientId,
@@ -40,7 +39,6 @@ public class CoreAuthTokenProvider implements AuthTokenProvider {
                 );
                 throw new AccessDeniedException("Failed to obtain access token");
             }
-
             logGetToken(token);
             return token;
         } catch (Exception e) {
@@ -52,6 +50,17 @@ public class CoreAuthTokenProvider implements AuthTokenProvider {
             );
             throw new AccessDeniedException("Failed to obtain access token", e);
         }
+    }
+
+    private String toTokenRequest(String clientId, String clientSecret, String scope) {
+        StringBuilder body = new StringBuilder();
+        body.append("grant_type=").append(AuthorizationGrantType.CLIENT_CREDENTIALS.getValue())
+                .append("&client_id=").append(URLEncoder.encode(clientId, StandardCharsets.UTF_8))
+                .append("&client_secret=").append(URLEncoder.encode(clientSecret, StandardCharsets.UTF_8));
+        if (StringUtils.isNotBlank(scope)) {
+            body.append("&scope=").append(URLEncoder.encode(scope, StandardCharsets.UTF_8));
+        }
+        return body.toString();
     }
 
     private void logGetToken(AuthToken token) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,7 +84,7 @@ core.applications.metadata.default.limit=${CORE_APPLICATIONS_METADATA_DEFAULT_LI
 core.toolsets.metadata.default.limit=${CORE_TOOLSETS_METADATA_DEFAULT_LIMIT:256}
 
 # Auth token provider configuration to interact with the DIAL Core
-core.auth.token.provider.url=${CORE_AUTH_TOKEN_PROVIDER_URL}
+core.auth.token.provider.url=${CORE_AUTH_TOKEN_PROVIDER_URL:}
 core.auth.token.provider.clientId=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_ID}
 core.auth.token.provider.clientSecret=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_SECRET}
 core.auth.token.provider.scope=${CORE_AUTH_TOKEN_PROVIDER_SCOPE:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,7 +84,7 @@ core.applications.metadata.default.limit=${CORE_APPLICATIONS_METADATA_DEFAULT_LI
 core.toolsets.metadata.default.limit=${CORE_TOOLSETS_METADATA_DEFAULT_LIMIT:256}
 
 # Auth token provider configuration to interact with the DIAL Core
-core.auth.token.provider.url=${CORE_AUTH_TOKEN_PROVIDER_URL:}
+core.auth.token.provider.url=${CORE_AUTH_TOKEN_PROVIDER_URL:http\://localhost/disabled}
 core.auth.token.provider.clientId=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_ID}
 core.auth.token.provider.clientSecret=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_SECRET}
 core.auth.token.provider.scope=${CORE_AUTH_TOKEN_PROVIDER_SCOPE:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -85,8 +85,8 @@ core.toolsets.metadata.default.limit=${CORE_TOOLSETS_METADATA_DEFAULT_LIMIT:256}
 
 # Auth token provider configuration to interact with the DIAL Core
 core.auth.token.provider.url=${CORE_AUTH_TOKEN_PROVIDER_URL:http\://localhost/disabled}
-core.auth.token.provider.clientId=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_ID}
-core.auth.token.provider.clientSecret=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_SECRET}
+core.auth.token.provider.clientId=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_ID:}
+core.auth.token.provider.clientSecret=${CORE_AUTH_TOKEN_PROVIDER_CLIENT_SECRET:}
 core.auth.token.provider.scope=${CORE_AUTH_TOKEN_PROVIDER_SCOPE:}
 core.auth.token.provider.cache.enabled=${CORE_AUTH_TOKEN_PROVIDER_CACHE_ENABLED:true}
 core.auth.token.provider.cache.refreshBeforeExpirationSeconds=${CORE_AUTH_TOKEN_PROVIDER_CACHE_REFRESH_BEFORE_EXPIRATION_SECONDS:600}

--- a/src/test/java/com/epam/aidial/cfg/security/CoreAuthTokenProviderTest.java
+++ b/src/test/java/com/epam/aidial/cfg/security/CoreAuthTokenProviderTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,13 +35,12 @@ class CoreAuthTokenProviderTest {
     @Test
     void getAuthToken_success() {
         TokenResponseDto dto = mock(TokenResponseDto.class);
-        when(client.getToken(
-                MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                AuthorizationGrantType.CLIENT_CREDENTIALS.getValue(),
-                clientId,
-                clientSecret,
-                scope
-        )).thenReturn(dto);
+        String expectedBody = "grant_type=client_credentials"
+                + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+                + "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8);
+
+        when(client.getToken(MediaType.APPLICATION_FORM_URLENCODED_VALUE, expectedBody)).thenReturn(dto);
 
         AuthToken expectedToken = new AuthToken("access-token", 3600);
 
@@ -56,13 +57,12 @@ class CoreAuthTokenProviderTest {
     @Test
     void getAuthToken_nullToken_throwsAccessDeniedException() {
         TokenResponseDto dto = mock(TokenResponseDto.class);
-        when(client.getToken(
-                MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                AuthorizationGrantType.CLIENT_CREDENTIALS.getValue(),
-                clientId,
-                clientSecret,
-                scope
-        )).thenReturn(dto);
+        String expectedBody = "grant_type=client_credentials"
+                + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+                + "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8);
+
+        when(client.getToken(MediaType.APPLICATION_FORM_URLENCODED_VALUE, expectedBody)).thenReturn(dto);
 
         // Mock static AuthToken.from to return null
         try (MockedStatic<AuthToken> authTokenStatic = mockStatic(AuthToken.class);
@@ -79,13 +79,13 @@ class CoreAuthTokenProviderTest {
 
     @Test
     void getAuthToken_clientThrowsException_throwsAccessDeniedException() {
-        when(client.getToken(
-                MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                AuthorizationGrantType.CLIENT_CREDENTIALS.getValue(),
-                clientId,
-                clientSecret,
-                scope
-        )).thenThrow(new RuntimeException("Service error"));
+        String expectedBody = "grant_type=client_credentials"
+                + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+                + "&scope=" + URLEncoder.encode(scope, StandardCharsets.UTF_8);
+
+        when(client.getToken(MediaType.APPLICATION_FORM_URLENCODED_VALUE, expectedBody))
+                .thenThrow(new RuntimeException("Service error"));
 
         try (MockedStatic<SecretUtils> secretUtilsStatic = mockStatic(SecretUtils.class)) {
             secretUtilsStatic.when(() -> SecretUtils.mask(clientSecret)).thenReturn("***MASKED***");


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- fix application start issue when `${CORE_AUTH_TOKEN_PROVIDER_URL}` is not configured
- use request body instead of params for token request

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.