### PR TITLE
fix: read allowedIpAddressRanges as null instead of empty list

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/converter/StringNullableListJsonConverter.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/converter/StringNullableListJsonConverter.java
@@ -27,9 +27,7 @@ public class StringNullableListJsonConverter implements AttributeConverter<List<
     @Override
     public List<String> convertToEntityAttribute(String data) {
         try {
-            return data == null
-                    ? null
-                    : mapper.readValue(data, new TypeReference<>() {
+            return data == null ? null : mapper.readValue(data, new TypeReference<>() {
             });
         } catch (Exception e) {
             log.debug("Failed to convert data to list. Raw attribute value: {}", data, e);

--- a/src/main/java/com/epam/aidial/cfg/dao/converter/StringNullableListJsonConverter.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/converter/StringNullableListJsonConverter.java
@@ -1,0 +1,40 @@
+package com.epam.aidial.cfg.dao.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Converter
+@Slf4j
+public class StringNullableListJsonConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return attribute == null ? null : mapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            log.debug("Failed to convert list to data. Attribute value: {}", attribute, e);
+            throw new IllegalStateException("Failed to convert list to data", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String data) {
+        try {
+            return data == null
+                    ? null
+                    : mapper.readValue(data, new TypeReference<>() {
+            });
+        } catch (Exception e) {
+            log.debug("Failed to convert data to list. Raw attribute value: {}", data, e);
+            throw new IllegalStateException("Failed to convert data to list", e);
+
+        }
+    }
+}

--- a/src/main/java/com/epam/aidial/cfg/dao/model/KeyEntity.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/model/KeyEntity.java
@@ -1,6 +1,6 @@
 package com.epam.aidial.cfg.dao.model;
 
-import com.epam.aidial.cfg.dao.converter.StringListJsonConverter;
+import com.epam.aidial.cfg.dao.converter.StringNullableListJsonConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -47,8 +47,8 @@ public class KeyEntity extends ValidityStateAwareEntity<String> {
     private Long expiresAt;
     @Column(name = "key_value_generated_at_ms")
     private long keyGeneratedAt;
-    @Convert(converter = StringListJsonConverter.class)
-    private List<String> allowedIpAddressRanges = new ArrayList<>();
+    @Convert(converter = StringNullableListJsonConverter.class)
+    private List<String> allowedIpAddressRanges;
 
     @PreRemove
     public void preRemove() {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/KeyFunctionalTest.java
@@ -96,6 +96,7 @@ public abstract class KeyFunctionalTest {
     @Test
     public void shouldSuccessfullyCreateWithEmptyRolesAndGetKeys() {
         KeyDto keyDto = createKeyDto("1");
+        keyDto.setAllowedIpAddressRanges(null);
         keyFacade.createKey(keyDto);
 
         KeyDto actual = keyFacade.getKey(keyDto.getName());


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #642

### Description of changes
Read null value in allowedIpAddressRanges DB column as null instead of empty list

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.