### PR TITLE
fix: adjust route mapping from core to admin format

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/mapper/RouteCoreMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/mapper/RouteCoreMapper.java
@@ -53,7 +53,7 @@ public abstract class RouteCoreMapper {
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "deployment.roleLimits", ignore = true)
     @Mapping(target = "deployment.defaultRoleLimit", ignore = true)
-    public abstract DependentRoute mapDependentRoute(CoreRoute route);
+    public abstract DependentRoute mapDependentRoute(String name, CoreRoute route);
 
     public LinkedHashMap<String, CoreRoute> mapRoutes(List<DependentRoute> routes) {
         if (CollectionUtils.isEmpty(routes)) {
@@ -72,8 +72,8 @@ public abstract class RouteCoreMapper {
             return null;
         }
         List<DependentRoute> routes = new ArrayList<>();
-        for (CoreRoute coreRoute : coreRoutes.values()) {
-            var route = mapDependentRoute(coreRoute);
+        for (var entry : coreRoutes.entrySet()) {
+            var route = mapDependentRoute(entry.getKey(), entry.getValue());
             routes.add(route);
         }
         return routes;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #603

### Description of changes
Adjust route mapping from core to admin format: name of the route is always key from Map<String, CoreRoute>

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.