### PR TITLE
chore: increase io.netty:netty-codec transitive dependencies version from 4.2.5.Final to 4.2.8.Final, increase org.apache.logging.log4j:log4j dependencies version from 2.24.3 to 2.25.3, increase org.apache.logging.log4j:log4j-core dependency version from 2.24.1 to 2.25.3 for buildscript in secret-utils module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ dependencies {
         exclude group: 'org.apache.logging.log4j'
     }
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3'
-    implementation 'org.apache.logging.log4j:log4j-core:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
     implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ dependencies {
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
                 because("previous versions have vulnerabilities)")
         }
-        implementation ('io.netty:netty-codec:4.2.5.Final') {
+        implementation ('io.netty:netty-codec:4.2.8.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation ('io.netty:netty-codec-http:4.2.8.Final') {

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,7 @@ dependencies {
         implementation ('io.netty:netty-codec:4.2.5.Final') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http:4.2.5.Final') {
+        implementation ('io.netty:netty-codec-http:4.2.8.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.springframework:spring-webmvc:6.2.10') {

--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,9 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-log4j2') {
         exclude group: 'org.apache.logging.log4j'
     }
-    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3'
     implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
-    implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-jul:2.25.3'
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.33.6-alpha'

--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3'
-    implementation 'org.apache.logging.log4j:log4j-core:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
     implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'

--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -5,6 +5,12 @@ buildscript {
     }
     dependencies {
         classpath "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
+
+        constraints {
+            classpath ('org.apache.logging.log4j:log4j-core:2.25.3') {
+                because("previous versions have vulnerabilities")
+            }
+        }
     }
 }
 

--- a/secrets-utils/build.gradle
+++ b/secrets-utils/build.gradle
@@ -28,9 +28,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3'
     implementation 'org.apache.logging.log4j:log4j-core:2.25.3'
-    implementation 'org.apache.logging.log4j:log4j-jul:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-jul:2.25.3'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
     compileOnly 'org.projectlombok:lombok:1.18.34'


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
- Increased io.netty:netty-codec transitive dependencies version from 4.2.5.Final to 4.2.8.Final
- Increased org.apache.logging.log4j:log4j dependencies version from 2.24.3 to 2.25.3, 
- Increased org.apache.logging.log4j:log4j-core dependency version from 2.24.1 to 2.25.3 for buildscript in secret-utils module

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.