### PR TITLE
chore: extend CVE-2025-59250 expiration date in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
 #Fixed version already in use, false positive per https://github.com/aquasecurity/trivy/discussions/9745
-CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-02-01
+CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-05-01


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Extended expiration date for [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w) in .trivyignore

Original PRs:
 - #644

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.