### PR TITLE
feat!: improve sync state comparison, remove GET /sync-state endpoint for keys

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
@@ -1,5 +1,11 @@
 package com.epam.aidial.cfg.configuration;
 
+import com.epam.aidial.core.config.CoreCostLimit;
+import com.epam.aidial.core.config.CoreCostLimitMixinForCoreObjectMapper;
+import com.epam.aidial.core.config.CoreLimit;
+import com.epam.aidial.core.config.CoreLimitMixinForCoreObjectMapper;
+import com.epam.aidial.core.config.CoreUpstream;
+import com.epam.aidial.core.config.CoreUpstreamMixinForCoreObjectMapper;
 import com.epam.aidial.core.config.validation.ValidationModule;
 import com.epam.aidial.ql.deserializers.json.QueryLanguageModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -12,6 +18,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 /**
  * Created by Aliaksei Kurnosau on 9/9/24.
@@ -20,8 +27,14 @@ import org.springframework.context.annotation.Configuration;
 public class JsonMapperConfiguration {
 
     @Bean
+    @Primary
     public JsonMapper getJsonMapper() {
         return createJsonMapper();
+    }
+
+    @Bean
+    public JsonMapper coreJsonMapper() {
+        return createCoreJsonMapper();
     }
 
     public static JsonMapper createJsonMapper() {
@@ -32,6 +45,15 @@ public class JsonMapperConfiguration {
     public static JsonMapper createPrettyJsonMapper() {
         return createDefaultJsonMapperBuilder()
                 .enable(SerializationFeature.INDENT_OUTPUT)
+                .build();
+    }
+
+    public static JsonMapper createCoreJsonMapper() {
+        return JsonMapper.builder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .addMixIn(CoreLimit.class, CoreLimitMixinForCoreObjectMapper.class)
+                .addMixIn(CoreCostLimit.class, CoreCostLimitMixinForCoreObjectMapper.class)
+                .addMixIn(CoreUpstream.class, CoreUpstreamMixinForCoreObjectMapper.class)
                 .build();
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/syncstate/EntitySyncStateResolver.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/syncstate/EntitySyncStateResolver.java
@@ -4,24 +4,35 @@ import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.model.EntitySyncState;
 import com.epam.aidial.cfg.model.EntitySyncStateStatus;
 import com.epam.aidial.cfg.service.config.reload.CoreConfigReloadCache;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.function.Function;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 @LogExecution
 public class EntitySyncStateResolver {
 
     private final ObjectMapper objectMapper;
+    private final ObjectMapper coreObjectMapper;
     private final CoreConfigReloadCache coreConfigReloadCache;
     private final EntitySyncStateStatusResolver syncStateStatusResolver;
+
+    public EntitySyncStateResolver(ObjectMapper objectMapper,
+                                   @Qualifier("coreJsonMapper") ObjectMapper coreObjectMapper,
+                                   CoreConfigReloadCache coreConfigReloadCache,
+                                   EntitySyncStateStatusResolver syncStateStatusResolver) {
+        this.objectMapper = objectMapper;
+        this.coreObjectMapper = coreObjectMapper;
+        this.coreConfigReloadCache = coreConfigReloadCache;
+        this.syncStateStatusResolver = syncStateStatusResolver;
+    }
 
     public <T> EntitySyncState resolveForEntityInObject(T currentState,
                                                         long currentStateUpdatedAt,
@@ -92,27 +103,25 @@ public class EntitySyncStateResolver {
         }
 
         JsonNode configStateJsonNode = entityFinder.apply(entitiesJsonNode);
-        JsonNode currentStateJsonNode = objectMapper.valueToTree(currentState);
-
-        // needed for at least transformation of POJONode to ObjectNode,
-        // so that subsequent call to {@link com.fasterxml.jackson.databind.JsonNode#equals(Object o)} will not return false
-        // when comparing identical POJONode and ObjectNode
-        JsonNode normalizedConfigStateJson = configStateJsonNode != null
-                ? objectMapper.readTree(objectMapper.writeValueAsString(configStateJsonNode))
-                : null;
-        JsonNode normalizedCurrentStateJson = objectMapper.readTree(objectMapper.writeValueAsString(currentStateJsonNode));
-
+        JsonNode normalizedCurrentStateJsonNode = getNormalizedCurrentStateJsonNode(currentState);
 
         EntitySyncStateStatus syncStateStatus = syncStateStatusResolver.resolve(
-                normalizedCurrentStateJson,
-                normalizedConfigStateJson,
+                normalizedCurrentStateJsonNode,
+                configStateJsonNode,
                 isCurrentStateValid,
                 currentStateUpdatedAt,
                 cacheEntry.reloadTimestamp()
         );
 
-        normalizedCurrentStateJson = isCurrentStateValid ? normalizedCurrentStateJson : null;
+        normalizedCurrentStateJsonNode = isCurrentStateValid ? normalizedCurrentStateJsonNode : null;
 
-        return new EntitySyncState(normalizedCurrentStateJson, normalizedConfigStateJson, syncStateStatus);
+        return new EntitySyncState(normalizedCurrentStateJsonNode, configStateJsonNode, syncStateStatus);
+    }
+
+    private <T> JsonNode getNormalizedCurrentStateJsonNode(T currentState) throws JsonProcessingException {
+        String serializedCurrentStateOnOurSide = objectMapper.writeValueAsString(currentState);
+        Object deserializedCurrentStateOnCoreSide = coreObjectMapper.readValue(serializedCurrentStateOnOurSide, currentState.getClass());
+        String serializedCurrentStateOnCoreSide = coreObjectMapper.writeValueAsString(deserializedCurrentStateOnCoreSide);
+        return objectMapper.readTree(serializedCurrentStateOnCoreSide);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/core/CoreKeyService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/core/CoreKeyService.java
@@ -8,8 +8,6 @@ import com.epam.aidial.cfg.domain.service.KeyService;
 import com.epam.aidial.cfg.dto.CoreWithDomainHash;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException.OptimisticLockConflictExceptionDetails;
-import com.epam.aidial.cfg.model.EntitySyncState;
-import com.epam.aidial.cfg.service.config.syncstate.EntitySyncStateResolver;
 import com.epam.aidial.cfg.service.config.transfer.importer.ConfigImporter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
@@ -34,7 +32,6 @@ public class CoreKeyService {
     private final KeyService keyService;
     private final KeyCoreMapper keyCoreMapper;
     private final ConfigImporter configImporter;
-    private final EntitySyncStateResolver entitySyncStateResolver;
 
     @Transactional(readOnly = true)
     public CoreWithDomainHash<CoreKey> getCoreKeyWithHash(String keyName) {
@@ -67,24 +64,6 @@ public class CoreKeyService {
         config.setKeys(coreKeys);
 
         configImporter.importConfigWithOverride(config);
-    }
-
-    @Transactional(readOnly = true)
-    public EntitySyncState getSyncState(String keyName, String hash) {
-        assertHashNotNull(keyName, hash);
-
-        var keyWithHash = keyService.getKeyWithHash(keyName);
-        assertKeyWasNotUpdated(keyWithHash, hash, OptimisticLockConflictException::onGetSyncState);
-
-        var key = keyWithHash.model();
-        if (StringUtils.isBlank(key.getKey())) {
-            return EntitySyncState.unknown();
-        }
-
-        var coreKey = keyCoreMapper.mapKey(key);
-        boolean isKeyValid = key.getValidityState().isValid();
-
-        return entitySyncStateResolver.resolveForEntityInObject(coreKey, isKeyValid, key.getUpdatedAt(), "keys", key.getKey());
     }
 
     private void assertHashNotNull(String keyName, String hash) {

--- a/src/main/java/com/epam/aidial/cfg/web/controller/KeyController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/KeyController.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.web.controller;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
-import com.epam.aidial.cfg.dto.EntitySyncStateDto;
 import com.epam.aidial.cfg.dto.KeyDto;
 import com.epam.aidial.cfg.web.facade.KeyFacade;
 import com.epam.aidial.core.config.CoreKey;
@@ -54,12 +53,6 @@ public class KeyController extends AbstractController {
                                               @RequestHeader(value = "If-None-Match") String previousHash) {
         var coreWithHash = keyFacade.getCoreKeyWithHash(name);
         return responseEntityForGet(coreWithHash.core(), coreWithHash.hash(), previousHash);
-    }
-
-    @GetMapping(path = "/{name}/sync-state", produces = MediaType.APPLICATION_JSON_VALUE)
-    public EntitySyncStateDto getSyncState(@PathVariable String name,
-                                           @RequestHeader(value = "If-Match") String previousHash) {
-        return keyFacade.getSyncState(name, StringUtils.unwrap(previousHash, '"'));
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/epam/aidial/cfg/web/facade/KeyFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/KeyFacade.java
@@ -5,10 +5,8 @@ import com.epam.aidial.cfg.domain.model.Key;
 import com.epam.aidial.cfg.domain.service.KeyService;
 import com.epam.aidial.cfg.dto.CoreWithDomainHash;
 import com.epam.aidial.cfg.dto.DtoWithDomainHash;
-import com.epam.aidial.cfg.dto.EntitySyncStateDto;
 import com.epam.aidial.cfg.dto.KeyDto;
 import com.epam.aidial.cfg.service.core.CoreKeyService;
-import com.epam.aidial.cfg.web.facade.mapper.EntitySyncStateDtoMapper;
 import com.epam.aidial.cfg.web.facade.mapper.KeyDtoMapper;
 import com.epam.aidial.core.config.CoreKey;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +24,6 @@ public class KeyFacade {
     private final KeyService keyService;
     private final KeyDtoMapper mapper;
     private final CoreKeyService coreKeyService;
-    private final EntitySyncStateDtoMapper entitySyncStateDtoMapper;
 
     public Collection<KeyDto> getAllKeys() {
         return keyService.getAllKeys()
@@ -48,11 +45,6 @@ public class KeyFacade {
 
     public CoreWithDomainHash<CoreKey> getCoreKeyWithHash(String keyName) {
         return coreKeyService.getCoreKeyWithHash(keyName);
-    }
-
-    public EntitySyncStateDto getSyncState(String keyName, String hash) {
-        var syncState = coreKeyService.getSyncState(keyName, hash);
-        return entitySyncStateDtoMapper.toDto(syncState);
     }
 
     public void createKey(KeyDto keyDto) {

--- a/src/main/java/com/epam/aidial/core/config/CoreCostLimitMixinForCoreObjectMapper.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreCostLimitMixinForCoreObjectMapper.java
@@ -1,0 +1,16 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.math.BigDecimal;
+
+public abstract class CoreCostLimitMixinForCoreObjectMapper {
+    @JsonInclude
+    private BigDecimal minute;
+    @JsonInclude
+    private BigDecimal day;
+    @JsonInclude
+    private BigDecimal week;
+    @JsonInclude
+    private BigDecimal month;
+}

--- a/src/main/java/com/epam/aidial/core/config/CoreLimitMixinForCoreObjectMapper.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreLimitMixinForCoreObjectMapper.java
@@ -1,0 +1,18 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public abstract class CoreLimitMixinForCoreObjectMapper {
+    @JsonInclude
+    private Long minute;
+    @JsonInclude
+    private Long day;
+    @JsonInclude
+    private Long week;
+    @JsonInclude
+    private Long month;
+    @JsonInclude
+    private Long requestHour;
+    @JsonInclude
+    private Long requestDay;
+}

--- a/src/main/java/com/epam/aidial/core/config/CoreModel.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreModel.java
@@ -1,11 +1,11 @@
 package com.epam.aidial.core.config;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+
+import java.util.List;
 
 @Data
 @Accessors(chain = true)
@@ -20,7 +20,7 @@ public class CoreModel extends Deployment {
     private String overrideName;
 
     @JsonAlias({"fieldsHashingOrder", "fields_hashing_order"})
-    private List<String> fieldsHashingOrder; // 0.26.0
+    private List<String> fieldsHashingOrder = List.of("prefix.body.tools", "prefix.body.messages"); // 0.26.0
 
     public CoreModel() {
         setMaxRetryAttempts(5);

--- a/src/main/java/com/epam/aidial/core/config/CoreUpstreamMixinForCoreObjectMapper.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreUpstreamMixinForCoreObjectMapper.java
@@ -1,0 +1,14 @@
+package com.epam.aidial.core.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+public abstract class CoreUpstreamMixinForCoreObjectMapper {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String key;
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    private String extraData;
+}

--- a/src/main/java/com/epam/aidial/core/config/Deployment.java
+++ b/src/main/java/com/epam/aidial/core/config/Deployment.java
@@ -1,13 +1,13 @@
 package com.epam.aidial.core.config;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonAlias;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -66,5 +66,5 @@ public abstract class Deployment extends RoleBasedEntity {
     /**
      * Dependent deployments
      */
