### PR TITLE
fix: add validation for adapter completion endpoint path

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ModelValidator.java
@@ -127,7 +127,10 @@ public class ModelValidator {
             throw new IllegalArgumentException("Adapter name is required when source type is 'Adapter'. Model: %s"
                     .formatted(name));
         }
-        validateEndpointEnding(model.getType(), adapterSource.getCompletionEndpointPath(), name);
+
+        String completionPath = adapterSource.getCompletionEndpointPath();
+        validateEndpointEnding(model.getType(), completionPath, name);
+        validateEndpointPath(completionPath, name);
     }
 
     private void validateContainerSource(ModelContainerSource containerSource, Model model) {

--- a/src/main/resources/db/migration/H2/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
+++ b/src/main/resources/db/migration/H2/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
@@ -1,0 +1,2 @@
+update model_entity set adapter_completion_endpoint_path = regexp_replace(adapter_completion_endpoint_path, '\s', '%20');
+update model_entity_aud set adapter_completion_endpoint_path = regexp_replace(adapter_completion_endpoint_path, '\s', '%20');

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
@@ -1,0 +1,2 @@
+update model_entity set adapter_completion_endpoint_path = replace(adapter_completion_endpoint_path, ' ', '%20');
+update model_entity_aud set adapter_completion_endpoint_path = replace(adapter_completion_endpoint_path, ' ', '%20');

--- a/src/main/resources/db/migration/POSTGRES/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.86__ReplaceWhitespaceWithUrlEncodedWhitespaceInAdapterCompletionEndpointPath.sql
@@ -1,0 +1,2 @@
+update model_entity set adapter_completion_endpoint_path = regexp_replace(adapter_completion_endpoint_path, '\s', '%20', 'g');
+update model_entity_aud set adapter_completion_endpoint_path = regexp_replace(adapter_completion_endpoint_path, '\s', '%20', 'g');

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ModelValidatorTest.java
@@ -34,10 +34,12 @@ class ModelValidatorTest {
     private static final String NAME_VALIDATION_PATTERN = "^[a-zA-Z0-9-_.]{1,30}$";
 
     private static final String INVALID_COMPLETION_MESSAGE = "Invalid completion endpoint:";
+    private static final String INVALID_COMPLETION_PATH_MESSAGE = "Invalid completion endpoint path:";
     private static final String INVALID_COMPLETION_END_MESSAGE =
             "Completion endpoint path should be provided and end with ";
     private static final String INVALID_START_MODEL_ENDPOINT = "//upstream1.endpoint.test.com/embeddings";
     private static final String INVALID_END_MODEL_ENDPOINT = "http://upstream1.endpoint.test.com/";
+    private static final String INVALID_PATH_WITH_WHITESPACE = "/model/with whitespace /embeddings";
 
     @Mock
     private DisplayFieldsValidator displayFieldsValidator;
@@ -167,7 +169,7 @@ class ModelValidatorTest {
             containerSource.setCompletionEndpointPath(endpoint);
             model.setSource(containerSource);
         }
-        ;
+
         model.setEndpoint(endpoint);
         return model;
     }
@@ -196,6 +198,9 @@ class ModelValidatorTest {
                         createModel(new AdapterSource(), ModelType.EMBEDDING, null),
                         INVALID_COMPLETION_END_MESSAGE),
                 Arguments.of(
+                        createModel(new AdapterSource(), ModelType.EMBEDDING, INVALID_PATH_WITH_WHITESPACE),
+                        INVALID_COMPLETION_PATH_MESSAGE),
+                Arguments.of(
                         createModel(new ModelContainerSource(), ModelType.EMBEDDING, INVALID_END_MODEL_ENDPOINT),
                         INVALID_COMPLETION_END_MESSAGE),
                 Arguments.of(
@@ -203,7 +208,10 @@ class ModelValidatorTest {
                         INVALID_COMPLETION_END_MESSAGE),
                 Arguments.of(
                         createModel(new ModelContainerSource(), ModelType.EMBEDDING, "  "),
-                        INVALID_COMPLETION_END_MESSAGE)
+                        INVALID_COMPLETION_END_MESSAGE),
+                Arguments.of(
+                        createModel(new ModelContainerSource(), ModelType.EMBEDDING, INVALID_PATH_WITH_WHITESPACE),
+                        INVALID_COMPLETION_PATH_MESSAGE)
         );
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #520 

### Description of changes
Added validation for adapter completion endpoint path (existing models are adjusted via migration script)

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.