### PR TITLE
fix: fix system rollback for models with adapter

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
@@ -209,6 +209,7 @@ public class AdapterService {
         Collection<Adapter> adapters = getAllAtRevision(revision);
         adapterJpaRepository.deleteAllExcept(adapters.stream().map(Adapter::getName).collect(Collectors.toList()));
         for (Adapter adapter : adapters) {
+            adapter.setModels(List.of());
             AdapterEntity entity = adapterJpaRepository.findById(adapter.getName()).orElseGet(AdapterEntity::new);
             AdapterEntity keyEntity = toEntity(adapter, entity);
             adapterJpaRepository.save(keyEntity);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/AdapterHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/AdapterHistoryFunctionalTest.java
@@ -8,6 +8,8 @@ import com.epam.aidial.cfg.web.facade.ModelFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 
@@ -16,6 +18,7 @@ import java.util.List;
 
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createAdapterDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createModelDto;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createModelDtoWithAdapter;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 
 public abstract class AdapterHistoryFunctionalTest {
@@ -101,6 +104,35 @@ public abstract class AdapterHistoryFunctionalTest {
         Assertions.assertEquals(revisionsListBeforeRollback.size() + 1, revisionsListAfterRollback.size());
 
         var adaptersAfterRollbackToRevision = adapterFacade.getAllAdapters();
+        Assertions.assertEquals(actualAtRevision, adaptersAfterRollbackToRevision);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    public void shouldSuccessfullyRollbackDeletedAdapterWithModel(boolean removeModel) {
+        // create adapter
+        AdapterDto adapterDto = createAdapterDto("1");
+        adapterFacade.createAdapter(adapterDto);
+
+        // create model
+        ModelDto modelDto = createModelDtoWithAdapter("1");
+        modelFacade.createModel(modelDto);
+
+        // remember rev number and expected adapters state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<AdapterDto> actualAtRevision = adapterFacade.getAllAdapters();
+
+        // delete adapter
+        adapterFacade.deleteAdapter(adapterDto.getName(), removeModel);
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
+
+        Collection<AdapterDto> adaptersAfterRollbackToRevision = adapterFacade.getAllAdapters();
         Assertions.assertEquals(actualAtRevision, adaptersAfterRollbackToRevision);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ModelHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ModelHistoryFunctionalTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createAdapterDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorDto;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createModelDtoWithAdapter;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createModelDtoWithLimitsAndEndpoint;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 
@@ -245,6 +246,34 @@ public abstract class ModelHistoryFunctionalTest {
         List<ConfigRevisionDto> revisionsListAfterRollback = historyFacade.getRevisionsList();
 
         Assertions.assertEquals(revisionsListBeforeRollback.size() + 1, revisionsListAfterRollback.size());
+
+        Collection<ModelDto> modelsAfterRollbackToRevision = modelFacade.getAll();
+        Assertions.assertEquals(actualAtRevision, modelsAfterRollbackToRevision);
+    }
+
+    @Test
+    public void shouldSuccessfullyRollbackDeletedModelWithAdapter() {
+        // create adapter
+        AdapterDto adapterDto = createAdapterDto("1");
+        adapterFacade.createAdapter(adapterDto);
+
+        // create model
+        ModelDto modelDto = createModelDtoWithAdapter("1");
+        modelFacade.createModel(modelDto);
+
+        // remember rev number and expected models state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<ModelDto> actualAtRevision = modelFacade.getAll();
+
+        // delete model
+        modelFacade.deleteModel(modelDto.getName());
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
 
         Collection<ModelDto> modelsAfterRollbackToRevision = modelFacade.getAll();
         Assertions.assertEquals(actualAtRevision, modelsAfterRollbackToRevision);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/TestHistoryFacade.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/TestHistoryFacade.java
@@ -30,6 +30,11 @@ public class TestHistoryFacade {
         return historyFacade.getRevisionsList(pageRequestDto);
     }
 
+    public int getRevisionsListSize() {
+        PageRequestDto pageRequestDto = new PageRequestDto();
+        return historyFacade.getRevisionsList(pageRequestDto).size();
+    }
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void rollbackToRevision(Number revision) {
         historyFacade.rollbackToRevision(revision);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #687

### Description of changes
Fixed system rollback for models with adapter (since adapters are rollbacked first, remove association with models for all rollbacked adapters, association will be restored during models rollback)

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.