### PR TITLE
fix: handle export request with empty set of topics as request without topics

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ConfigExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ConfigExporter.java
@@ -58,7 +58,7 @@ public class ConfigExporter {
     private final FullToSelectedItemsExportRequestTransformer fullToSelectedItemsExportRequestTransformer;
 
     public ExportConfig getConfig(ExportRequest request) {
-        if (request instanceof FullExportRequest exportRequest && exportRequest.getTopics() != null) {
+        if (request instanceof FullExportRequest exportRequest && CollectionUtils.isNotEmpty(exportRequest.getTopics())) {
             request = fullToSelectedItemsExportRequestTransformer.transform(exportRequest);
         }
 
@@ -96,7 +96,7 @@ public class ConfigExporter {
     }
 
     public ExportConfigPreview preview(ExportRequest request) {
-        if (request instanceof FullExportRequest exportRequest && exportRequest.getTopics() != null) {
+        if (request instanceof FullExportRequest exportRequest && CollectionUtils.isNotEmpty(exportRequest.getTopics())) {
             request = fullToSelectedItemsExportRequestTransformer.transform(exportRequest);
         }
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtils.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.service.config.transfer.exporter.util;
 
 import lombok.experimental.UtilityClass;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.Set;
 
@@ -8,7 +9,7 @@ import java.util.Set;
 public class ExportUtils {
 
     public static boolean hasAnyRequestedTopic(Set<String> entityTopics, Set<String> requestedTopics) {
-        return requestedTopics == null
+        return CollectionUtils.isEmpty(requestedTopics)
                 || (entityTopics != null && requestedTopics.stream().anyMatch(entityTopics::contains));
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/transfer/exporter/util/ExportUtilsTest.java
@@ -1,0 +1,38 @@
+package com.epam.aidial.cfg.service.config.transfer.exporter.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExportUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("hasAnyRequestedTopicTestParams")
+    void testHasAnyRequestedTopic(Set<String> entityTopics, Set<String> requestedTopics, boolean expected) {
+        assertThat(ExportUtils.hasAnyRequestedTopic(entityTopics, requestedTopics)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> hasAnyRequestedTopicTestParams() {
+        return Stream.of(
+                // empty requested topics
+                Arguments.of(Set.of("a", "b"), null, true),
+                Arguments.of(Set.of("a", "b"), Set.of(), true),
+                Arguments.of(null, null, true),
+                Arguments.of(null, Set.of(), true),
+                Arguments.of(Set.of(), null, true),
+                Arguments.of(Set.of(), Set.of(), true),
+
+                // not empty requested topics
+                Arguments.of(null, Set.of("c", "d"), false),
+                Arguments.of(Set.of(), Set.of("c", "d"), false),
+                Arguments.of(Set.of("a", "b"), Set.of("c", "d"), false),
+                Arguments.of(Set.of("a", "b", "c"), Set.of("c", "d"), true),
+                Arguments.of(Set.of("a", "b", "c"), Set.of("b", "c", "d"), true)
+        );
+    }
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #581 

### Description of changes
Handled export request with empty set of topics as request without topics

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.