### PR TITLE
fix: delete folder as resource in case of Azure Blob Storage with enabled "Hierarchical namespace" option

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/client/ConversationClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/ConversationClient.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.client;
 import com.epam.aidial.cfg.client.dto.ConversationDto;
 import com.epam.aidial.cfg.client.dto.ConversationMetadataDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,4 +35,7 @@ public interface ConversationClient {
      */
     @GetMapping("/v1/conversations/{path}")
     ConversationDto getConversation(@PathVariable String path);
+
+    @DeleteMapping("/v1/conversations/{path}")
+    void deleteConversation(@PathVariable String path);
 }

--- a/src/main/java/com/epam/aidial/cfg/service/ApplicationResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ApplicationResourceService.java
@@ -134,7 +134,7 @@ public class ApplicationResourceService implements ResourceService {
         List<String> deletedApplicationResources = new ArrayList<>();
         for (var path : paths) {
             try {
-                deleteApplicationResource(path, null);
+                delete(path, null);
                 deletedApplicationResources.add(path);
             } catch (Exception exception) {
                 log.warn("Unable to delete applications: {}, deleted applications: {}", path, deletedApplicationResources,
@@ -144,8 +144,8 @@ public class ApplicationResourceService implements ResourceService {
         }
     }
 
-    public void deleteApplicationResource(String path,
-                                          String etag) {
+    @Override
+    public void delete(String path, String etag) {
         var headers = createIfMatchHeaders(etag);
         applicationClient.deleteApplicationResource(path, headers);
     }

--- a/src/main/java/com/epam/aidial/cfg/service/ConversationService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ConversationService.java
@@ -61,4 +61,8 @@ public class ConversationService implements ResourceService {
         return conversationClientMapper.toConversation(conversationDto, conversationMetadataDto);
     }
 
+    @Override
+    public void delete(String path, String etag) {
+        conversationClient.deleteConversation(path);
+    }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/FileService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/FileService.java
@@ -241,6 +241,11 @@ public class FileService implements ResourceService {
     }
 
     public void deleteFile(String path) {
+        delete(path, null);
+    }
+
+    @Override
+    public void delete(String path, String etag) {
         fileClient.deleteFile(path);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/FolderService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/FolderService.java
@@ -15,6 +15,7 @@ import com.epam.aidial.cfg.model.ResourceType;
 import com.epam.aidial.cfg.model.Rule;
 import com.epam.aidial.cfg.model.UpdateRulesRequest;
 import com.epam.aidial.cfg.service.publication.PublicationService;
+import com.epam.aidial.cfg.utils.PathUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -76,6 +77,7 @@ public class FolderService {
                 .build();
         String publication = publicationService.createPublication(createPublication);
         approvePublication(publication);
+        deleteFolderAsResource(path);
     }
 
     public void moveFolder(MoveFolderRequest moveFolderRequest) {
@@ -102,6 +104,18 @@ public class FolderService {
     private void approvePublication(String publication) {
         String path = CoreMetadataUtils.removeMetadataPrefix(publication, PUBLICATIONS_PREFIX);
         publicationService.approvePublication(path);
+    }
+
+    // this is needed to delete empty folder as resource in case of Azure Blob Storage with enabled "Hierarchical namespace" option
+    private void deleteFolderAsResource(String path) {
+        resourceServicesByResourceType.values()
+                .forEach(resourceService -> {
+                    try {
+                        resourceService.delete(PathUtils.trimTrailingSlash(path), null);
+                    } catch (Exception e) {
+                        log.trace("Unable to delete folder as resource. Path: {}", path, e);
+                    }
+                });
     }
 
     private FolderInfo merge(List<FolderInfo> folderInfos) {

--- a/src/main/java/com/epam/aidial/cfg/service/ResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ResourceService.java
@@ -26,6 +26,8 @@ public interface ResourceService {
 
     ResourceType getResourceType();
 
+    void delete(String path, String etag);
+
     default Set<String> getResourceUrls(String path) {
         try {
             ResourceMetadataRequest request = ResourceMetadataRequest.builder()

--- a/src/main/java/com/epam/aidial/cfg/service/ToolSetResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ToolSetResourceService.java
@@ -141,7 +141,7 @@ public class ToolSetResourceService implements ResourceService {
         List<String> deleteToolSetResources = new ArrayList<>();
         for (var path : paths) {
             try {
-                deleteToolSetResource(path, null);
+                delete(path, null);
                 deleteToolSetResources.add(path);
             } catch (Exception exception) {
                 log.warn("Unable to delete toolsets: {}, deleted toolsets: {}", path, deleteToolSetResources,
@@ -151,8 +151,8 @@ public class ToolSetResourceService implements ResourceService {
         }
     }
 
-    public void deleteToolSetResource(String path,
-                                      String etag) {
+    @Override
+    public void delete(String path, String etag) {
         var headers = createIfMatchHeaders(etag);
         toolSetClient.deleteToolSetResource(path, headers);
     }

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
@@ -129,7 +129,7 @@ public class PromptService implements ResourceService {
         List<String> deletedPrompts = new ArrayList<>();
         for (var path : paths) {
             try {
-                deletePrompt(path, null);
+                delete(path, null);
                 deletedPrompts.add(path);
             } catch (Exception exception) {
                 log.warn("Unable to delete prompt: {}, deleted prompts: {}", path, deletedPrompts, exception);
@@ -138,7 +138,8 @@ public class PromptService implements ResourceService {
         }
     }
 
-    public void deletePrompt(String path, String etag) {
+    @Override
+    public void delete(String path, String etag) {
         var headers = createIfMatchHeaders(etag);
         promptClient.deletePrompt(path, headers);
     }

--- a/src/main/java/com/epam/aidial/cfg/web/controller/ApplicationResourceController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/ApplicationResourceController.java
@@ -95,7 +95,7 @@ public class ApplicationResourceController {
             consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     public void deleteApplicationResource(@RequestBody ResourcePathDto applicationPath,
                                           @RequestHeader(value = "If-Match") String etag) {
-        applicationService.deleteApplicationResource(applicationPath.getPath(), etag);
+        applicationService.delete(applicationPath.getPath(), etag);
     }
 
     @PostMapping(path = "/delete/bulk",

--- a/src/main/java/com/epam/aidial/cfg/web/controller/PromptsController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/PromptsController.java
@@ -91,7 +91,7 @@ public class PromptsController {
             consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     public void deletePrompt(@RequestBody ResourcePathDto promptPath,
                              @RequestHeader(value = "If-Match") String etag) {
-        promptService.deletePrompt(promptPath.getPath(), etag);
+        promptService.delete(promptPath.getPath(), etag);
     }
 
     @PostMapping(path = "/delete/bulk",

--- a/src/main/java/com/epam/aidial/cfg/web/controller/ToolSetResourceController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/ToolSetResourceController.java
@@ -98,7 +98,7 @@ public class ToolSetResourceController {
             consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     public void deleteToolSetResource(@RequestBody ResourcePathDto resourcePath,
                                       @RequestHeader(value = "If-Match") String etag) {
-        toolSetResourceService.deleteToolSetResource(resourcePath.getPath(), etag);
+        toolSetResourceService.delete(resourcePath.getPath(), etag);
     }
 
     @PostMapping(path = "/delete/bulk",

--- a/src/test/java/com/epam/aidial/cfg/service/FolderServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/FolderServiceTest.java
@@ -128,17 +128,27 @@ class FolderServiceTest {
     void testUnpublishFolder() {
         // given
         String path = "public/test/";
+        String pathAsResource = "public/test";
+
         when(fileService.getResourceUrls(path)).thenReturn(Set.of("files/public/test/test.json"));
         when(publicationService.createPublication(any())).thenReturn("publications/publicationUrl");
+
         // when
         folderService.unpublishFolder(path);
+
         // then
         verify(applicationService).getResourceUrls(path);
         verify(conversationService).getResourceUrls(path);
         verify(fileService).getResourceUrls(path);
         verify(promptService).getResourceUrls(path);
+
         verify(publicationService).createPublication(any());
         verify(publicationService).approvePublication("publicationUrl");
+
+        verify(applicationService).delete(pathAsResource, null);
+        verify(conversationService).delete(pathAsResource, null);
+        verify(fileService).delete(pathAsResource, null);
+        verify(promptService).delete(pathAsResource, null);
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationResourceControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ApplicationResourceControllerTest.java
@@ -305,7 +305,7 @@ class ApplicationResourceControllerTest extends AbstractControllerNoneSecureTest
                         .header(HEADER_IF_MATCH, "*"))
                 .andExpect(status().isOk());
 
-        verify(applicationResourceService).deleteApplicationResource(APP_PATH, "*");
+        verify(applicationResourceService).delete(APP_PATH, "*");
     }
 
     @Test
@@ -313,7 +313,7 @@ class ApplicationResourceControllerTest extends AbstractControllerNoneSecureTest
         var body = new ResourcePathDto();
         body.setPath(APP_PATH);
 
-        doThrow(new ResourceNotFoundException("Not Found")).when(applicationResourceService).deleteApplicationResource(any(), any());
+        doThrow(new ResourceNotFoundException("Not Found")).when(applicationResourceService).delete(any(), any());
 
         mockMvc.perform(post(DELETE_API_PATH)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -323,7 +323,7 @@ class ApplicationResourceControllerTest extends AbstractControllerNoneSecureTest
                 .andExpect(jsonPath("$.message")
                         .value("Not Found"));
 
-        verify(applicationResourceService).deleteApplicationResource(APP_PATH, TEST_ETAG);
+        verify(applicationResourceService).delete(APP_PATH, TEST_ETAG);
     }
 
     @Test
@@ -331,7 +331,7 @@ class ApplicationResourceControllerTest extends AbstractControllerNoneSecureTest
         var body = new ResourcePathDto();
         body.setPath(APP_PATH);
 
-        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(applicationResourceService).deleteApplicationResource(any(), any());
+        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(applicationResourceService).delete(any(), any());
 
         mockMvc.perform(post(DELETE_API_PATH)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/PromptControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/PromptControllerTest.java
@@ -233,7 +233,7 @@ class PromptControllerTest extends AbstractControllerNoneSecureTest {
                         .header(HEADER_IF_MATCH, TEST_ETAG))
                 .andExpect(status().isOk());
 
-        verify(promptService).deletePrompt(promptPath, TEST_ETAG);
+        verify(promptService).delete(promptPath, TEST_ETAG);
     }
 
     @Test
@@ -256,7 +256,7 @@ class PromptControllerTest extends AbstractControllerNoneSecureTest {
         var body = new ResourcePathDto();
         body.setPath(promptPath);
 
-        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(promptService).deletePrompt(any(), any());
+        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(promptService).delete(any(), any());
 
         mockMvc.perform(post("/api/v1/prompts/delete")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ToolSetResourceControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ToolSetResourceControllerTest.java
@@ -386,7 +386,7 @@ public class ToolSetResourceControllerTest extends AbstractControllerNoneSecureT
                         .header(HEADER_IF_MATCH, "*"))
                 .andExpect(status().isOk());
 
-        verify(toolSetResourceService).deleteToolSetResource(APP_PATH, "*");
+        verify(toolSetResourceService).delete(APP_PATH, "*");
     }
 
     @Test
@@ -394,7 +394,7 @@ public class ToolSetResourceControllerTest extends AbstractControllerNoneSecureT
         var body = new ResourcePathDto();
         body.setPath(APP_PATH);
 
-        doThrow(new ResourceNotFoundException("Not Found")).when(toolSetResourceService).deleteToolSetResource(any(), any());
+        doThrow(new ResourceNotFoundException("Not Found")).when(toolSetResourceService).delete(any(), any());
 
         mockMvc.perform(post(DELETE_API_PATH)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -404,7 +404,7 @@ public class ToolSetResourceControllerTest extends AbstractControllerNoneSecureT
                 .andExpect(jsonPath("$.message")
                         .value("Not Found"));
 
-        verify(toolSetResourceService).deleteToolSetResource(APP_PATH, TEST_ETAG);
+        verify(toolSetResourceService).delete(APP_PATH, TEST_ETAG);
     }
 
     @Test
@@ -412,7 +412,7 @@ public class ToolSetResourceControllerTest extends AbstractControllerNoneSecureT
         var body = new ResourcePathDto();
         body.setPath(APP_PATH);
 
-        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(toolSetResourceService).deleteToolSetResource(any(), any());
+        doThrow(new ResourcePreconditionFailedException("Precondition failed")).when(toolSetResourceService).delete(any(), any());
 
         mockMvc.perform(post(DELETE_API_PATH)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. epam/ai-dial-admin-frontend#123) -->
- fixes #https://github.com/epam/ai-dial-admin-backend/issues/518

### Description of changes
Added deletion of folder as resource in addition to deletion of all resources in folder for the case of Azure Blob Storage with enabled "Hierarchical namespace" option

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.