-    private List<String> dependencies; // 0.27.0
+    private List<String> dependencies = List.of(); // 0.27.0
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
@@ -18,7 +18,6 @@ import com.epam.aidial.core.config.CoreApplication;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -423,11 +422,11 @@ public abstract class ApplicationFunctionalTest {
         ApplicationDto applicationDto = createApplicationDtoWithEndpoint("1");
         applicationFacade.createApplication(applicationDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode applicationState = coreApplication();
+        JsonNode applicationState = config.get("applications").get("application1");
 
         EntitySyncStateDto actualSyncState = applicationFacade.getSyncState(applicationDto.getName(), "*");
 
@@ -443,12 +442,13 @@ public abstract class ApplicationFunctionalTest {
         applicationDto.setDescription("description OLD");
         applicationFacade.createApplication(applicationDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configApplicationState = coreApplication();
-        JsonNode currentApplicationState = ((ObjectNode) coreApplication()).put("description", "description OLD");
+        JsonNode configApplicationState = config.get("applications").get("application1");
+        JsonNode currentApplicationState = configApplicationState.deepCopy();
+        ((ObjectNode) currentApplicationState).put("description", "description OLD");
 
         EntitySyncStateDto actualSyncState = applicationFacade.getSyncState(applicationDto.getName(), "*");
 
@@ -493,47 +493,42 @@ public abstract class ApplicationFunctionalTest {
                 .collect(Collectors.toMap(getName, Function.identity()));
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreApplications = JsonNodeFactory.instance.objectNode();
-        coreApplications.set("application1", coreApplication());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("applications", coreApplications);
-
-        return config;
-    }
-
-    private JsonNode coreApplication() throws JsonProcessingException {
-        String application = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                  "name": "application1",
-                  "user_roles": [],
-                  "endpoint": "endpoint1",
-                  "display_name": "application1",
-                  "description": "description1",
-                  "forward_auth_token": false,
-                  "features": {
-                    "system_prompt_supported": true,
-                    "tools_supported": false,
-                    "seed_supported": false,
-                    "url_attachments_supported": false,
-                    "folder_attachments_supported": false,
-                    "allow_resume": true,
-                    "accessible_by_per_request_key": true,
-                    "content_parts_supported": false,
-                    "temperature_supported": true,
-                    "parallel_tool_calls_supported": true,
-                    "assistant_attachments_in_request_supported": false
-                  },
-                  "defaults": {},
-                  "interceptors": [],
-                  "description_keywords": [],
-                  "max_retry_attempts": 1,
-                  "created_at": 1000,
-                  "updated_at": 1000,
-                  "application_properties": {}
+                  "applications": {
+                    "application1": {
+                      "name": "application1",
+                      "user_roles": [],
+                      "endpoint": "endpoint1",
+                      "display_name": "application1",
+                      "description": "description1",
+                      "forward_auth_token": false,
+                      "features": {
+                        "system_prompt_supported": true,
+                        "tools_supported": false,
+                        "seed_supported": false,
+                        "url_attachments_supported": false,
+                        "folder_attachments_supported": false,
+                        "allow_resume": true,
+                        "accessible_by_per_request_key": true,
+                        "content_parts_supported": false,
+                        "temperature_supported": true,
+                        "parallel_tool_calls_supported": true,
+                        "assistant_attachments_in_request_supported": false
+                      },
+                      "defaults": {},
+                      "interceptors": [],
+                      "description_keywords": [],
+                      "max_retry_attempts": 1,
+                      "created_at": 1000,
+                      "updated_at": 1000,
+                      "dependencies": [],
+                      "application_properties": {}
+                    }
+                  }
                 }
                 """;
-        return OBJECT_MAPPER.readTree(application);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationTypeSchemaFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationTypeSchemaFunctionalTest.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -452,11 +450,11 @@ public abstract class ApplicationTypeSchemaFunctionalTest {
     public void shouldSuccessfullyGetFullySyncedEntitySyncStateWhenSchemaIsEqualToConfigSchema() throws JsonProcessingException {
         typeSchemaFacade.create(dto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode schemaState = coreSchema();
+        JsonNode schemaState = config.get("applicationTypeSchemas").get(0);
 
         EntitySyncStateDto actualSyncState = typeSchemaFacade.getSyncState(dto.getId(), "*");
 
@@ -471,12 +469,13 @@ public abstract class ApplicationTypeSchemaFunctionalTest {
         dto.setTitle("Sample Schema NEW");
         typeSchemaFacade.create(dto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configSchemaState = coreSchema();
-        JsonNode currentSchemaState = ((ObjectNode) coreSchema()).put("title", "Sample Schema NEW");
+        JsonNode configSchemaState = config.get("applicationTypeSchemas").get(0);
+        JsonNode currentSchemaState = configSchemaState.deepCopy();
+        ((ObjectNode) currentSchemaState).put("title", "Sample Schema NEW");
 
         EntitySyncStateDto actualSyncState = typeSchemaFacade.getSyncState(dto.getId(), "*");
 
@@ -485,91 +484,88 @@ public abstract class ApplicationTypeSchemaFunctionalTest {
         assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.IN_PROGRESS_TOO_LONG);
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ArrayNode coreSchemas = JsonNodeFactory.instance.arrayNode();
-        coreSchemas.add(coreSchema());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("applicationTypeSchemas", coreSchemas);
-
-        return config;
-    }
-
-    private JsonNode coreSchema() throws JsonProcessingException {
-        String schema = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                  "$schema": "https://dial.epam.com/application_type_schemas/schema#",
-                  "$id": "https://test-schema.example",
-                  "dial:applicationTypeEditorUrl": "https://test.com/billings",
-                  "dial:applicationTypeViewerUrl": "https://test.com/claims",
-                  "dial:applicationTypeDisplayName": "Claims Use case",
-                  "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
-                  "dial:applicationTypeConfigurationEndpoint": "https://test.io/openai/configuration",
-                  "dial:applicationTypeRateEndpoint": "https://test.io/openai/rate",
-                  "dial:applicationTypeTokenizeEndpoint": "https://test.io/openai/tokenize",
-                  "dial:applicationTypeTruncatePromptEndpoint": "https://test.io/openai/truncate",
-                  "dial:appendApplicationPropertiesHeader": true,
-                  "dial:applicationTypeAssistantAttachmentsInRequestSupported": false,
-                  "dial:applicationTypeInterceptors": [],
-                  "dial:applicationTypeBucketCopy": "ENABLED",
-                  "$defs": {
-                    "ToolEndpointInfo": {
-                      "properties": {
-                        "name": {
-                          "title": "Name",
-                          "type": "string"
-                        },
-                        "method_url": {
-                          "title": "Method Url",
-                          "type": "string"
-                        },
-                        "method_type": {
-                          "$ref": "#/$defs/ToolEndpointInfoMethodType"
-                        },
-                        "description": {
-                          "title": "Description",
-                          "type": "string"
-                        },
-                        "parameters": {
-                          "items": {
-                            "$ref": "#/$defs/ToolEndpointParameterInfo"
+                  "applicationTypeSchemas": [
+                    {
+                      "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+                      "$id": "https://test-schema.example",
+                      "dial:applicationTypeEditorUrl": "https://test.com/billings",
+                      "dial:applicationTypeViewerUrl": "https://test.com/claims",
+                      "dial:applicationTypeDisplayName": "Claims Use case",
+                      "dial:applicationTypeCompletionEndpoint": "https://test.io/openai/deployments/mindmap/chat/completions",
+                      "dial:applicationTypeConfigurationEndpoint": "https://test.io/openai/configuration",
+                      "dial:applicationTypeRateEndpoint": "https://test.io/openai/rate",
+                      "dial:applicationTypeTokenizeEndpoint": "https://test.io/openai/tokenize",
+                      "dial:applicationTypeTruncatePromptEndpoint": "https://test.io/openai/truncate",
+                      "dial:appendApplicationPropertiesHeader": true,
+                      "dial:applicationTypeAssistantAttachmentsInRequestSupported": false,
+                      "dial:applicationTypeInterceptors": [],
+                      "dial:applicationTypeBucketCopy": "ENABLED",
+                      "dial:applicationTypeIconUrl": null,
+                      "dial:applicationTypePlaybackSupport": null,
+                      "dial:applicationTypeRoutes": null,
+                      "$defs": {
+                        "ToolEndpointInfo": {
+                          "properties": {
+                            "name": {
+                              "title": "Name",
+                              "type": "string"
+                            },
+                            "method_url": {
+                              "title": "Method Url",
+                              "type": "string"
+                            },
+                            "method_type": {
+                              "$ref": "#/$defs/ToolEndpointInfoMethodType"
+                            },
+                            "description": {
+                              "title": "Description",
+                              "type": "string"
+                            },
+                            "parameters": {
+                              "items": {
+                                "$ref": "#/$defs/ToolEndpointParameterInfo"
+                              },
+                              "title": "Parameters",
+                              "type": "array"
+                            }
                           },
-                          "title": "Parameters",
-                          "type": "array"
+                          "required": [
+                            "name",
+                            "method_url",
+                            "method_type",
+                            "description",
+                            "parameters"
+                          ],
+                          "title": "ToolEndpointInfo",
+                          "type": "object"
+                        }
+                      },
+                      "properties": {
+                        "temperature": {
+                          "title": "Temperature",
+                          "type": "number",
+                          "dial:meta": {
+                            "dial:propertyKind": "server",
+                            "dial:propertyOrder": 1
+                          }
                         }
                       },
                       "required": [
-                        "name",
-                        "method_url",
-                        "method_type",
-                        "description",
-                        "parameters"
+                        "temperature",
+                        "instructions",
+                        "model",
+                        "web_api_toolset"
                       ],
-                      "title": "ToolEndpointInfo",
-                      "type": "object"
+                      "description": "testDescription",
+                      "type": "OBJECT",
+                      "title": "Sample Schema"
                     }
-                  },
-                  "properties": {
-                    "temperature": {
-                      "title": "Temperature",
-                      "type": "number",
-                      "dial:meta": {
-                        "dial:propertyKind": "server",
-                        "dial:propertyOrder": 1
-                      }
-                    }
-                  },
-                  "required": [
-                    "temperature",
-                    "instructions",
-                    "model",
-                    "web_api_toolset"
-                  ],
-                  "description": "testDescription",
-                  "type": "object",
-                  "title": "Sample Schema"
+                  ]
                 }
                 """;
-        return objectMapper.readTree(schema);
+        return objectMapper.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -532,11 +531,11 @@ public abstract class InterceptorFunctionalTest {
         InterceptorDto interceptorDto = createInterceptorDto("1");
         interceptorFacade.createInterceptor(interceptorDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode interceptorState = coreInterceptor();
+        JsonNode interceptorState = config.get("interceptors").get("interceptor1");
 
         EntitySyncStateDto actualSyncState = interceptorFacade.getSyncState(interceptorDto.getName(), "*");
 
@@ -552,12 +551,13 @@ public abstract class InterceptorFunctionalTest {
         interceptorDto.setDescription("description OLD");
         interceptorFacade.createInterceptor(interceptorDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configInterceptorState = coreInterceptor();
-        JsonNode currentInterceptorState = ((ObjectNode) coreInterceptor()).put("description", "description OLD");
+        JsonNode configInterceptorState = config.get("interceptors").get("interceptor1");
+        JsonNode currentInterceptorState = configInterceptorState.deepCopy();
+        ((ObjectNode) currentInterceptorState).put("description", "description OLD");
 
         EntitySyncStateDto actualSyncState = interceptorFacade.getSyncState(interceptorDto.getName(), "*");
 
@@ -566,45 +566,47 @@ public abstract class InterceptorFunctionalTest {
         assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.IN_PROGRESS_TOO_LONG);
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreInterceptors = JsonNodeFactory.instance.objectNode();
-        coreInterceptors.set("interceptor1", coreInterceptor());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("interceptors", coreInterceptors);
-
-        return config;
-    }
-
-    private JsonNode coreInterceptor() throws JsonProcessingException {
-        String interceptor = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                  "name": "interceptor1",
-                  "endpoint": "https://endpoint.test.com/interceptor1",
-                  "displayName": "displayName1",
-                  "description": "description1",
-                  "forwardAuthToken": false,
-                  "features": {
-                    "system_prompt_supported": true,
-                    "tools_supported": false,
-                    "seed_supported": false,
-                    "url_attachments_supported": false,
-                    "folder_attachments_supported": false,
-                    "allow_resume": true,
-                    "accessible_by_per_request_key": true,
-                    "content_parts_supported": false,
-                    "temperature_supported": true,
-                    "parallel_tool_calls_supported": true,
-                    "assistant_attachments_in_request_supported": false
-                  },
-                  "defaults": {},
-                  "interceptors": [],
-                  "descriptionKeywords": [],
-                  "maxRetryAttempts": 1,
-                  "createdAt": 1000,
-                  "updatedAt": 1000
+                  "interceptors": {
+                    "interceptor1": {
+                      "name": "interceptor1",
+                      "userRoles": null,
+                      "endpoint": "https://endpoint.test.com/interceptor1",
+                      "displayName": "displayName1",
+                      "displayVersion": null,
+                      "iconUrl": null,
+                      "description": "description1",
+                      "reference": null,
+                      "forwardAuthToken": false,
+                      "features": {
+                        "system_prompt_supported": true,
+                        "tools_supported": false,
+                        "seed_supported": false,
+                        "url_attachments_supported": false,
+                        "folder_attachments_supported": false,
+                        "allow_resume": true,
+                        "accessible_by_per_request_key": true,
+                        "content_parts_supported": false,
+                        "temperature_supported": true,
+                        "parallel_tool_calls_supported": true,
+                        "assistant_attachments_in_request_supported": false
+                      },
+                      "inputAttachmentTypes": null,
+                      "maxInputAttachments": null,
+                      "defaults": {},
+                      "interceptors": [],
+                      "descriptionKeywords": [],
+                      "maxRetryAttempts": 1,
+                      "author": null,
+                      "createdAt": 1000,
+                      "updatedAt": 1000,
+                      "dependencies": []
+                    }
+                  }
                 }
                 """;
-        return OBJECT_MAPPER.readTree(interceptor);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
@@ -1,8 +1,5 @@
 package com.epam.aidial.cfg.functional.tests;
 
-import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
-import com.epam.aidial.cfg.dto.EntitySyncStateDto;
-import com.epam.aidial.cfg.dto.EntitySyncStateStatusDto;
 import com.epam.aidial.cfg.dto.KeyDto;
 import com.epam.aidial.cfg.dto.RoleDto;
 import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
@@ -13,11 +10,6 @@ import com.epam.aidial.cfg.transaction.timestamp.TransactionTimestampContext;
 import com.epam.aidial.cfg.web.facade.KeyFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
 import com.epam.aidial.core.config.CoreKey;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,13 +32,8 @@ import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.validSta
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public abstract class KeyFunctionalTest {
-
-    private static final ObjectMapper OBJECT_MAPPER = JsonMapperConfiguration.createJsonMapper();
 
     @Autowired
     private KeyFacade keyFacade;
@@ -510,75 +497,6 @@ public abstract class KeyFunctionalTest {
         assertKeyExcludingGeneratedFields(actual, expected);
     }
 
-    @Test
-    public void shouldSuccessfullyGetFullySyncedEntitySyncStateWhenKeyIsValidAndEqualToConfigKey() throws JsonProcessingException {
-        KeyDto keyDto = createKeyDtoWithRole("1");
-        keyFacade.createKey(keyDto);
-
-        ObjectNode config = coreConfig("keyValue1");
-        CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
-        when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
-
-        JsonNode keyState = coreKey();
-
-        EntitySyncStateDto actualSyncState = keyFacade.getSyncState(keyDto.getName(), "*");
-
-        assertThat(actualSyncState.getCurrentState()).isEqualTo(keyState);
-        assertThat(actualSyncState.getConfigState()).isEqualTo(keyState);
-        assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.FULLY_SYNCED);
-    }
-
-    @Test
-    public void shouldSuccessfullyGetUnknownEntitySyncStateWhenKeyValueIsMissing() {
-        KeyDto keyDto = createKeyDtoWithRole("1");
-        keyDto.setKey(null);
-        keyFacade.createKey(keyDto);
-
-        EntitySyncStateDto actualSyncState = keyFacade.getSyncState(keyDto.getName(), "*");
-
-        assertThat(actualSyncState.getCurrentState()).isNull();
-        assertThat(actualSyncState.getConfigState()).isNull();
-        assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.UNKNOWN);
-
-        verify(coreConfigReloadCache, never()).get();
-    }
-
-    @Test
-    public void shouldSuccessfullyGetFullySyncedEntitySyncStateWhenKeyIsInvalidAndConfigDoesNotHaveKey() throws JsonProcessingException {
-        KeyDto keyDto = createKeyDto("1"); // key is invalid since doesn't have roles
-        keyFacade.createKey(keyDto);
-
-        ObjectNode config = coreConfig("keyValue_NEW");
-
-        CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
-        when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
-
-        EntitySyncStateDto actualSyncState = keyFacade.getSyncState(keyDto.getName(), "*");
-
-        assertThat(actualSyncState.getCurrentState()).isNull();
-        assertThat(actualSyncState.getConfigState()).isNull();
-        assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.FULLY_SYNCED);
-    }
-
-    @Test
-    public void shouldSuccessfullyGetInProgressEntitySyncStateWhenKeyIsInvalidAndConfigHasKey() throws JsonProcessingException {
-        KeyDto keyDto = createKeyDto("1"); // key is invalid since doesn't have roles
-        keyFacade.createKey(keyDto);
-
-        ObjectNode config = coreConfig("keyValue1");
-
-        CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
-        when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
-
-        JsonNode keyState = coreKey();
-
-        EntitySyncStateDto actualSyncState = keyFacade.getSyncState(keyDto.getName(), "*");
-
-        assertThat(actualSyncState.getCurrentState()).isNull();
-        assertThat(actualSyncState.getConfigState()).isEqualTo(keyState);
-        assertThat(actualSyncState.getStatus()).isEqualTo(EntitySyncStateStatusDto.IN_PROGRESS);
-    }
-
     private void assertKeys(Collection<KeyDto> actual, Collection<KeyDto> expected, boolean excludeGeneratedFields) {
         expected.forEach(keyDto -> keyDto.setKey(null));
         Map<String, KeyDto> actualMap = toMap(actual);
@@ -609,28 +527,5 @@ public abstract class KeyFunctionalTest {
 
     private void assertKey(KeyDto actual, KeyDto expected) {
         assertThat(actual).isEqualTo(expected);
-    }
-
-    private ObjectNode coreConfig(String entityConfigKey) throws JsonProcessingException {
-        ObjectNode coreKeys = JsonNodeFactory.instance.objectNode();
-        coreKeys.set(entityConfigKey, coreKey());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("keys", coreKeys);
-
-        return config;
-    }
-
-    private JsonNode coreKey() throws JsonProcessingException {
-        String key = """
-                {
-                   "project": "project1",
-                   "roles": [
-                     "role1"
-                   ],
-                   "secured": false
-                 }
-                """;
-        return OBJECT_MAPPER.readTree(key);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -10,6 +10,7 @@ import com.epam.aidial.cfg.dto.InterceptorDto;
 import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.dto.ShareResourceLimitDto;
+import com.epam.aidial.cfg.dto.UpstreamDto;
 import com.epam.aidial.cfg.dto.source.AdapterSourceDto;
 import com.epam.aidial.cfg.dto.source.ModelContainerSourceDto;
 import com.epam.aidial.cfg.dto.source.ModelEndpointsSourceDto;
@@ -26,7 +27,6 @@ import com.epam.aidial.core.config.CoreModel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -492,14 +492,19 @@ public abstract class ModelFunctionalTest {
     @Test
     public void shouldSuccessfullyGetFullySyncedEntitySyncStateWhenModelIsEqualToConfigModel() throws JsonProcessingException {
         doReturn(1000L).when(transactionTimestampContext).getTimestamp();
+        UpstreamDto upstreamDto = new UpstreamDto();
+        upstreamDto.setEndpoint("http://localhost");
+        upstreamDto.setKey("secretKey");
+        upstreamDto.setExtraData("{\"temp\":951}");
         ModelDto modelDto = createModelDto("1");
+        modelDto.setUpstreams(List.of(upstreamDto));
         modelFacade.createModel(modelDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode modelState = coreModel();
+        JsonNode modelState = config.get("models").get("model1");
 
         EntitySyncStateDto actualSyncState = modelFacade.getSyncState(modelDto.getName(), "*");
 
@@ -511,16 +516,22 @@ public abstract class ModelFunctionalTest {
     @Test
     public void shouldSuccessfullyGetInProgressTooLongEntitySyncStateWhenModelIsNotEqualToConfigModelAndUpdatedLongAgo() throws JsonProcessingException {
         doReturn(1000L).when(transactionTimestampContext).getTimestamp();
+        UpstreamDto upstreamDto = new UpstreamDto();
+        upstreamDto.setEndpoint("http://localhost");
+        upstreamDto.setKey("secretKey");
+        upstreamDto.setExtraData("{\"temp\":951}");
         ModelDto modelDto = createModelDto("1");
+        modelDto.setUpstreams(List.of(upstreamDto));
         modelDto.setDescription("description OLD");
         modelFacade.createModel(modelDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configModelState = coreModel();
-        JsonNode currentModelState = ((ObjectNode) coreModel()).put("description", "description OLD");
+        JsonNode configModelState = config.get("models").get("model1");
+        JsonNode currentModelState = configModelState.deepCopy();
+        ((ObjectNode) currentModelState).put("description", "description OLD");
 
         EntitySyncStateDto actualSyncState = modelFacade.getSyncState(modelDto.getName(), "*");
 
@@ -599,46 +610,61 @@ public abstract class ModelFunctionalTest {
         return modelDto;
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreModels = JsonNodeFactory.instance.objectNode();
-        coreModels.set("model1", coreModel());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("models", coreModels);
-
-        return config;
-    }
-
-    private JsonNode coreModel() throws JsonProcessingException {
-        String model = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                   "name": "model1",
-                   "userRoles": [],
-                   "displayName": "model1",
-                   "description": "description1",
-                   "forwardAuthToken": false,
-                   "features": {
-                     "system_prompt_supported": true,
-                     "tools_supported": false,
-                     "seed_supported": false,
-                     "url_attachments_supported": false,
-                     "folder_attachments_supported": false,
-                     "allow_resume": true,
-                     "accessible_by_per_request_key": true,
-                     "content_parts_supported": false,
-                     "temperature_supported": true,
-                     "parallel_tool_calls_supported": true,
-                     "assistant_attachments_in_request_supported": false
-                   },
-                   "defaults": {},
-                   "interceptors": [],
-                   "descriptionKeywords": [],
-                   "maxRetryAttempts": 1,
-                   "createdAt": 1000,
-                   "updatedAt": 1000,
-                   "upstreams": []
-                 }
+                  "models": {
+                    "model1": {
+                      "name": "model1",
+                      "userRoles": [],
+                      "endpoint": null,
+                      "displayName": "model1",
+                      "displayVersion": null,
+                      "iconUrl": null,
+                      "description": "description1",
+                      "reference": null,
+                      "forwardAuthToken": false,
+                      "features": {
+                        "system_prompt_supported": true,
+                        "tools_supported": false,
+                        "seed_supported": false,
+                        "url_attachments_supported": false,
+                        "folder_attachments_supported": false,
+                        "allow_resume": true,
+                        "accessible_by_per_request_key": true,
+                        "content_parts_supported": false,
+                        "temperature_supported": true,
+                        "parallel_tool_calls_supported": true,
+                        "assistant_attachments_in_request_supported": false
+                      },
+                      "inputAttachmentTypes": null,
+                      "maxInputAttachments":null,
+                      "defaults": {},
+                      "interceptors": [],
+                      "descriptionKeywords": [],
+                      "maxRetryAttempts": 1,
+                      "author": null,
+                      "createdAt": 1000,
+                      "updatedAt": 1000,
+                      "dependencies": [],
+                      "type": null,
+                      "tokenizerModel": null,
+                      "limits": null,
+                      "pricing": null,
+                      "upstreams": [
+                        {
+                          "endpoint": "http://localhost",
+                          "extraData": "{\\"temp\\":951}",
+                          "weight": 1,
+                          "tier":0
+                        }
+                      ],
+                      "overrideName": null,
+                      "fieldsHashingOrder": ["prefix.body.tools","prefix.body.messages"]
+                    }
+                  }
+                }
                 """;
-        return OBJECT_MAPPER.readTree(model);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RolesFunctionalTest.java
@@ -24,7 +24,6 @@ import com.epam.aidial.core.config.CoreShareResourceLimit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -553,15 +552,17 @@ public abstract class RolesFunctionalTest {
         doReturn(1000L).when(transactionTimestampContext).getTimestamp();
         CostLimitDto costLimitDto = new CostLimitDto();
         costLimitDto.setWeek(BigDecimal.valueOf(10));
-        RoleDto roleDto = createRoleDto("1");
+        LimitDto dayLimit = new LimitDto();
+        dayLimit.setDay(10L);
+        RoleDto roleDto = createDtoWithLimits("1", Map.of("addon1", dayLimit));
         roleDto.setCostLimit(costLimitDto);
         roleFacade.createRole(roleDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode roleState = coreRole();
+        JsonNode roleState = config.get("roles").get("role1");
 
         EntitySyncStateDto actualSyncState = roleFacade.getSyncState(roleDto.getName(), "*");
 
@@ -575,18 +576,19 @@ public abstract class RolesFunctionalTest {
         doReturn(1000L).when(transactionTimestampContext).getTimestamp();
         CostLimitDto costLimitDto = new CostLimitDto();
         costLimitDto.setWeek(BigDecimal.valueOf(15));
-        RoleDto roleDto = createRoleDto("1");
+        LimitDto dayLimit = new LimitDto();
+        dayLimit.setDay(10L);
+        RoleDto roleDto = createDtoWithLimits("1", Map.of("addon1", dayLimit));
         roleDto.setCostLimit(costLimitDto);
         roleFacade.createRole(roleDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configRoleState = coreRole();
-        ObjectNode costLimitJsonNode = JsonNodeFactory.instance.objectNode();
-        costLimitJsonNode.put("week", 15);
-        JsonNode currentRoleState = ((ObjectNode) coreRole()).set("costLimit", costLimitJsonNode);
+        JsonNode configRoleState = config.get("roles").get("role1");
+        JsonNode currentRoleState = configRoleState.deepCopy();
+        ((ObjectNode) currentRoleState.get("costLimit")).put("week", 15);
 
         EntitySyncStateDto actualSyncState = roleFacade.getSyncState(roleDto.getName(), "*");
 
@@ -664,26 +666,33 @@ public abstract class RolesFunctionalTest {
         return roleDto;
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreRoles = JsonNodeFactory.instance.objectNode();
-        coreRoles.set("role1", coreRole());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("roles", coreRoles);
-
-        return config;
-    }
-
-    private JsonNode coreRole() throws JsonProcessingException {
-        String role = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                  "name": "role1",
-                  "limits": {},
-                  "costLimit": {
-                    "week": 10.0
+                  "roles": {
+                    "role1": {
+                      "name": "role1",
+                      "limits": {
+                        "addon1": {
+                          "minute": 9223372036854775807,
+                          "day": 10,
+                          "week": 9223372036854775807,
+                          "month": 9223372036854775807,
+                          "requestHour": 9223372036854775807,
+                          "requestDay": 9223372036854775807
+                        }
+                      },
+                      "costLimit": {
+                        "minute": 9223372036854775807,
+                        "day": 9223372036854775807,
+                        "week": 10.0,
+                        "month": 9223372036854775807
+                        },
+                      "share":{}
+                    }
                   }
                 }
                 """;
-        return OBJECT_MAPPER.readTree(role);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
@@ -13,7 +13,6 @@ import com.epam.aidial.core.config.CoreRoute;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -193,11 +192,11 @@ public abstract class RouteFunctionalTest {
         routeDto.setDescription("description");
         routeFacade.createRoute(routeDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode routeState = coreRoute();
+        JsonNode routeState = config.get("routes").get("route1");
 
         EntitySyncStateDto actualSyncState = routeFacade.getSyncState(routeDto.getName(), "*");
 
@@ -212,12 +211,13 @@ public abstract class RouteFunctionalTest {
         routeDto.setRewritePath(true);
         routeFacade.createRoute(routeDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configRouteState = coreRoute();
-        JsonNode currentRouteState = ((ObjectNode) coreRoute()).put("rewritePath", true);
+        JsonNode configRouteState = config.get("routes").get("route1");
+        JsonNode currentRouteState = configRouteState.deepCopy();
+        ((ObjectNode) currentRouteState).put("rewritePath", true);
 
         EntitySyncStateDto actualSyncState = routeFacade.getSyncState(routeDto.getName(), "*");
 
@@ -247,34 +247,29 @@ public abstract class RouteFunctionalTest {
                 .collect(Collectors.toMap(RouteDto::getName, Function.identity()));
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreRoutes = JsonNodeFactory.instance.objectNode();
-        coreRoutes.set("route1", coreRoute());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("routes", coreRoutes);
-
-        return config;
-    }
-
-    private JsonNode coreRoute() throws JsonProcessingException {
-        String route = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                  "name": "route1",
-                  "userRoles": [],
-                  "rewritePath": false,
-                  "methods": [],
-                  "upstreams": [],
-                  "maxRetryAttempts": 1,
-                  "order": 2147483647,
-                  "permissions": [],
-                  "attachmentPaths": {
-                    "requestBody": [],
-                    "responseBody": []
-                  },
-                  "paths": ["path1"]
+                  "routes": {
+                    "route1": {
+                      "name": "route1",
+                      "userRoles": [],
+                      "response": null,
+                      "rewritePath": false,
+                      "paths": ["path1"],
+                      "methods": [],
+                      "upstreams": [],
+                      "maxRetryAttempts": 1,
+                      "order": 2147483647,
+                      "permissions": [],
+                      "attachmentPaths": {
+                        "requestBody": [],
+                        "responseBody": []
+                      }
+                    }
+                  }
                 }
                 """;
-        return OBJECT_MAPPER.readTree(route);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ToolSetFunctionalTest.java
@@ -20,7 +20,6 @@ import com.epam.aidial.core.config.CoreToolSet;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -362,11 +361,11 @@ public abstract class ToolSetFunctionalTest {
         ToolSetDto toolSetDto = createToolSetDto("1");
         toolSetFacade.createToolSet(toolSetDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 1000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode toolSetState = coreToolSet();
+        JsonNode toolSetState = config.get("toolsets").get("ToolSet1");
 
         EntitySyncStateDto actualSyncState = toolSetFacade.getSyncState(toolSetDto.getName(), "*");
 
@@ -382,12 +381,13 @@ public abstract class ToolSetFunctionalTest {
         toolSetDto.setDescription("description OLD");
         toolSetFacade.createToolSet(toolSetDto);
 
-        ObjectNode config = coreConfig();
+        JsonNode config = coreConfig();
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, 122000);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        JsonNode configToolSetState = coreToolSet();
-        JsonNode currentToolSetState = ((ObjectNode) coreToolSet()).put("description", "description OLD");
+        JsonNode configToolSetState = config.get("toolsets").get("ToolSet1");
+        JsonNode currentToolSetState = configToolSetState.deepCopy();
+        ((ObjectNode) currentToolSetState).put("description", "description OLD");
 
         EntitySyncStateDto actualSyncState = toolSetFacade.getSyncState(toolSetDto.getName(), "*");
 
@@ -416,38 +416,36 @@ public abstract class ToolSetFunctionalTest {
                 .collect(Collectors.toMap(ToolSetDto::getName, Function.identity()));
     }
 
-    private ObjectNode coreConfig() throws JsonProcessingException {
-        ObjectNode coreToolSets = JsonNodeFactory.instance.objectNode();
-        coreToolSets.set("ToolSet1", coreToolSet());
-
-        ObjectNode config = JsonNodeFactory.instance.objectNode();
-        config.set("toolsets", coreToolSets);
-
-        return config;
-    }
-
-    private JsonNode coreToolSet() throws JsonProcessingException {
-        String toolSet = """
+    private JsonNode coreConfig() throws JsonProcessingException {
+        String config = """
                 {
-                   "name": "ToolSet1",
-                   "user_roles": [
-                     "role1"
-                   ],
-                   "endpoint": "https://endpoint.test.com/toolset1",
-                   "display_name": "ToolSet1",
-                   "description": "description1",
-                   "forward_auth_token": false,
-                   "defaults": {},
-                   "interceptors": [],
-                   "description_keywords": [],
-                   "max_retry_attempts": 1,
-                   "created_at": 1000,
-                   "updated_at": 1000,
-                   "forward_per_request_key": false,
-                   "transport": "http",
-                   "allowed_tools": []
-                 }
+                  "toolsets": {
+                    "ToolSet1": {
+                      "name": "ToolSet1",
+                      "user_roles": [
+                        "role1"
+                      ],
+                      "endpoint": "https://endpoint.test.com/toolset1",
+                      "display_name": "ToolSet1",
+                      "description": "description1",
+                      "forward_auth_token": false,
+                      "defaults": {},
+                      "interceptors": [],
+                      "description_keywords": [],
+                      "max_retry_attempts": 1,
+                      "created_at": 1000,
+                      "updated_at": 1000,
+                      "dependencies": [],
+                      "forward_per_request_key": false,
+                      "auth_settings": {
+                        "authentication_type": "NONE"
+                      },
+                      "transport": "HTTP",
+                      "allowed_tools": []
+                    }
+                  }
+                }
                 """;
-        return OBJECT_MAPPER.readTree(toolSet);
+        return OBJECT_MAPPER.readTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitterTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitterTest.java
@@ -13,7 +13,6 @@ import com.epam.aidial.core.config.CoreModel;
 import com.epam.aidial.core.config.CoreRole;
 import com.epam.aidial.core.config.CoreRoute;
 import com.epam.aidial.core.config.CoreToolSet;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
@@ -47,7 +46,7 @@ class ConfigSplitterTest {
     }
 
     @Test
-    void splitConfig() throws JsonProcessingException {
+    void splitConfig() {
         ConfigSplitter splitter = new ConfigSplitter();
         Config configBody = new Config();
         configBody.getRoutes().put("route1", generateRoute());
@@ -69,7 +68,7 @@ class ConfigSplitterTest {
         configBody.getApplicationTypeSchemas().put("schema1", generateSchema());
         configBody.getToolsets().put("toolset1", generateToolSet());
 
-        List<ConfigPart> splittedConfig = splitter.splitConfig(configBody, this::encode, 400, 10);
+        List<ConfigPart> splittedConfig = splitter.splitConfig(configBody, this::encode, 500, 10);
 
         Assertions.assertEquals(9, splittedConfig.size());
         List<Config> expected = expected();

--- a/src/test/java/com/epam/aidial/cfg/service/config/syncstate/EntitySyncStateResolverTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/syncstate/EntitySyncStateResolverTest.java
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,12 +26,18 @@ class EntitySyncStateResolverTest {
     @Mock
     private ObjectMapper objectMapper;
     @Mock
+    private ObjectMapper coreObjectMapper;
+    @Mock
     private CoreConfigReloadCache coreConfigReloadCache;
     @Mock
     private EntitySyncStateStatusResolver syncStateStatusResolver;
 
-    @InjectMocks
     private EntitySyncStateResolver syncStateResolver;
+
+    @BeforeEach
+    void setUp() {
+        syncStateResolver = new EntitySyncStateResolver(objectMapper, coreObjectMapper, coreConfigReloadCache, syncStateStatusResolver);
+    }
 
     @Test
     void resolveForEntityInObject_cacheIsEmpty_returnsUnknownState() {
@@ -97,9 +103,10 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, null, true, currentStateUpdatedAt, configReloadTimestamp))
@@ -146,13 +153,11 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        String requestedEntityJsonNodeAsString = "requestedEntityJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
-        when(objectMapper.writeValueAsString(requestedEntity)).thenReturn(requestedEntityJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
-        when(objectMapper.readTree(requestedEntityJsonNodeAsString)).thenReturn(requestedEntity);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, requestedEntity, true, currentStateUpdatedAt, configReloadTimestamp))
                 .thenReturn(EntitySyncStateStatus.FULLY_SYNCED);
@@ -199,13 +204,11 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        String requestedEntityJsonNodeAsString = "requestedEntityJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
-        when(objectMapper.writeValueAsString(requestedEntity)).thenReturn(requestedEntityJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
-        when(objectMapper.readTree(requestedEntityJsonNodeAsString)).thenReturn(requestedEntity);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, requestedEntity, false, currentStateUpdatedAt, configReloadTimestamp))
                 .thenReturn(EntitySyncStateStatus.IN_PROGRESS);
@@ -284,9 +287,10 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, null, true, currentStateUpdatedAt, configReloadTimestamp))
@@ -335,13 +339,11 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        String requestedEntityJsonNodeAsString = "requestedEntityJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
-        when(objectMapper.writeValueAsString(requestedEntity)).thenReturn(requestedEntityJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
-        when(objectMapper.readTree(requestedEntityJsonNodeAsString)).thenReturn(requestedEntity);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, requestedEntity, true, currentStateUpdatedAt, configReloadTimestamp))
                 .thenReturn(EntitySyncStateStatus.FULLY_SYNCED);
@@ -390,13 +392,11 @@ class EntitySyncStateResolverTest {
         CoreConfigReloadCache.Entry cacheEntry = new CoreConfigReloadCache.Entry(config, configReloadTimestamp);
         when(coreConfigReloadCache.get()).thenReturn(cacheEntry);
 
-        when(objectMapper.valueToTree(currentState)).thenReturn(currentStateJsonNode);
         String currentStateJsonNodeAsString = "currentStateJsonNodeAsString";
-        String requestedEntityJsonNodeAsString = "requestedEntityJsonNodeAsString";
-        when(objectMapper.writeValueAsString(currentStateJsonNode)).thenReturn(currentStateJsonNodeAsString);
-        when(objectMapper.writeValueAsString(requestedEntity)).thenReturn(requestedEntityJsonNodeAsString);
+        when(objectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
+        when(coreObjectMapper.readValue(currentStateJsonNodeAsString, CurrentState.class)).thenReturn(currentState);
+        when(coreObjectMapper.writeValueAsString(currentState)).thenReturn(currentStateJsonNodeAsString);
         when(objectMapper.readTree(currentStateJsonNodeAsString)).thenReturn(currentStateJsonNode);
-        when(objectMapper.readTree(requestedEntityJsonNodeAsString)).thenReturn(requestedEntity);
 
         when(syncStateStatusResolver.resolve(currentStateJsonNode, requestedEntity, false, currentStateUpdatedAt, configReloadTimestamp))
                 .thenReturn(EntitySyncStateStatus.IN_PROGRESS);

--- a/src/test/resources/domain/config/config_only_toolsets.json
+++ b/src/test/resources/domain/config/config_only_toolsets.json
@@ -53,7 +53,8 @@
           "second"
         ]
       },
-      "forward_per_request_key":false
+      "forward_per_request_key": false,
+      "dependencies": []
     }
   }
 }

--- a/src/test/resources/full_core_export.json
+++ b/src/test/resources/full_core_export.json
@@ -115,8 +115,13 @@
       "maxRetryAttempts": 5,
       "createdAt": 123,
       "updatedAt": 123,
+      "dependencies": [],
       "type": "embedding",
-      "upstreams": []
+      "upstreams": [],
+      "fieldsHashingOrder": [
+        "prefix.body.tools",
+        "prefix.body.messages"
+      ]
     },
     "testModel1": {
       "name": "testModel1",
@@ -225,6 +230,7 @@
       "max_retry_attempts": 1,
       "created_at": 123,
       "updated_at": 123,
+      "dependencies": [],
       "application_properties": {}
     }
   },
@@ -241,6 +247,7 @@
       "max_retry_attempts": 1,
       "created_at": 123,
       "updated_at": 123,
+      "dependencies": [],
       "auth_settings": {
         "authentication_type": "oauth",
         "client_id": "some-client-id"

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -927,6 +927,7 @@
         },
         "applicationProperties": {},
         "routes": [],
+        "dependencies": [],
         "validityState": {
           "valid": true
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #205

### Description of changes
 Improved sync state diff calculation

BREAKING CHANGE: removed `GET /api/v1/keys/{name}/sync-state` endpoint for keys

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.