### PR TITLE
fix: set correct interceptors_order for models and applications in regular and audit tables

### DIFF
--- a/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
@@ -24,12 +24,10 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
 UPDATE interceptor_model t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_model_ranked r
-    WHERE r.model_name = t.model_name
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_model_ranked r
+WHERE t.model_name = r.model_name
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_ranked;
@@ -63,13 +61,11 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
 UPDATE interceptor_model_aud t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_model_aud_ranked r
-    WHERE r.model_name = t.model_name
-      AND r.rev = t.rev
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_model_aud_ranked r
+WHERE t.model_name = r.model_name
+  AND t.rev = r.rev
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_aud_ranked;

--- a/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
@@ -1,0 +1,76 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT model_name
+FROM interceptor_model
+GROUP BY model_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_ranked table
+CREATE TEMP TABLE interceptor_model_ranked AS
+SELECT
+    a.model_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_model a
+JOIN all_zero_groups g
+  ON a.model_name = g.model_name;
+
+-- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
+UPDATE interceptor_model t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_model_ranked;
+DROP TABLE all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT model_name, rev
+FROM interceptor_model_aud
+GROUP BY model_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_aud_ranked table
+CREATE TEMP TABLE interceptor_model_aud_ranked AS
+SELECT
+    a.model_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_model_aud a
+JOIN all_zero_groups g
+  ON a.model_name = g.model_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
+UPDATE interceptor_model_aud t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_aud_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_model_aud_ranked;
+DROP TABLE all_zero_groups;

--- a/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
@@ -24,10 +24,18 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
 UPDATE interceptor_model t
-SET interceptors_order = r.new_order
-FROM interceptor_model_ranked r
-WHERE t.model_name = r.model_name
-  AND t.interceptor_name = r.interceptor_name;
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.interceptor_name = t.interceptor_name
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM interceptor_model_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.interceptor_name = t.interceptor_name
+);
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_ranked;
@@ -61,11 +69,20 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
 UPDATE interceptor_model_aud t
-SET interceptors_order = r.new_order
-FROM interceptor_model_aud_ranked r
-WHERE t.model_name = r.model_name
-  AND t.rev = r.rev
-  AND t.interceptor_name = r.interceptor_name;
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_aud_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM interceptor_model_aud_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_aud_ranked;

--- a/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
@@ -1,0 +1,76 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT application_name
+FROM interceptor_application
+GROUP BY application_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_ranked table
+CREATE TEMP TABLE interceptor_application_ranked AS
+SELECT
+    a.application_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_application a
+JOIN all_zero_groups g
+  ON a.application_name = g.application_name;
+
+-- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
+UPDATE interceptor_application t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_application_ranked;
+DROP TABLE all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT application_name, rev
+FROM interceptor_application_aud
+GROUP BY application_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_aud_ranked table
+CREATE TEMP TABLE interceptor_application_aud_ranked AS
+SELECT
+    a.application_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_application_aud a
+JOIN all_zero_groups g
+  ON a.application_name = g.application_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
+UPDATE interceptor_application_aud t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_aud_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_application_aud_ranked;
+DROP TABLE all_zero_groups;

--- a/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
@@ -24,10 +24,18 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
 UPDATE interceptor_application t
-SET interceptors_order = r.new_order
-FROM interceptor_application_ranked r
-WHERE t.application_name = r.application_name
-  AND t.interceptor_name = r.interceptor_name;
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.interceptor_name = t.interceptor_name
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM interceptor_application_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.interceptor_name = t.interceptor_name
+);  
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_ranked;
@@ -61,11 +69,20 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
 UPDATE interceptor_application_aud t
-SET interceptors_order = r.new_order
-FROM interceptor_application_aud_ranked r
-WHERE t.application_name = r.application_name
-  AND t.rev = r.rev
-  AND t.interceptor_name = r.interceptor_name;
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_aud_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM interceptor_application_aud_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_aud_ranked;

--- a/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/H2/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
@@ -24,12 +24,10 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
 UPDATE interceptor_application t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_application_ranked r
-    WHERE r.application_name = t.application_name
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_application_ranked r
+WHERE t.application_name = r.application_name
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_ranked;
@@ -63,13 +61,11 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
 UPDATE interceptor_application_aud t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_application_aud_ranked r
