### PR TITLE
feat: add security-info controller

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
@@ -45,6 +45,7 @@ public class JsonMapperConfiguration {
                 .addModule(new QueryLanguageModule())
                 .addModule(new ValidationModule())
                 .addModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/SecurityInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/SecurityInfoDto.java
@@ -1,0 +1,8 @@
+package com.epam.aidial.cfg.dto;
+
+import lombok.Data;
+
+@Data
+public class SecurityInfoDto {
+
+}

--- a/src/main/java/com/epam/aidial/cfg/web/controller/SecurityInfoController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/SecurityInfoController.java
@@ -1,0 +1,21 @@
+package com.epam.aidial.cfg.web.controller;
+
+import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.dto.SecurityInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/security-info")
+@LogExecution
+@RequiredArgsConstructor
+public class SecurityInfoController {
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public SecurityInfoDto getSecurityInfo() {
+        return new SecurityInfoDto();
+    }
+}

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/SecurityInfoControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/SecurityInfoControllerTest.java
@@ -1,0 +1,30 @@
+package com.epam.aidial.cfg.web.controller.none;
+
+import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
+import com.epam.aidial.cfg.web.controller.SecurityInfoController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.json.JsonCompareMode;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SecurityInfoController.class)
+@Import({
+        JsonMapperConfiguration.class,
+})
+class SecurityInfoControllerTest extends AbstractControllerNoneSecureTest {
+
+    private static final String SECURITY_INFO_BASE_API_PATH = "/api/v1/security-info";
+
+    @Test
+    void testGetSecurityInfo() throws Exception {
+        var responseJson = "{}";
+
+        mockMvc.perform(get(SECURITY_INFO_BASE_API_PATH))
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson, JsonCompareMode.LENIENT));
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #476

### Description of changes
Added endpoint `GET api/v1/security-info` which returns empty object now, but will be adjusted in future once granular security design is ready

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.