### PR TITLE
fix: set model endpoint to null when model has adapter, fix endpoint mapping for core model during retrieval of model in core format or calculating sync state

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/ModelEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/ModelEntityMapper.java
@@ -105,8 +105,9 @@ public abstract class ModelEntityMapper {
         }
         // Explicitly clear and set adapter/container fields to ensure mutual exclusivity
         if (adapterEntity != null) {
-            // Setting adapter: clear container and set adapter
+            // Setting adapter: clear container and endpoint and set adapter
             updatedEntity.setModelContainer(null);
+            updatedEntity.setEndpoint(null);
             adapterEntity.getModels().add(updatedEntity);
             updatedEntity.setAdapter(adapterEntity);
             updatedEntity.setAdapterCompletionEndpointPath(completionEndpointPath);

--- a/src/main/java/com/epam/aidial/cfg/service/core/CoreModelService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/core/CoreModelService.java
@@ -4,7 +4,10 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.domain.mapper.ModelCoreMapper;
 import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.model.Model;
+import com.epam.aidial.cfg.domain.model.source.AdapterSource;
+import com.epam.aidial.cfg.domain.service.AdapterService;
 import com.epam.aidial.cfg.domain.service.ModelService;
+import com.epam.aidial.cfg.domain.utils.ModelEndpointUtils;
 import com.epam.aidial.cfg.dto.CoreWithDomainHash;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException.OptimisticLockConflictExceptionDetails;
@@ -31,6 +34,7 @@ import static com.epam.aidial.cfg.service.hashing.HashCalculator.ANY_HASH;
 public class CoreModelService {
 
     private final ModelService modelService;
+    private final AdapterService adapterService;
     private final ModelCoreMapper modelCoreMapper;
     private final ConfigImporter configImporter;
     private final EntitySyncStateResolver entitySyncStateResolver;
@@ -38,7 +42,9 @@ public class CoreModelService {
     @Transactional(readOnly = true)
     public CoreWithDomainHash<CoreModel> getCoreModelWithHash(String modelName) {
         var modelWithHash = modelService.getModelWithHash(modelName);
-        var coreModel = modelCoreMapper.mapModel(modelWithHash.model());
+        var model = modelWithHash.model();
+        var endpoint = getModelEndpoint(model);
+        var coreModel = modelCoreMapper.mapModel(model, endpoint);
         return new CoreWithDomainHash<>(coreModel, modelWithHash.hash());
     }
 
@@ -72,7 +78,8 @@ public class CoreModelService {
         assertModelWasNotUpdated(modelWithHash, hash, OptimisticLockConflictException::onGetSyncState);
 
         var model = modelWithHash.model();
-        var coreModel = modelCoreMapper.mapModel(model);
+        var endpoint = getModelEndpoint(model);
+        var coreModel = modelCoreMapper.mapModel(model, endpoint);
 
         return entitySyncStateResolver.resolveForEntityInObject(
                 coreModel,
@@ -80,6 +87,14 @@ public class CoreModelService {
                 "models",
                 modelName
         );
+    }
+
+    private String getModelEndpoint(Model model) {
+        if (model.getSource() instanceof AdapterSource adapterSource) {
+            var adapter = adapterService.get(adapterSource.getAdapterName());
+            return ModelEndpointUtils.concatEndpointAndPath(adapter.getBaseEndpoint(), adapterSource.getCompletionEndpointPath());
+        }
+        return model.getEndpoint();
     }
 
     private void assertHashNotNull(String modelName, String hash) {

--- a/src/main/resources/db/migration/H2/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
+++ b/src/main/resources/db/migration/H2/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint = null where adapter_name is not null;
+update model_entity_aud set endpoint = null where adapter_name is not null;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint = null where adapter_name is not null;
+update model_entity_aud set endpoint = null where adapter_name is not null;

--- a/src/main/resources/db/migration/POSTGRES/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.85__SetModelEndpointToNullWhenModelHasAdapter.sql
@@ -1,0 +1,2 @@
+update model_entity set endpoint = null where adapter_name is not null;
+update model_entity_aud set endpoint = null where adapter_name is not null;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -281,7 +281,7 @@ public abstract class ConfigTransferFunctionalTest {
         Assertions.assertThat(models.get("testModel1")).satisfies(model -> {
             Assertions.assertThat(model.getDisplayName()).isEqualTo("Test Model1");
             Assertions.assertThat(model.getDisplayVersion()).isEqualTo("2.0.0");
-            Assertions.assertThat(model.getEndpoint()).isEqualTo("https://endpoint1/embeddings");
+            Assertions.assertThat(model.getEndpoint()).isNull();
             Assertions.assertThat(model.getSource() instanceof AdapterSourceDto);
         });
     }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -128,6 +128,7 @@ public abstract class ModelFunctionalTest {
         expected.setMaxRetryAttempts(1);
         expected.setDefaultRoleLimit(new LimitDto());
         expected.setSource(new AdapterSourceDto("adapter2", "/newEndpointDeploymentName/chat/completions"));
+        expected.setEndpoint(null);
         updatedModel.setDefaults(Map.of());
         updatedModel.setDefaultRoleLimit(new LimitDto());
         assertModel(actual, expected);

--- a/src/test/resources/import/import_modelWithAdapter_preview.json
+++ b/src/test/resources/import/import_modelWithAdapter_preview.json
@@ -33,7 +33,6 @@
           "isPublic": false,
           "defaultRoleLimit": {}
         },
-        "endpoint": "http://endpoint1/testModel1/embeddings",
         "displayName": "Test Model1",
         "displayVersion": "2.0.0",
         "forwardAuthToken": false,
@@ -82,7 +81,6 @@
           "isPublic": false,
           "defaultRoleLimit": {}
         },
-        "endpoint": "http://endpoint2/testModel2/embeddings",
         "displayName": "Test Model2",
         "displayVersion": "2.0.0",
         "forwardAuthToken": false,

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -634,7 +634,6 @@
           "seed",
           "system"
         ],
-        "endpoint": "https://endpoint1/embeddings",
         "source": {
           "$type": "adapter",
           "adapterName": "<will be defined during import 1>",
@@ -735,7 +734,6 @@
           "seed",
           "system"
         ],
-        "endpoint": "https://endpoint2/embeddings",
         "source": {
           "$type": "adapter",
           "adapterName": "<will be defined during import 0>",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #543 

### Description of changes
1. Added logic to set model endpoint to null when model has adapter (existing models are adjusted via migration script)
2. Fixed endpoint mapping for core model during retrieval of model in core format or calculating sync state

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.