### PR TITLE
chore: increase io.vertx:vertx-core transitive dependency version from 4.5.14 to 4.5.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,9 @@ dependencies {
         implementation ('org.springframework:spring-core:6.2.11') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('io.vertx:vertx-core:4.5.24') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Increased io.vertx:vertx-core transitive dependency version from 4.5.14 to 4.5.24

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.