### PR TITLE
fix: adjust toolset name validation according to pattern introduced in core

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 @Component
 public class ToolSetValidator {
 
+    private static final Pattern NAME_PATTERN = Pattern.compile("^[A-Za-z0-9-_]+$");
+
     private final DeploymentManagerService deploymentManagerService;
     private final DeploymentInfoValidator deploymentInfoValidator;
     private final DeploymentValidator deploymentValidator;
@@ -40,13 +42,7 @@ public class ToolSetValidator {
         final String toolSetName = toolSet.getDeployment().getName();
 
         deploymentValidator.validateCreation("ToolSet", toolSetName);
-
-        if (StringUtils.isEmpty(toolSetNameValidationPattern)) {
-            log.debug("ToolSet name validation pattern is empty, skipping name pattern validation for ToolSet: {}", toolSetName);
-        } else if (!Pattern.matches(toolSetNameValidationPattern, toolSetName)) {
-            throw new IllegalArgumentException("toolSet name '" + toolSetName
-                        + "' does not match the required pattern: " + toolSetNameValidationPattern);
-        }
+        validateName(toolSetName);
         displayFieldsValidator.validateDisplayName(toolSet.getDisplayName(), "ToolSet", toolSetName);
         validateToolSetSource(toolSet);
     }
@@ -55,6 +51,20 @@ public class ToolSetValidator {
         deploymentValidator.validateUpdate(toolSetName, toolSet.getDeployment(), "ToolSet");
         displayFieldsValidator.validateDisplayName(toolSet.getDisplayName(), "ToolSet", toolSetName);
         validateToolSetSource(toolSet);
+    }
+
+    private void validateName(String toolSetName) {
+        if (!NAME_PATTERN.matcher(toolSetName).matches()) {
+            throw new IllegalArgumentException("toolSet name '" + toolSetName
+                    + "' does not match the required pattern: " + NAME_PATTERN);
+        }
+
+        if (StringUtils.isEmpty(toolSetNameValidationPattern)) {
+            log.debug("ToolSet name validation pattern is empty, skipping name pattern validation for ToolSet: {}", toolSetName);
+        } else if (!Pattern.matches(toolSetNameValidationPattern, toolSetName)) {
+            throw new IllegalArgumentException("toolSet name '" + toolSetName
+                    + "' does not match the required pattern: " + toolSetNameValidationPattern);
+        }
     }
 
     private void validateToolSetSource(ToolSet toolSet) {

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ToolSetValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ToolSetValidatorTest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.domain.validator;
 
-import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
 import com.epam.aidial.cfg.client.dto.InterceptorDeploymentInfoDto;
 import com.epam.aidial.cfg.client.dto.McpDeploymentInfoDto;
 import com.epam.aidial.cfg.domain.model.SecuredResource;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -67,6 +65,35 @@ public class ToolSetValidatorTest {
         verify(deploymentValidator).validateCreation("ToolSet", toolSet.getDisplayName());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid name", "invalid@name", "invalid#name"})
+    void validateCreation_shouldThrowExceptionForInvalidName() {
+        // given
+        String toolSetName = "invalid name with spaces";
+        ToolSet toolSet = new ToolSet();
+        toolSet.setDisplayName(toolSetName);
+        SecuredResource deployment = new SecuredResource(toolSetName);
+        toolSet.setDeployment(deployment);
+
+        // when & then
+        assertThatThrownBy(() -> toolSetValidator.validateCreation(toolSet))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the required pattern: ^[A-Za-z0-9-_]+$");
+    }
+
+    @Test
+    void validateCreation_shouldNotThrowExceptionForValidName() {
+        // given
+        ToolSet toolSet = new ToolSet();
+        toolSet.setDisplayName(TEST_TOOLSET_NAME);
+        SecuredResource deployment = new SecuredResource(TEST_TOOLSET_NAME);
+        toolSet.setDeployment(deployment);
+        ReflectionTestUtils.setField(toolSetValidator, "toolSetNameValidationPattern", NAME_VALIDATION_PATTERN);
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> toolSetValidator.validateCreation(toolSet));
+    }
+
     @Test
     void validateCreation_withNameValidationPattern_shouldValidateNameAgainstPattern() {
         // given
@@ -81,7 +108,7 @@ public class ToolSetValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"invalid name", "invalid@name", "invalid#name"})
+    @ValueSource(strings = {"invalid_name_too___________long"})
     void validateCreation_withInvalidNameAgainstPattern_shouldThrowException(String invalidName) {
         // given
         ToolSet toolSet = new ToolSet();
@@ -94,19 +121,6 @@ public class ToolSetValidatorTest {
         assertThatThrownBy(() -> toolSetValidator.validateCreation(toolSet))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not match the required pattern: " + NAME_VALIDATION_PATTERN);
-    }
-
-    @Test
-    void validateCreation_withoutNameValidationPattern_shouldNotValidateNameAgainstPattern() {
-        // given
-        String toolSetName = "invalid name with spaces";
-        ToolSet toolSet = new ToolSet();
-        toolSet.setDisplayName(toolSetName);
-        SecuredResource deployment = new SecuredResource(toolSetName);
-        toolSet.setDeployment(deployment);
-
-        // when & then
-        assertThatNoException().isThrownBy(() -> toolSetValidator.validateCreation(toolSet));
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #529 

### Description of changes
Adjusted toolset name validation according to pattern introduced in core (`^[A-Za-z0-9-_]+$`)

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.