### PR TITLE
fix: fix system rollback for interceptors with runner and applications with schema

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AdapterService.java
@@ -208,6 +208,7 @@ public class AdapterService {
 
         Collection<Adapter> adapters = getAllAtRevision(revision);
         adapterJpaRepository.deleteAllExcept(adapters.stream().map(Adapter::getName).collect(Collectors.toList()));
+
         for (Adapter adapter : adapters) {
             adapter.setModels(List.of());
             AdapterEntity entity = adapterJpaRepository.findById(adapter.getName()).orElseGet(AdapterEntity::new);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationTypeSchemaService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationTypeSchemaService.java
@@ -167,9 +167,12 @@ public class ApplicationTypeSchemaService {
             applicationEntity.setEndpoint("endpoint");
         });
         applicationJpaRepository.saveAllAndFlush(applications);
+
         Collection<ApplicationTypeSchema> applicationTypeSchemas = getAllAtRevision(revision);
         jpaRepository.deleteAllExcept(applicationTypeSchemas.stream().map(ApplicationTypeSchema::getSchemaId).collect(Collectors.toList()));
+
         for (ApplicationTypeSchema domain : applicationTypeSchemas) {
+            domain.setApplications(List.of());
             ApplicationTypeSchemaEntity entity = jpaRepository.findById(domain.getSchemaId()).orElseGet(ApplicationTypeSchemaEntity::new);
             ApplicationTypeSchemaEntity applicationTypeSchemaEntity = toEntity(domain, entity);
             jpaRepository.save(applicationTypeSchemaEntity);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorRunnerService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorRunnerService.java
@@ -167,6 +167,7 @@ public class InterceptorRunnerService {
         interceptorRunnerJpaRepository.deleteAllExcept(interceptorRunners.stream().map(InterceptorRunner::getName).toList());
 
         for (InterceptorRunner interceptorRunner : interceptorRunners) {
+            interceptorRunner.setInterceptors(List.of());
             InterceptorRunnerEntity entity = interceptorRunnerJpaRepository.findById(interceptorRunner.getName()).orElseGet(InterceptorRunnerEntity::new);
             InterceptorRunnerEntity interceptorRunnerEntity = toEntity(interceptorRunner, entity);
             interceptorRunnerJpaRepository.save(interceptorRunnerEntity);

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RollbackService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RollbackService.java
@@ -39,8 +39,8 @@ public class RollbackService {
         assistantService.rollbackAssistants(revision);
         assistantsPropertyService.rollbackAssistantsProperties(revision);
         routeService.rollbackRoutes(revision);
-        interceptorService.rollbackInterceptors(revision);
         interceptorRunnerService.rollbackInterceptorRunners(revision);
+        interceptorService.rollbackInterceptors(revision);
         globalSettingsService.rollbackGlobalSettings(revision);
         adminSettingsService.rollbackAdminSettings(revision);
     }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationHistoryFunctionalTest.java
@@ -149,7 +149,7 @@ public abstract class ApplicationHistoryFunctionalTest {
         var actualApplicationAtRevision = applicationFacade.getApplication(applicationDto.getName());
 
         // create interceptor1
-        InterceptorDto interceptor2 =  createInterceptorDto("2");
+        InterceptorDto interceptor2 = createInterceptorDto("2");
         interceptorFacade.createInterceptor(interceptor2);
 
         // update application
@@ -239,6 +239,35 @@ public abstract class ApplicationHistoryFunctionalTest {
         var applicationAfterRollbackToRevision = applicationFacade.getApplication(application1Dto.getName());
         Assertions.assertEquals(actualAtRevision, applicationsAfterRollbackToRevision);
         Assertions.assertEquals(actualApplication1AtRevision, applicationAfterRollbackToRevision);
+    }
+
+    @Test
+    public void shouldSuccessfullyRollbackDeletedApplicationWithAppTypeSchema() {
+        // create application type schema
+        ApplicationTypeSchemaDto applicationTypeSchemaDto = createAppTypeSchema("1");
+        applicationTypeSchemaFacade.create(applicationTypeSchemaDto);
+
+        // create application
+        ApplicationDto applicationDto = createBaseApplicationDto("1");
+        applicationDto.setCustomAppSchemaId(URI.create(applicationTypeSchemaDto.getId()));
+        applicationFacade.createApplication(applicationDto);
+
+        // remember rev number and expected applications state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<ApplicationInfoDto> actualAtRevision = applicationFacade.getAllApplications();
+
+        // delete application
+        applicationFacade.deleteApplication(applicationDto.getName());
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
+
+        Collection<ApplicationInfoDto> applicationsAfterRollbackToRevision = applicationFacade.getAllApplications();
+        Assertions.assertEquals(actualAtRevision, applicationsAfterRollbackToRevision);
     }
 
     private ApplicationTypeSchemaDto createAppTypeSchema(String suffix) {

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationTypeSchemaHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/ApplicationTypeSchemaHistoryFunctionalTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.functional.tests.history;
 
+import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationTypeSchemaDto;
 import com.epam.aidial.cfg.dto.ConfigRevisionDto;
 import com.epam.aidial.cfg.functional.utils.FunctionalTestHelper;
@@ -8,12 +9,17 @@ import com.epam.aidial.cfg.web.facade.ApplicationTypeSchemaFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createBaseApplicationDto;
 
 public abstract class ApplicationTypeSchemaHistoryFunctionalTest {
 
@@ -34,7 +40,7 @@ public abstract class ApplicationTypeSchemaHistoryFunctionalTest {
         ApplicationTypeSchemaDto applicationDto = createDto("1");
         applicationDto.setInterceptors(List.of("interceptor1", "interceptor2"));
         applicationTypeSchemaFacade.create(applicationDto);
-        applicationTypeSchemaFacade.get("id1");
+        applicationTypeSchemaFacade.get("https://test-schema.example/1");
 
         // 2 update application1 description
         ApplicationTypeSchemaDto updatedApplicationTypeSchema = createDto("1");
@@ -83,10 +89,34 @@ public abstract class ApplicationTypeSchemaHistoryFunctionalTest {
         Assertions.assertEquals(actualAtOldRevision, applicationsAfterRollback);
     }
 
-    private ApplicationTypeSchemaDto createAppTypeSchema(String suffix) {
-        ApplicationTypeSchemaDto dto = new ApplicationTypeSchemaDto();
-        dto.setId("https://test-schema.example/" + suffix);
-        return dto;
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    public void shouldSuccessfullyRollbackDeletedApplicationTypeSchemaWithApplication(boolean removeApplication) {
+        // create application type schema
+        ApplicationTypeSchemaDto applicationTypeSchemaDto = createDto("1");
+        applicationTypeSchemaFacade.create(applicationTypeSchemaDto);
+
+        // create application
+        ApplicationDto applicationDto = createBaseApplicationDto("1");
+        applicationDto.setCustomAppSchemaId(URI.create(applicationTypeSchemaDto.getId()));
+        applicationFacade.createApplication(applicationDto);
+
+        // remember rev number and expected application type schemas state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<ApplicationTypeSchemaDto> actualAtRevision = applicationTypeSchemaFacade.getAll();
+
+        // delete application type schema
+        applicationTypeSchemaFacade.delete(applicationTypeSchemaDto.getId(), removeApplication);
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
+
+        Collection<ApplicationTypeSchemaDto> applicationTypeSchemasAfterRollbackToRevision = applicationTypeSchemaFacade.getAll();
+        Assertions.assertEquals(actualAtRevision, applicationTypeSchemasAfterRollbackToRevision);
     }
 
     private void assertApplicationTypeSchema(ApplicationTypeSchemaDto actual, ApplicationTypeSchemaDto expected) {
@@ -95,7 +125,7 @@ public abstract class ApplicationTypeSchemaHistoryFunctionalTest {
 
     private ApplicationTypeSchemaDto createDto(String suffix) {
         ApplicationTypeSchemaDto applicationDto = new ApplicationTypeSchemaDto();
-        applicationDto.setId("id" + suffix);
+        applicationDto.setId("https://test-schema.example/" + suffix);
         applicationDto.setDescription("description" + suffix);
         applicationDto.setApplicationTypeDisplayName("id" + suffix);
         applicationDto.setApplicationTypeSchemaEndpoint("https://test.com/endpoint_" + suffix);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorHistoryFunctionalTest.java
@@ -4,11 +4,14 @@ import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ConfigRevisionDto;
 import com.epam.aidial.cfg.dto.GlobalSettingsDto;
 import com.epam.aidial.cfg.dto.InterceptorDto;
+import com.epam.aidial.cfg.dto.InterceptorRunnerDto;
 import com.epam.aidial.cfg.dto.ModelDto;
 import com.epam.aidial.cfg.dto.source.InterceptorEndpointsSourceDto;
+import com.epam.aidial.cfg.dto.source.InterceptorRunnerSourceDto;
 import com.epam.aidial.cfg.web.facade.ApplicationFacade;
 import com.epam.aidial.cfg.web.facade.GlobalSettingsFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorFacade;
+import com.epam.aidial.cfg.web.facade.InterceptorRunnerFacade;
 import com.epam.aidial.cfg.web.facade.ModelFacade;
 import com.epam.aidial.cfg.web.facade.RoleFacade;
 import org.junit.jupiter.api.Assertions;
@@ -22,6 +25,7 @@ import java.util.Map;
 
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createApplicationDtoWithEndpoint;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorDto;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorRunnerDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createModelDto;
 import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createRoleDto;
 
@@ -38,6 +42,8 @@ public abstract class InterceptorHistoryFunctionalTest {
     @Autowired
     private RoleFacade roleFacade;
     @Autowired
+    private InterceptorRunnerFacade interceptorRunnerFacade;
+    @Autowired
     private TestHistoryFacade historyFacade;
 
     @Test
@@ -48,7 +54,7 @@ public abstract class InterceptorHistoryFunctionalTest {
         interceptorFacade.createInterceptor(interceptorDto);
 
         // update interceptor1 description
-        InterceptorDto updatedInterceptor =  createInterceptorDto("1");
+        InterceptorDto updatedInterceptor = createInterceptorDto("1");
         updatedInterceptor.setDescription("new interceptor description");
         interceptorFacade.updateInterceptor(interceptorDto.getName(), updatedInterceptor, "*");
 
@@ -157,6 +163,35 @@ public abstract class InterceptorHistoryFunctionalTest {
         Assertions.assertEquals(revisionsListBeforeRollback.size() + 1, revisionsListAfterRollback.size());
 
         var interceptorsAfterRollbackToRevision = interceptorFacade.getAllInterceptors();
+        Assertions.assertEquals(actualAtRevision, interceptorsAfterRollbackToRevision);
+    }
+
+    @Test
+    public void shouldSuccessfullyRollbackDeletedInterceptorWithInterceptorRunner() {
+        // create interceptor runner
+        InterceptorRunnerDto interceptorRunnerDto = createInterceptorRunnerDto("1");
+        interceptorRunnerFacade.createInterceptorRunner(interceptorRunnerDto);
+
+        // create interceptor
+        InterceptorDto interceptorDto = createInterceptorDto("1");
+        interceptorDto.setSource(new InterceptorRunnerSourceDto(interceptorRunnerDto.getName()));
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        // remember rev number and expected interceptors state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<InterceptorDto> actualAtRevision = interceptorFacade.getAllInterceptors();
+
+        // delete interceptor
+        interceptorFacade.deleteInterceptor(interceptorDto.getName());
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
+
+        Collection<InterceptorDto> interceptorsAfterRollbackToRevision = interceptorFacade.getAllInterceptors();
         Assertions.assertEquals(actualAtRevision, interceptorsAfterRollbackToRevision);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorRunnerHistoryFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/history/InterceptorRunnerHistoryFunctionalTest.java
@@ -1,21 +1,30 @@
 package com.epam.aidial.cfg.functional.tests.history;
 
 import com.epam.aidial.cfg.dto.ConfigRevisionDto;
+import com.epam.aidial.cfg.dto.InterceptorDto;
 import com.epam.aidial.cfg.dto.InterceptorRunnerDto;
+import com.epam.aidial.cfg.dto.source.InterceptorRunnerSourceDto;
+import com.epam.aidial.cfg.web.facade.InterceptorFacade;
 import com.epam.aidial.cfg.web.facade.InterceptorRunnerFacade;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorDto;
+import static com.epam.aidial.cfg.functional.utils.FunctionalTestHelper.createInterceptorRunnerDto;
 
 public abstract class InterceptorRunnerHistoryFunctionalTest {
 
     @Autowired
     private InterceptorRunnerFacade interceptorRunnerFacade;
+    @Autowired
+    private InterceptorFacade interceptorFacade;
     @Autowired
     private TestHistoryFacade historyFacade;
 
@@ -23,17 +32,17 @@ public abstract class InterceptorRunnerHistoryFunctionalTest {
     public void shouldSuccessfullyCreateAndUpdateInterceptorRunner() {
 
         // create interceptorRunner1
-        InterceptorRunnerDto interceptorRunnerDto = createDto("1");
+        InterceptorRunnerDto interceptorRunnerDto = createInterceptorRunnerDto("1");
         interceptorRunnerFacade.createInterceptorRunner(interceptorRunnerDto);
 
         // update interceptorRunner1 description
-        InterceptorRunnerDto updatedInterceptorRunner = createDto("1");
+        InterceptorRunnerDto updatedInterceptorRunner = createInterceptorRunnerDto("1");
         updatedInterceptorRunner.setDescription("new interceptorRunner description");
         interceptorRunnerFacade.updateInterceptorRunner(interceptorRunnerDto.getName(), updatedInterceptorRunner, "*");
 
         // verify interceptorRunner1
         InterceptorRunnerDto actual = interceptorRunnerFacade.getInterceptorRunner(interceptorRunnerDto.getName());
-        var expected = createDto("1");
+        var expected = createInterceptorRunnerDto("1");
         expected.setDescription("new interceptorRunner description");
         assertInterceptorRunner(actual, expected);
 
@@ -46,10 +55,10 @@ public abstract class InterceptorRunnerHistoryFunctionalTest {
         interceptorRunnerFacade.deleteInterceptorRunner(interceptorRunnerDto.getName(), false);
 
         // create interceptorRunner 2
-        interceptorRunnerFacade.createInterceptorRunner(createDto("2"));
+        interceptorRunnerFacade.createInterceptorRunner(createInterceptorRunnerDto("2"));
 
         // create interceptorRunner3
-        interceptorRunnerFacade.createInterceptorRunner(createDto("3"));
+        interceptorRunnerFacade.createInterceptorRunner(createInterceptorRunnerDto("3"));
 
         List<ConfigRevisionDto> revisionsListBeforeRollback = historyFacade.getRevisionsList();
         historyFacade.rollbackToRevision(revNumberToRollback);
@@ -61,18 +70,37 @@ public abstract class InterceptorRunnerHistoryFunctionalTest {
         Assertions.assertEquals(List.of(actual), interceptorRunnersAfterRollbackToRevision);
     }
 
-    private void assertInterceptorRunner(InterceptorRunnerDto actual, InterceptorRunnerDto expected) {
-        Assertions.assertEquals(expected, actual);
+    @ParameterizedTest
+    @CsvSource({"true", "false"})
+    public void shouldSuccessfullyRollbackDeletedInterceptorRunnerWithInterceptor(boolean removeInterceptor) {
+        // create interceptor runner
+        InterceptorRunnerDto interceptorRunnerDto = createInterceptorRunnerDto("1");
+        interceptorRunnerFacade.createInterceptorRunner(interceptorRunnerDto);
+
+        // create interceptor
+        InterceptorDto interceptorDto = createInterceptorDto("1");
+        interceptorDto.setSource(new InterceptorRunnerSourceDto(interceptorRunnerDto.getName()));
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        // remember rev number and expected interceptor runners state
+        Integer revNumberToRollback = CollectionUtils.lastElement(historyFacade.getRevisionsList()).getId();
+        Collection<InterceptorRunnerDto> actualAtRevision = interceptorRunnerFacade.getAllInterceptorRunners();
+
+        // delete interceptor runner
+        interceptorRunnerFacade.deleteInterceptorRunner(interceptorRunnerDto.getName(), removeInterceptor);
+
+        // rollback and verify
+        int revisionsListSizeBeforeRollback = historyFacade.getRevisionsListSize();
+        historyFacade.rollbackToRevision(revNumberToRollback);
+        int revisionsListSizeAfterRollback = historyFacade.getRevisionsListSize();
+
+        Assertions.assertEquals(revisionsListSizeBeforeRollback + 1, revisionsListSizeAfterRollback);
+
+        Collection<InterceptorRunnerDto> interceptorRunnersAfterRollbackToRevision = interceptorRunnerFacade.getAllInterceptorRunners();
+        Assertions.assertEquals(actualAtRevision, interceptorRunnersAfterRollbackToRevision);
     }
 
-    private InterceptorRunnerDto createDto(String suffix) {
-        InterceptorRunnerDto interceptorRunnerDto = new InterceptorRunnerDto();
-        interceptorRunnerDto.setName("interceptorRunner" + suffix);
-        interceptorRunnerDto.setDisplayName("Interceptor Runner " + suffix);
-        interceptorRunnerDto.setDescription("description" + suffix);
-        interceptorRunnerDto.setCompletionEndpoint("https://endpoint.test.com/completion" + suffix);
-        interceptorRunnerDto.setConfigurationEndpoint("https://endpoint.test.com/configuration" + suffix);
-        interceptorRunnerDto.setInterceptors(new ArrayList<>());
-        return interceptorRunnerDto;
+    private void assertInterceptorRunner(InterceptorRunnerDto actual, InterceptorRunnerDto expected) {
+        Assertions.assertEquals(expected, actual);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/utils/FunctionalTestHelper.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/utils/FunctionalTestHelper.java
@@ -6,6 +6,7 @@ import com.epam.aidial.cfg.dto.AdminSettingsDto;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.AssistantDto;
 import com.epam.aidial.cfg.dto.InterceptorDto;
+import com.epam.aidial.cfg.dto.InterceptorRunnerDto;
 import com.epam.aidial.cfg.dto.KeyDto;
 import com.epam.aidial.cfg.dto.LimitDto;
 import com.epam.aidial.cfg.dto.ModelDto;
@@ -20,6 +21,7 @@ import com.epam.aidial.cfg.dto.source.ModelEndpointsSourceDto;
 import com.epam.aidial.core.config.CoreFeatures;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -245,5 +247,16 @@ public class FunctionalTestHelper {
         AdminSettingsDto adminSettingsDto = new AdminSettingsDto();
         adminSettingsDto.setCoreConfigVersion(coreConfigVersion);
         return adminSettingsDto;
+    }
+
+    public static InterceptorRunnerDto createInterceptorRunnerDto(String suffix) {
+        InterceptorRunnerDto interceptorRunnerDto = new InterceptorRunnerDto();
+        interceptorRunnerDto.setName("interceptorRunner" + suffix);
+        interceptorRunnerDto.setDisplayName("Interceptor Runner " + suffix);
+        interceptorRunnerDto.setDescription("description" + suffix);
+        interceptorRunnerDto.setCompletionEndpoint("https://endpoint.test.com/completion" + suffix);
+        interceptorRunnerDto.setConfigurationEndpoint("https://endpoint.test.com/configuration" + suffix);
+        interceptorRunnerDto.setInterceptors(new ArrayList<>());
+        return interceptorRunnerDto;
     }
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #687

### Description of changes
Fixed:
- system rollback for interceptors with interceptor runner (since interceptor runners are rollbacked first, remove association with interceptors for all rollbacked interceptor runners, association will be restored during interceptors rollback)
- system rollback for applications with application type schema (since application type schemas are rollbacked first, remove association with applications for all rollbacked application type schemas, association will be restored during applications rollback)

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.