### PR TITLE
feat: add 'permissions' field to folder info response

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/client/ApplicationClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/ApplicationClient.java
@@ -29,7 +29,8 @@ public interface ApplicationClient {
     ApplicationMetadataDto getApplicationMetadata(@PathVariable String path,
                                                   @RequestParam boolean recursive,
                                                   @RequestParam String token,
-                                                  @RequestParam int limit);
+                                                  @RequestParam int limit,
+                                                  @RequestParam boolean permissions);
     /**
      * Implementation Details:
      *

--- a/src/main/java/com/epam/aidial/cfg/client/ConversationClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/ConversationClient.java
@@ -22,7 +22,8 @@ public interface ConversationClient {
     @GetMapping("/v1/metadata/conversations/{path}")
     ConversationMetadataDto getConversationMetadata(@PathVariable String path,
                                                     @RequestParam boolean recursive,
-                                                    @RequestParam String token);
+                                                    @RequestParam String token,
+                                                    @RequestParam boolean permissions);
 
     /**
      * Implementation Details:

--- a/src/main/java/com/epam/aidial/cfg/client/FileClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/FileClient.java
@@ -27,7 +27,8 @@ public interface FileClient {
     @GetMapping("/v1/metadata/files/{path}")
     FileMetadataDto getFilesMetadata(@PathVariable String path,
                                      @RequestParam boolean recursive,
-                                     @RequestParam String token);
+                                     @RequestParam String token,
+                                     @RequestParam boolean permissions);
 
     @GetMapping("/v1/files/{path}")
     Response getFile(@PathVariable String path);

--- a/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/PromptClient.java
@@ -31,7 +31,8 @@ public interface PromptClient {
             @PathVariable String path,
             @RequestParam boolean recursive,
             @RequestParam String token,
-            @RequestParam int limit
+            @RequestParam int limit,
+            @RequestParam boolean permissions
     );
 
     /**

--- a/src/main/java/com/epam/aidial/cfg/client/ToolSetClient.java
+++ b/src/main/java/com/epam/aidial/cfg/client/ToolSetClient.java
@@ -29,7 +29,8 @@ public interface ToolSetClient {
     ToolSetMetadataDto getToolSetMetadata(@PathVariable String path,
                                           @RequestParam boolean recursive,
                                           @RequestParam String token,
-                                          @RequestParam int limit);
+                                          @RequestParam int limit,
+                                          @RequestParam boolean permissions);
     /**
      * Implementation Details:
      *

--- a/src/main/java/com/epam/aidial/cfg/client/dto/BaseMetadataDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/BaseMetadataDto.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.client.dto;
 
-import com.epam.aidial.cfg.dto.NodeTypeDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,6 +22,7 @@ public abstract class BaseMetadataDto {
     private String author;
     private Long updatedAt;
     private String nextToken;
+    private List<ResourceAccessTypeDto> permissions;
 
     public abstract List<? extends BaseMetadataDto> getItems();
 

--- a/src/main/java/com/epam/aidial/cfg/client/dto/NodeTypeDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/NodeTypeDto.java
@@ -1,0 +1,6 @@
+package com.epam.aidial.cfg.client.dto;
+
+public enum NodeTypeDto {
+    FOLDER,
+    ITEM,
+}

--- a/src/main/java/com/epam/aidial/cfg/client/dto/ResourceAccessTypeDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/ResourceAccessTypeDto.java
@@ -1,0 +1,7 @@
+package com.epam.aidial.cfg.client.dto;
+
+public enum ResourceAccessTypeDto {
+    READ,
+    WRITE,
+    SHARE,
+}

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/ApplicationClientMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/ApplicationClientMapper.java
@@ -2,8 +2,8 @@ package com.epam.aidial.cfg.client.mapper;
 
 import com.epam.aidial.cfg.client.dto.ApplicationMetadataDto;
 import com.epam.aidial.cfg.client.dto.ApplicationResourceDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.dto.ApplicationEximDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.ApplicationExim;
 import com.epam.aidial.cfg.model.ApplicationResource;
 import com.epam.aidial.cfg.model.ApplicationResourceNodeInfo;

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/ConversationClientMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/ConversationClientMapper.java
@@ -2,7 +2,7 @@ package com.epam.aidial.cfg.client.mapper;
 
 import com.epam.aidial.cfg.client.dto.ConversationDto;
 import com.epam.aidial.cfg.client.dto.ConversationMetadataDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.Conversation;
 import com.epam.aidial.cfg.utils.PathUtils;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/FileClientMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/FileClientMapper.java
@@ -1,7 +1,7 @@
 package com.epam.aidial.cfg.client.mapper;
 
 import com.epam.aidial.cfg.client.dto.FileMetadataDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.FileNodeInfo;
 import com.epam.aidial.cfg.model.NodeType;
 import lombok.Builder;

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/FolderMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/FolderMapper.java
@@ -1,7 +1,7 @@
 package com.epam.aidial.cfg.client.mapper;
 
 import com.epam.aidial.cfg.client.dto.BaseMetadataDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.FolderInfo;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/PromptClientMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/PromptClientMapper.java
@@ -1,8 +1,8 @@
 package com.epam.aidial.cfg.client.mapper;
 
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.client.dto.PromptDto;
 import com.epam.aidial.cfg.client.dto.PromptMetadataDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.CreatePrompt;
 import com.epam.aidial.cfg.model.NodeType;
 import com.epam.aidial.cfg.model.Prompt;

--- a/src/main/java/com/epam/aidial/cfg/client/mapper/ToolSetClientMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/client/mapper/ToolSetClientMapper.java
@@ -1,15 +1,11 @@
 package com.epam.aidial.cfg.client.mapper;
 
-import com.epam.aidial.cfg.client.dto.ResourceSignInRequestDto;
-import com.epam.aidial.cfg.client.dto.ResourceSignOutRequestDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.client.dto.ToolSetMetadataDto;
 import com.epam.aidial.cfg.client.dto.ToolSetResourceDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
 import com.epam.aidial.cfg.dto.ToolSetEximDto;
 import com.epam.aidial.cfg.model.CreateToolSetResource;
 import com.epam.aidial.cfg.model.NodeType;
-import com.epam.aidial.cfg.model.ResourceSignInRequest;
-import com.epam.aidial.cfg.model.ResourceSignOutRequest;
 import com.epam.aidial.cfg.model.ToolSetExim;
 import com.epam.aidial.cfg.model.ToolSetResource;
 import com.epam.aidial.cfg.model.ToolSetResourceNodeInfo;
@@ -95,10 +91,6 @@ public abstract class ToolSetClientMapper {
     public abstract ToolSetResourceDto toToolSetResourceDto(CreateToolSetResource createToolSetResource);
 
     protected abstract NodeType toNodeType(NodeTypeDto dto);
-
-    public abstract ResourceSignInRequestDto toResourceSignInRequestDto(ResourceSignInRequest request);
-
-    public abstract ResourceSignOutRequestDto toResourceSignOutRequestDto(ResourceSignOutRequest request);
 
     public abstract ToolSetExim toToolSetExim(ToolSetResource toolSetResource);
 

--- a/src/main/java/com/epam/aidial/cfg/dto/FolderInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/FolderInfoDto.java
@@ -10,5 +10,6 @@ public class FolderInfoDto {
     private String parentPath;
     private String bucket;
     private String path;
+    private List<ResourceAccessTypeDto> permissions;
     private List<FolderInfoDto> items;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ResourceAccessTypeDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ResourceAccessTypeDto.java
@@ -1,0 +1,7 @@
+package com.epam.aidial.cfg.dto;
+
+public enum ResourceAccessTypeDto {
+    READ,
+    WRITE,
+    SHARE,
+}

--- a/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ResourceMetadataRequestDto.java
@@ -13,4 +13,5 @@ public class ResourceMetadataRequestDto {
     @Nullable
     private String nextToken;
     private Integer limit;
+    private boolean permissions;
 }

--- a/src/main/java/com/epam/aidial/cfg/model/FolderInfo.java
+++ b/src/main/java/com/epam/aidial/cfg/model/FolderInfo.java
@@ -17,5 +17,6 @@ public class FolderInfo {
     private String parentPath;
     private String bucket;
     private String path;
+    private List<ResourceAccessType> permissions;
     private List<FolderInfo> items;
 }

--- a/src/main/java/com/epam/aidial/cfg/model/ResourceAccessType.java
+++ b/src/main/java/com/epam/aidial/cfg/model/ResourceAccessType.java
@@ -1,0 +1,7 @@
+package com.epam.aidial.cfg.model;
+
+public enum ResourceAccessType {
+    READ,
+    WRITE,
+    SHARE,
+}

--- a/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
+++ b/src/main/java/com/epam/aidial/cfg/model/ResourceMetadataRequest.java
@@ -14,4 +14,5 @@ public class ResourceMetadataRequest {
     private String path;
     private String nextToken;
     private Integer limit;
+    private boolean permissions;
 }

--- a/src/main/java/com/epam/aidial/cfg/service/ApplicationResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ApplicationResourceService.java
@@ -73,7 +73,8 @@ public class ApplicationResourceService implements ResourceService {
         var nextToken = request.getNextToken();
         var path = request.getPath() != null ? request.getPath() : BASE_PATH;
         var limit = request.getLimit() != null ? request.getLimit() : applicationsMetadataDefaultLimit;
-        return applicationClient.getApplicationMetadata(path, recursive, nextToken, limit);
+        var permissions = request.isPermissions();
+        return applicationClient.getApplicationMetadata(path, recursive, nextToken, limit, permissions);
     }
 
     @Override
@@ -102,7 +103,8 @@ public class ApplicationResourceService implements ResourceService {
                 path,
                 false,
                 null,
-                applicationsMetadataDefaultLimit
+                applicationsMetadataDefaultLimit,
+                false
         );
 
         var applicationResourceDto = response.getBody();

--- a/src/main/java/com/epam/aidial/cfg/service/ConversationService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ConversationService.java
@@ -41,7 +41,7 @@ public class ConversationService implements ResourceService {
 
     @Override
     public ConversationMetadataDto getMetadata(ResourceMetadataRequest request) {
-        return conversationClient.getConversationMetadata(request.getPath(), request.isRecursive(), request.getNextToken());
+        return conversationClient.getConversationMetadata(request.getPath(), request.isRecursive(), request.getNextToken(), request.isPermissions());
     }
 
     @Override
@@ -57,7 +57,7 @@ public class ConversationService implements ResourceService {
 
     public Conversation getConversation(String path) {
         var conversationDto = conversationClient.getConversation(path);
-        var conversationMetadataDto = conversationClient.getConversationMetadata(path, false, null);
+        var conversationMetadataDto = conversationClient.getConversationMetadata(path, false, null, false);
         return conversationClientMapper.toConversation(conversationDto, conversationMetadataDto);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/FileService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/FileService.java
@@ -76,7 +76,7 @@ public class FileService implements ResourceService {
 
     @Override
     public FileMetadataDto getMetadata(ResourceMetadataRequest request) {
-        return fileClient.getFilesMetadata(request.getPath(), request.isRecursive(), request.getNextToken());
+        return fileClient.getFilesMetadata(request.getPath(), request.isRecursive(), request.getNextToken(), request.isPermissions());
     }
 
     public Response get(String path) {

--- a/src/main/java/com/epam/aidial/cfg/service/ResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ResourceService.java
@@ -1,7 +1,7 @@
 package com.epam.aidial.cfg.service;
 
 import com.epam.aidial.cfg.client.dto.BaseMetadataDto;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.exception.ResourceNotFoundException;
 import com.epam.aidial.cfg.model.FolderInfo;
 import com.epam.aidial.cfg.model.MoveResource;

--- a/src/main/java/com/epam/aidial/cfg/service/ToolSetResourceService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/ToolSetResourceService.java
@@ -81,7 +81,8 @@ public class ToolSetResourceService implements ResourceService {
         var nextToken = request.getNextToken();
         var path = request.getPath() != null ? request.getPath() : BASE_PATH;
         var limit = request.getLimit() != null ? request.getLimit() : toolSetsMetadataDefaultLimit;
-        return toolSetClient.getToolSetMetadata(path, recursive, nextToken, limit);
+        var permissions = request.isPermissions();
+        return toolSetClient.getToolSetMetadata(path, recursive, nextToken, limit, permissions);
     }
 
     @Override
@@ -110,7 +111,9 @@ public class ToolSetResourceService implements ResourceService {
                 path,
                 false,
                 null,
-                toolSetsMetadataDefaultLimit);
+                toolSetsMetadataDefaultLimit,
+                false
+        );
 
         var toolSetResource = toolSetClientMapper.toToolSetResource(response.getBody(), metadata);
         var currentEtag = response.getHeaders().getETag();

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIterator.java
@@ -18,6 +18,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
     private final String path;
     private final boolean recursive;
     private final int limit;
+    private final boolean permissions;
 
     private List<PromptMetadataDto> items = Collections.emptyList();
     private String nextToken = null;
@@ -32,7 +33,7 @@ class PromptMetadataIterator implements Iterator<PromptMetadataDto> {
         }
         firstRequest = false;
 
-        var data = promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
+        var data = promptClient.getPromptsMetadata(path, recursive, nextToken, limit, permissions);
         log.debug("New batch of prompt metadata is fetched in iterator: data={}", data);
         items = data.getItems() != null ? data.getItems() : Collections.emptyList();
         nextToken = data.getNextToken();

--- a/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
+++ b/src/main/java/com/epam/aidial/cfg/service/prompt/PromptService.java
@@ -85,7 +85,8 @@ public class PromptService implements ResourceService {
         var nextToken = request.getNextToken();
         var path = request.getPath() != null ? request.getPath() : BASE_PATH;
         var limit = request.getLimit() != null ? request.getLimit() : promptsMetadataDefaultLimit;
-        return promptClient.getPromptsMetadata(path, recursive, nextToken, limit);
+        var permissions = request.isPermissions();
+        return promptClient.getPromptsMetadata(path, recursive, nextToken, limit, permissions);
     }
 
     public Prompt getPrompt(String path) {
@@ -98,7 +99,7 @@ public class PromptService implements ResourceService {
 
     private DomainModelWithEtag<Prompt> fetchApplicationResource(String path, String etag) {
         var response = promptClient.getPrompt(path, createIfNonMatchHeaders(etag));
-        var promptMetadata = promptClient.getPromptsMetadata(path, false, null, promptsMetadataDefaultLimit);
+        var promptMetadata = promptClient.getPromptsMetadata(path, false, null, promptsMetadataDefaultLimit, false);
         var prompt = promptClientMapper.toPrompt(response.getBody(), promptMetadata);
         var currentEtag = response.getHeaders().getETag();
         return new DomainModelWithEtag<>(prompt, currentEtag);
@@ -156,7 +157,7 @@ public class PromptService implements ResourceService {
     }
 
     private Stream<PromptMetadataDto> createStream(String path, boolean recursive) {
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, promptsMetadataDefaultLimit);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, promptsMetadataDefaultLimit, false);
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/service/FileServiceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/FileServiceTest.java
@@ -4,10 +4,10 @@ import com.epam.aidial.cfg.client.FileClient;
 import com.epam.aidial.cfg.client.ResourceClient;
 import com.epam.aidial.cfg.client.dto.FileMetadataDto;
 import com.epam.aidial.cfg.client.dto.MoveResourceDto;
+import com.epam.aidial.cfg.client.dto.NodeTypeDto;
 import com.epam.aidial.cfg.client.mapper.FileClientMapperImpl;
 import com.epam.aidial.cfg.client.mapper.FolderMapperImpl;
 import com.epam.aidial.cfg.client.mapper.ResourceClientMapperImpl;
-import com.epam.aidial.cfg.dto.NodeTypeDto;
 import com.epam.aidial.cfg.model.FileNodeInfo;
 import com.epam.aidial.cfg.model.FolderInfo;
 import com.epam.aidial.cfg.model.ImportConflictResolutionStrategy;
@@ -76,13 +76,13 @@ class FileServiceTest {
         expected.setPath("public/testFile.txt");
         expected.setFolderId("public");
         expected.setNodeType(NodeType.ITEM);
-        when(fileClient.getFilesMetadata(any(), anyBoolean(), any())).thenReturn(fileMetadataDto);
+        when(fileClient.getFilesMetadata(any(), anyBoolean(), any(), anyBoolean())).thenReturn(fileMetadataDto);
         // when
         FileNodeInfo result = fileService.getAll(filesRequest);
         // then
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(expected);
-        verify(fileClient).getFilesMetadata(any(), anyBoolean(), any());
+        verify(fileClient).getFilesMetadata(any(), anyBoolean(), any(), anyBoolean());
     }
 
     @Test
@@ -166,7 +166,7 @@ class FileServiceTest {
                 .bucket("public")
                 .items(List.of(item, folder))
                 .build();
-        when(fileClient.getFilesMetadata(any(), anyBoolean(), any())).thenReturn(response);
+        when(fileClient.getFilesMetadata(any(), anyBoolean(), any(), anyBoolean())).thenReturn(response);
         // when
         FolderInfo folderInfo = fileService.getFolders(request);
         // then
@@ -200,7 +200,7 @@ class FileServiceTest {
                 .bucket("public")
                 .items(List.of(item2, folder))
                 .build();
-        when(fileClient.getFilesMetadata(any(), anyBoolean(), any())).thenReturn(response);
+        when(fileClient.getFilesMetadata(any(), anyBoolean(), any(), anyBoolean())).thenReturn(response);
         // when
         Set<String> resourceUrls = fileService.getResourceUrls(path);
         // then

--- a/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
@@ -111,9 +111,9 @@ class PromptMetadataIteratorTest {
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null, limit, recursive)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit, permissions)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, recursive);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, permissions);
 
         assertThat(iterator.hasNext()).isFalse();
         assertThatThrownBy(iterator::next)

--- a/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/prompt/PromptMetadataIteratorTest.java
@@ -24,6 +24,7 @@ class PromptMetadataIteratorTest {
     void testIteration_SinglePage_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        boolean permissions = true;
         int limit = 100;
 
         var item1 = new PromptMetadataDto();
@@ -35,9 +36,9 @@ class PromptMetadataIteratorTest {
         response.setItems(List.of(item1, item2));
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit, permissions)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, permissions);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -50,6 +51,7 @@ class PromptMetadataIteratorTest {
     void testIteration_MultiplePages_ReturnsAllItems() {
         String path = "test-path";
         boolean recursive = true;
+        boolean permissions = true;
         int limit = 2;
 
         var item1 = new PromptMetadataDto();
@@ -66,10 +68,10 @@ class PromptMetadataIteratorTest {
         secondResponse.setItems(List.of(item3));
         secondResponse.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(firstResponse);
-        when(promptClient.getPromptsMetadata(path, recursive, "next-token", limit)).thenReturn(secondResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit, permissions)).thenReturn(firstResponse);
+        when(promptClient.getPromptsMetadata(path, recursive, "next-token", limit, permissions)).thenReturn(secondResponse);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, permissions);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(item1);
@@ -84,15 +86,16 @@ class PromptMetadataIteratorTest {
     void testHasNext_EmptyData_ReturnsFalse() {
         String path = "test-path";
         boolean recursive = true;
+        boolean permissions = true;
         int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit, permissions)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, permissions);
 
         assertThat(iterator.hasNext()).isFalse();
     }
@@ -101,15 +104,16 @@ class PromptMetadataIteratorTest {
     void testNext_NoMoreElements_ThrowsException() {
         String path = "test-path";
         boolean recursive = true;
+        boolean permissions = true;
         int limit = 100;
 
         var response = new PromptMetadataDto();
         response.setItems(List.of());
         response.setNextToken(null);
 
-        when(promptClient.getPromptsMetadata(path, recursive, null, limit)).thenReturn(response);
+        when(promptClient.getPromptsMetadata(path, recursive, null, limit, recursive)).thenReturn(response);
 
-        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit);
+        var iterator = new PromptMetadataIterator(promptClient, path, recursive, limit, recursive);
 
         assertThat(iterator.hasNext()).isFalse();
         assertThatThrownBy(iterator::next)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/ai-dial-admin-frontend/issues/1105

### Description of changes
Added 'permissions' field to folder info response. Applicable values are ["read", "write", "share"]

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.