### PR TITLE
chore: increase io.fabric8:kubernetes-client dependency version from 7.4.0 to 7.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql:11.4.1'
     implementation 'org.flywaydb:flyway-sqlserver:11.4.1'
 
-    implementation 'io.fabric8:kubernetes-client:7.4.0'
+    implementation 'io.fabric8:kubernetes-client:7.5.2'
 
     implementation 'com.influxdb:influxdb-client-java:7.2.0'
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Increased io.fabric8:kubernetes-client dependency version from 7.4.0 to 7.5.2

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.