-    WHERE r.application_name = t.application_name
-      AND r.rev = t.rev
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_application_aud_ranked r
+WHERE t.application_name = r.application_name
+  AND t.rev = r.rev
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_aud_ranked;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.89__UpdateInterceptorsOrderInInterceptorModelAudTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.89__UpdateInterceptorsOrderInInterceptorModelAudTable.sql
@@ -1,0 +1,74 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+SELECT model_name
+INTO #all_zero_groups
+FROM interceptor_model
+GROUP BY model_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_ranked table
+SELECT
+    a.model_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+INTO #interceptor_model_ranked
+FROM interceptor_model a
+JOIN #all_zero_groups g
+  ON a.model_name = g.model_name;
+
+-- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
+UPDATE t
+SET interceptors_order = r.new_order
+FROM interceptor_model t
+JOIN #interceptor_model_ranked r
+  ON t.model_name = r.model_name
+ AND t.interceptor_name = r.interceptor_name;
+
+-- Drop temporary tables
+DROP TABLE #interceptor_model_ranked;
+DROP TABLE #all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+SELECT model_name, rev
+INTO #all_zero_groups
+FROM interceptor_model_aud
+GROUP BY model_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_aud_ranked table
+SELECT
+    a.model_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+INTO #interceptor_model_aud_ranked
+FROM interceptor_model_aud a
+JOIN #all_zero_groups g
+  ON a.model_name = g.model_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
+UPDATE t
+SET interceptors_order = r.new_order
+FROM interceptor_model_aud t
+JOIN #interceptor_model_aud_ranked r
+  ON t.model_name = r.model_name
+ AND t.rev = r.rev
+ AND t.interceptor_name = r.interceptor_name;
+
+-- Drop temporary tables
+DROP TABLE #interceptor_model_aud_ranked;
+DROP TABLE #all_zero_groups;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.89__UpdateInterceptorsOrderInInterceptorModelAudTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.89__UpdateInterceptorsOrderInInterceptorModelAudTable.sql
@@ -33,6 +33,7 @@ JOIN #interceptor_model_ranked r
 -- Drop temporary tables
 DROP TABLE #interceptor_model_ranked;
 DROP TABLE #all_zero_groups;
+GO
 
 -- AUDIT TABLE
 
@@ -72,3 +73,4 @@ JOIN #interceptor_model_aud_ranked r
 -- Drop temporary tables
 DROP TABLE #interceptor_model_aud_ranked;
 DROP TABLE #all_zero_groups;
+GO

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.90__UpdateInterceptorsOrderInInterceptorApplicationAudTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.90__UpdateInterceptorsOrderInInterceptorApplicationAudTable.sql
@@ -1,0 +1,74 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+SELECT application_name
+INTO #all_zero_groups
+FROM interceptor_application
+GROUP BY application_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_ranked table
+SELECT
+    a.application_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+INTO #interceptor_application_ranked
+FROM interceptor_application a
+JOIN #all_zero_groups g
+  ON a.application_name = g.application_name;
+
+-- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
+UPDATE t
+SET interceptors_order = r.new_order
+FROM interceptor_application t
+JOIN #interceptor_application_ranked r
+  ON t.application_name = r.application_name
+ AND t.interceptor_name = r.interceptor_name;
+
+-- Drop temporary tables
+DROP TABLE #interceptor_application_ranked;
+DROP TABLE #all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+SELECT application_name, rev
+INTO #all_zero_groups
+FROM interceptor_application_aud
+GROUP BY application_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_aud_ranked table
+SELECT
+    a.application_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+INTO #interceptor_application_aud_ranked
+FROM interceptor_application_aud a
+JOIN #all_zero_groups g
+  ON a.application_name = g.application_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
+UPDATE t
+SET interceptors_order = r.new_order
+FROM interceptor_application_aud t
+JOIN #interceptor_application_aud_ranked r
+  ON t.application_name = r.application_name
+ AND t.rev = r.rev
+ AND t.interceptor_name = r.interceptor_name;
+
+-- Drop temporary tables
+DROP TABLE #interceptor_application_aud_ranked;
+DROP TABLE #all_zero_groups;

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.90__UpdateInterceptorsOrderInInterceptorApplicationAudTable.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.90__UpdateInterceptorsOrderInInterceptorApplicationAudTable.sql
@@ -33,6 +33,7 @@ JOIN #interceptor_application_ranked r
 -- Drop temporary tables
 DROP TABLE #interceptor_application_ranked;
 DROP TABLE #all_zero_groups;
+GO
 
 -- AUDIT TABLE
 
@@ -72,3 +73,4 @@ JOIN #interceptor_application_aud_ranked r
 -- Drop temporary tables
 DROP TABLE #interceptor_application_aud_ranked;
 DROP TABLE #all_zero_groups;
+GO

--- a/src/main/resources/db/migration/POSTGRES/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
@@ -24,12 +24,10 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
 UPDATE interceptor_model t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_model_ranked r
-    WHERE r.model_name = t.model_name
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_model_ranked r
+WHERE t.model_name = r.model_name
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_ranked;
@@ -63,13 +61,11 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
 UPDATE interceptor_model_aud t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_model_aud_ranked r
