### PR TITLE
fix: fix azure auth with v2.0 token

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/web/security/JwtProviderUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/web/security/JwtProviderUtils.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @Slf4j
 public class JwtProviderUtils {
     private static final String V1_ISSUER_FORMAT = "https://%s/%s/";
-    private static final String V2_ISSUER_FORMAT = "https://%s/%s/v2.0/";
+    private static final String V2_ISSUER_FORMAT = "https://%s/%s/v2.0";
 
     public Set<String> getAcceptedIssuers(JwtProvidersProperties.ProviderConfig config) {
         final HashSet<String> acceptedIssuers = new HashSet<>();


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #652

### Description of changes
Fixed azure auth v2.0 token
Example of "iss" claim in token for v2.0: "https://login.microsoftonline.com/b41b72d0-4e9f-4c26-8a69-f949f367c91d/v2.0"

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.