### PR TITLE
feat!: sync DeploymentInfoDto with deployment-manager

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/client/dto/AdapterDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/AdapterDeploymentInfoDto.java
@@ -2,11 +2,9 @@ package com.epam.aidial.cfg.client.dto;
 
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @NoArgsConstructor
 public class AdapterDeploymentInfoDto extends DeploymentInfoDto {
-    public AdapterDeploymentInfoDto(UUID id, String name, String url) {
+    public AdapterDeploymentInfoDto(String id, String name, String url) {
         super(id, name, url);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/client/dto/DeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/DeploymentInfoDto.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         property = "$type"
@@ -28,9 +26,9 @@ import java.util.UUID;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class DeploymentInfoDto {
     @NotNull
-    private UUID id;
+    private String id;
     @NotNull
-    private String name;
+    private String displayName;
     @Nullable
     private String url;
 }

--- a/src/main/java/com/epam/aidial/cfg/client/dto/InferenceDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/InferenceDeploymentInfoDto.java
@@ -2,11 +2,9 @@ package com.epam.aidial.cfg.client.dto;
 
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @NoArgsConstructor
 public class InferenceDeploymentInfoDto extends DeploymentInfoDto {
-    public InferenceDeploymentInfoDto(UUID id, String name, String url) {
+    public InferenceDeploymentInfoDto(String id, String name, String url) {
         super(id, name, url);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/client/dto/InterceptorDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/InterceptorDeploymentInfoDto.java
@@ -2,11 +2,9 @@ package com.epam.aidial.cfg.client.dto;
 
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @NoArgsConstructor
 public class InterceptorDeploymentInfoDto extends DeploymentInfoDto {
-    public InterceptorDeploymentInfoDto(UUID id, String name, String url) {
+    public InterceptorDeploymentInfoDto(String id, String name, String url) {
         super(id, name, url);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/client/dto/McpDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/McpDeploymentInfoDto.java
@@ -7,8 +7,6 @@ import lombok.Setter;
 import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.UUID;
-
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,7 +16,7 @@ public class McpDeploymentInfoDto extends DeploymentInfoDto {
     @NotNull
     private McpTransport transport = McpTransport.HTTP_STREAMING;
 
-    public McpDeploymentInfoDto(UUID id, String name, String url, McpTransport transport) {
+    public McpDeploymentInfoDto(String id, String name, String url, McpTransport transport) {
         super(id, name, url);
         this.transport = transport;
     }

--- a/src/main/java/com/epam/aidial/cfg/client/dto/NimDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/NimDeploymentInfoDto.java
@@ -2,11 +2,9 @@ package com.epam.aidial.cfg.client.dto;
 
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @NoArgsConstructor
 public class NimDeploymentInfoDto extends DeploymentInfoDto {
-    public NimDeploymentInfoDto(UUID id, String name, String url) {
+    public NimDeploymentInfoDto(String id, String name, String url) {
         super(id, name, url);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentManagerService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentManagerService.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -21,7 +20,7 @@ public class DeploymentManagerService {
     private final DeploymentManagerClient deploymentManagerClient;
     private final String deploymentClientUrl;
 
-    private final Cache<UUID, DeploymentInfoDto> deploymentCache;
+    private final Cache<String, DeploymentInfoDto> deploymentCache;
 
     public DeploymentManagerService(DeploymentManagerClient deploymentManagerClient,
                                     @Value("${plugins.deployment.manager.cache.expiration.interval}") long cacheExpirationInterval,
@@ -35,7 +34,7 @@ public class DeploymentManagerService {
 
     public DeploymentInfoDto getById(String id) {
         try {
-            return deploymentCache.get(UUID.fromString(id), () -> {
+            return deploymentCache.get(id, () -> {
                 log.debug("Deployment '{}' is not present in cache, loading from deployment manager client", id);
                 return getDeploymentInfoDto(id);
             });

--- a/src/main/java/com/epam/aidial/cfg/domain/util/ContainerEndpointResolver.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/util/ContainerEndpointResolver.java
@@ -212,7 +212,7 @@ public class ContainerEndpointResolver {
             BiConsumer<R, ContainerEndpoints> endpointConsumer,
             R target) {
 
-        String containerName = deploymentInfo.getName();
+        String containerName = deploymentInfo.getDisplayName();
         String containerUrl = deploymentInfo.getUrl();
         String completionPath = completionPathExtractor.apply(pathProvider);
         String configPath = configPathExtractor != null ? configPathExtractor.apply(pathProvider) : null;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -37,7 +37,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -344,8 +343,8 @@ public abstract class InterceptorFunctionalTest {
         updatedInterceptor.setSource(source);
 
         DeploymentInfoDto deploymentInfoDto = new InterceptorDeploymentInfoDto();
-        deploymentInfoDto.setId(UUID.fromString(containerId));
-        deploymentInfoDto.setName(containerName);
+        deploymentInfoDto.setId(containerId);
+        deploymentInfoDto.setDisplayName(containerName);
         deploymentInfoDto.setUrl(containerUrl);
 
         Mockito.when(deploymentManagerService.getById(containerId)).thenReturn(deploymentInfoDto);
@@ -423,8 +422,8 @@ public abstract class InterceptorFunctionalTest {
         String configPath = "/api/config";
 
         DeploymentInfoDto deploymentInfoDto = new InterceptorDeploymentInfoDto();
-        deploymentInfoDto.setId(UUID.fromString(containerId));
-        deploymentInfoDto.setName("Test Container");
+        deploymentInfoDto.setId(containerId);
+        deploymentInfoDto.setDisplayName("Test Container");
         deploymentInfoDto.setUrl(containerUrl);
 
         Mockito.when(deploymentManagerService.getById(containerId)).thenReturn(deploymentInfoDto);
@@ -467,13 +466,13 @@ public abstract class InterceptorFunctionalTest {
         String configPath = "/api/config";
 
         DeploymentInfoDto initialDeploymentInfo = new InterceptorDeploymentInfoDto();
-        initialDeploymentInfo.setId(UUID.fromString(containerId));
-        initialDeploymentInfo.setName(deploymentName);
+        initialDeploymentInfo.setId(containerId);
+        initialDeploymentInfo.setDisplayName(deploymentName);
         initialDeploymentInfo.setUrl(initialUrl);
 
         DeploymentInfoDto updatedDeploymentInfo = new InterceptorDeploymentInfoDto();
-        updatedDeploymentInfo.setId(UUID.fromString(containerId));
-        updatedDeploymentInfo.setName(deploymentName);
+        updatedDeploymentInfo.setId(containerId);
+        updatedDeploymentInfo.setDisplayName(deploymentName);
         updatedDeploymentInfo.setUrl(updatedUrl);
 
         Mockito.when(deploymentManagerService.getById(containerId))

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
@@ -33,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -238,8 +237,8 @@ public abstract class ToolSetFunctionalTest {
 
         McpDeploymentInfoDto deploymentInfoDto = new McpDeploymentInfoDto();
         deploymentInfoDto.setTransport(McpDeploymentInfoDto.McpTransport.HTTP_STREAMING);
-        deploymentInfoDto.setId(UUID.fromString(containerId));
-        deploymentInfoDto.setName("Test Container");
+        deploymentInfoDto.setId(containerId);
+        deploymentInfoDto.setDisplayName("Test Container");
         deploymentInfoDto.setUrl(containerUrl);
 
         Mockito.when(deploymentManagerService.getById(containerId)).thenReturn(deploymentInfoDto);
@@ -279,14 +278,14 @@ public abstract class ToolSetFunctionalTest {
         String refreshedToolSetName = "refresh-toolset";
 
         McpDeploymentInfoDto initialDeploymentInfo = new McpDeploymentInfoDto();
-        initialDeploymentInfo.setId(UUID.fromString(containerId));
-        initialDeploymentInfo.setName(deploymentName);
+        initialDeploymentInfo.setId(containerId);
+        initialDeploymentInfo.setDisplayName(deploymentName);
         initialDeploymentInfo.setUrl(initialUrl);
         initialDeploymentInfo.setTransport(McpDeploymentInfoDto.McpTransport.HTTP_STREAMING);
 
         McpDeploymentInfoDto updatedDeploymentInfo = new McpDeploymentInfoDto();
-        updatedDeploymentInfo.setId(UUID.fromString(containerId));
-        updatedDeploymentInfo.setName(deploymentName);
+        updatedDeploymentInfo.setId(containerId);
+        updatedDeploymentInfo.setDisplayName(deploymentName);
         updatedDeploymentInfo.setUrl(updatedUrl);
         updatedDeploymentInfo.setTransport(McpDeploymentInfoDto.McpTransport.HTTP_STREAMING);
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ToolSetHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ToolSetHistoryFunctionalTest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.functional.tests.history;
 
-import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
 import com.epam.aidial.cfg.client.dto.McpDeploymentInfoDto;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
 import com.epam.aidial.cfg.dto.AuthenticationTypeDto;
@@ -21,7 +20,6 @@ import org.springframework.util.CollectionUtils;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createToolSetDto;
@@ -53,8 +51,8 @@ public abstract class ToolSetHistoryFunctionalTest {
         String containerName = "Test Container";
         String endpointPath = "/some-path";
         McpDeploymentInfoDto deploymentInfoDto = new McpDeploymentInfoDto();
-        deploymentInfoDto.setId(UUID.fromString(containerId));
-        deploymentInfoDto.setName(containerName);
+        deploymentInfoDto.setId(containerId);
+        deploymentInfoDto.setDisplayName(containerName);
         deploymentInfoDto.setUrl(containerUrl);
         deploymentInfoDto.setTransport(McpDeploymentInfoDto.McpTransport.HTTP_STREAMING);
 


### PR DESCRIPTION
### Description of changes

To reflect new changes in Deployment fields in Deployment Manager, updated 'id' field type to 'String' and re-named 'name' to 'displayName'.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.