-    WHERE r.model_name = t.model_name
-      AND r.rev = t.rev
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_model_aud_ranked r
+WHERE t.model_name = r.model_name
+  AND t.rev = r.rev
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_model_aud_ranked;

--- a/src/main/resources/db/migration/POSTGRES/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.89__UpdateInterceptorsOrderInInterceptorModelRegularAndAuditTables.sql
@@ -1,0 +1,76 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT model_name
+FROM interceptor_model
+GROUP BY model_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_ranked table
+CREATE TEMP TABLE interceptor_model_ranked AS
+SELECT
+    a.model_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_model a
+JOIN all_zero_groups g
+  ON a.model_name = g.model_name;
+
+-- Update interceptors_order in interceptor_model according to values from temporary interceptor_model_ranked table
+UPDATE interceptor_model t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_model_ranked;
+DROP TABLE all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT model_name, rev
+FROM interceptor_model_aud
+GROUP BY model_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_model_aud_ranked table
+CREATE TEMP TABLE interceptor_model_aud_ranked AS
+SELECT
+    a.model_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.model_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_model_aud a
+JOIN all_zero_groups g
+  ON a.model_name = g.model_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_model_aud according to values from temporary interceptor_model_aud_ranked table
+UPDATE interceptor_model_aud t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_model_aud_ranked r
+    WHERE r.model_name = t.model_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_model_aud_ranked;
+DROP TABLE all_zero_groups;

--- a/src/main/resources/db/migration/POSTGRES/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
@@ -1,0 +1,76 @@
+-- REGULAR TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT application_name
+FROM interceptor_application
+GROUP BY application_name
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_ranked table
+CREATE TEMP TABLE interceptor_application_ranked AS
+SELECT
+    a.application_name,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_application a
+JOIN all_zero_groups g
+  ON a.application_name = g.application_name;
+
+-- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
+UPDATE interceptor_application t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_application_ranked;
+DROP TABLE all_zero_groups;
+
+-- AUDIT TABLE
+
+-- Find all groups (with more than 1 rows) which have interceptors_order = 0 for all rows in group
+-- and store them in temporary all_zero_groups table
+CREATE TEMP TABLE all_zero_groups AS
+SELECT application_name, rev
+FROM interceptor_application_aud
+GROUP BY application_name, rev
+HAVING SUM(CASE WHEN interceptors_order <> 0 THEN 1 ELSE 0 END) = 0 AND COUNT(*) > 1;
+
+-- For all groups in all_zero_groups table calculate correct interceptors_order value
+-- and store result in temporary interceptor_application_aud_ranked table
+CREATE TEMP TABLE interceptor_application_aud_ranked AS
+SELECT
+    a.application_name,
+    a.rev,
+    a.interceptor_name,
+    ROW_NUMBER() OVER (
+        PARTITION BY a.application_name, a.rev
+        ORDER BY a.interceptor_name
+    ) - 1 AS new_order
+FROM interceptor_application_aud a
+JOIN all_zero_groups g
+  ON a.application_name = g.application_name
+ AND a.rev = g.rev;
+
+-- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
+UPDATE interceptor_application_aud t
+SET interceptors_order = (
+    SELECT r.new_order
+    FROM interceptor_application_aud_ranked r
+    WHERE r.application_name = t.application_name
+      AND r.rev = t.rev
+      AND r.interceptor_name = t.interceptor_name
+);
+
+-- Drop temporary tables
+DROP TABLE interceptor_application_aud_ranked;
+DROP TABLE all_zero_groups;

--- a/src/main/resources/db/migration/POSTGRES/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.90__UpdateInterceptorsOrderInInterceptorApplicationRegularAndAuditTables.sql
@@ -24,12 +24,10 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application according to values from temporary interceptor_application_ranked table
 UPDATE interceptor_application t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_application_ranked r
-    WHERE r.application_name = t.application_name
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_application_ranked r
+WHERE t.application_name = r.application_name
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_ranked;
@@ -63,13 +61,11 @@ JOIN all_zero_groups g
 
 -- Update interceptors_order in interceptor_application_aud according to values from temporary interceptor_application_aud_ranked table
 UPDATE interceptor_application_aud t
-SET interceptors_order = (
-    SELECT r.new_order
-    FROM interceptor_application_aud_ranked r
-    WHERE r.application_name = t.application_name
-      AND r.rev = t.rev
-      AND r.interceptor_name = t.interceptor_name
-);
+SET interceptors_order = r.new_order
+FROM interceptor_application_aud_ranked r
+WHERE t.application_name = r.application_name
+  AND t.rev = r.rev
+  AND t.interceptor_name = r.interceptor_name;
 
 -- Drop temporary tables
 DROP TABLE interceptor_application_aud_ranked;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #567

### Description of changes
In regular and audit tables set correct interceptors_order for models and applications which have several linked interceptors and interceptors_order = 0 for each interceptor

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.