### PR TITLE
fix: set completion endpoint path in model's adapter source

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
@@ -4,6 +4,7 @@ import com.epam.aidial.cfg.dao.model.AdapterContainerEntity;
 import com.epam.aidial.cfg.dao.model.AdapterEntity;
 import com.epam.aidial.cfg.dao.model.DeploymentEntity;
 import com.epam.aidial.cfg.dao.model.ModelEntity;
+import com.epam.aidial.cfg.dao.model.ModelTypeEntity;
 import com.epam.aidial.cfg.domain.model.Adapter;
 import com.epam.aidial.cfg.domain.model.source.AdapterEndpointsSource;
 import com.epam.aidial.cfg.domain.model.source.AdapterSource;
@@ -15,10 +16,16 @@ import org.mapstruct.Named;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public abstract class AdapterEntityMapper {
+
+    private static final Map<Boolean, String> ENDPOINT_ENDING_MAP = Map.of(
+            true, "chat/completions",
+            false, "embeddings"
+    );
 
     @Autowired
     protected AdapterContainerEntityMapper adapterContainerEntityMapper;
@@ -59,8 +66,11 @@ public abstract class AdapterEntityMapper {
                         // Clear container when setting adapter to ensure mutual exclusivity
                         model.setModelContainer(null);
                         model.setAdapter(updatedEntity);
-                        model.setAdapterCompletionEndpointPath(model.getId() + "/chat/completions");
                         model.setEndpoint(null);
+
+                        boolean isChat = isChat(model.getType());
+                        String endpointEnding = ENDPOINT_ENDING_MAP.get(isChat);
+                        model.setAdapterCompletionEndpointPath("%s/%s".formatted(model.getId(), endpointEnding));
                     });
             updatedEntity.getModels().clear();
             updatedEntity.getModels().addAll(models);
@@ -83,5 +93,9 @@ public abstract class AdapterEntityMapper {
                 .map(ModelEntity::getDeployment)
                 .map(DeploymentEntity::getName)
                 .collect(Collectors.toList());
+    }
+
+    private boolean isChat(ModelTypeEntity type) {
+        return type == ModelTypeEntity.CHAT || type == null;
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
@@ -4,7 +4,6 @@ import com.epam.aidial.cfg.dao.model.AdapterContainerEntity;
 import com.epam.aidial.cfg.dao.model.AdapterEntity;
 import com.epam.aidial.cfg.dao.model.DeploymentEntity;
 import com.epam.aidial.cfg.dao.model.ModelEntity;
-import com.epam.aidial.cfg.dao.model.ModelTypeEntity;
 import com.epam.aidial.cfg.domain.model.Adapter;
 import com.epam.aidial.cfg.domain.model.source.AdapterEndpointsSource;
 import com.epam.aidial.cfg.domain.model.source.AdapterSource;
@@ -16,16 +15,10 @@ import org.mapstruct.Named;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public abstract class AdapterEntityMapper {
-
-    private static final Map<Boolean, String> ENDPOINT_ENDING_MAP = Map.of(
-            true, "chat/completions",
-            false, "embeddings"
-    );
 
     @Autowired
     protected AdapterContainerEntityMapper adapterContainerEntityMapper;
@@ -67,10 +60,7 @@ public abstract class AdapterEntityMapper {
                         model.setModelContainer(null);
                         model.setAdapter(updatedEntity);
                         model.setEndpoint(null);
-
-                        boolean isChat = isChat(model.getType());
-                        String endpointEnding = ENDPOINT_ENDING_MAP.get(isChat);
-                        model.setAdapterCompletionEndpointPath("%s/%s".formatted(model.getId(), endpointEnding));
+                        model.setAdapterCompletionEndpointPath(ModelEndpointUtils.getAdapterCompletionEndpointPath(model.getType(), model.getId()));
                     });
             updatedEntity.getModels().clear();
             updatedEntity.getModels().addAll(models);
@@ -93,9 +83,5 @@ public abstract class AdapterEntityMapper {
                 .map(ModelEntity::getDeployment)
                 .map(DeploymentEntity::getName)
                 .collect(Collectors.toList());
-    }
-
-    private boolean isChat(ModelTypeEntity type) {
-        return type == ModelTypeEntity.CHAT || type == null;
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
+++ b/src/main/java/com/epam/aidial/cfg/dao/mapper/AdapterEntityMapper.java
@@ -55,11 +55,12 @@ public abstract class AdapterEntityMapper {
                     });
             models.stream()
                     .filter(model -> !updatedEntity.getModels().contains(model))
-                    .forEach(app -> {
+                    .forEach(model -> {
                         // Clear container when setting adapter to ensure mutual exclusivity
-                        app.setModelContainer(null);
-                        app.setAdapter(updatedEntity);
-                        app.setEndpoint(null);
+                        model.setModelContainer(null);
+                        model.setAdapter(updatedEntity);
+                        model.setAdapterCompletionEndpointPath(model.getId() + "/chat/completions");
+                        model.setEndpoint(null);
                     });
             updatedEntity.getModels().clear();
             updatedEntity.getModels().addAll(models);

--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.domain.utils;
 
+import com.epam.aidial.cfg.dao.model.ModelTypeEntity;
 import com.epam.aidial.core.config.ModelType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -24,6 +25,11 @@ public class ModelEndpointUtils {
             false, Pair.of("embeddings", NON_CHAT_MODEL_ENDPOINT_PATTERN)
     );
 
+    private static final Map<Boolean, String> ENDPOINT_ENDING_MAP = Map.of(
+            true, "chat/completions",
+            false, "embeddings"
+    );
+
     public ModelEndpointComponents parseModelEndpoint(String modelEndpoint, ModelType type) {
         boolean isChat = isChat(type);
         String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
@@ -44,6 +50,16 @@ public class ModelEndpointUtils {
         }
 
         return new ModelEndpointComponents(getValueFromMatcherGroup(matcher, 1), getValueFromMatcherGroup(matcher, 2) + endpointEnding);
+    }
+
+    public static String getAdapterCompletionEndpointPath(ModelTypeEntity type, String id) {
+        boolean isChat = isChat(type);
+        String endpointEnding = ENDPOINT_ENDING_MAP.get(isChat);
+        return "%s/%s".formatted(id, endpointEnding);
+    }
+
+    private static boolean isChat(ModelTypeEntity type) {
+        return type == ModelTypeEntity.CHAT || type == null;
     }
 
     public boolean isChat(com.epam.aidial.cfg.domain.model.ModelType type) {

--- a/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/utils/ModelEndpointUtils.java
@@ -25,11 +25,6 @@ public class ModelEndpointUtils {
             false, Pair.of("embeddings", NON_CHAT_MODEL_ENDPOINT_PATTERN)
     );
 
-    private static final Map<Boolean, String> ENDPOINT_ENDING_MAP = Map.of(
-            true, "chat/completions",
-            false, "embeddings"
-    );
-
     public ModelEndpointComponents parseModelEndpoint(String modelEndpoint, ModelType type) {
         boolean isChat = isChat(type);
         String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
@@ -54,7 +49,7 @@ public class ModelEndpointUtils {
 
     public static String getAdapterCompletionEndpointPath(ModelTypeEntity type, String id) {
         boolean isChat = isChat(type);
-        String endpointEnding = ENDPOINT_ENDING_MAP.get(isChat);
+        String endpointEnding = MODEL_PATTERN_MAP.get(isChat).getLeft();
         return "%s/%s".formatted(id, endpointEnding);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/AdapterFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/AdapterFunctionalTest.java
@@ -172,6 +172,8 @@ public abstract class AdapterFunctionalTest {
 
     @Test
     public void shouldChangeModelsInAdapter() {
+        // Verify model is assigned to adapter after model source update
+
         AdapterDto adapterDto1 = createAdapterDto("1");
         adapterFacade.createAdapter(adapterDto1);
 
@@ -184,7 +186,6 @@ public abstract class AdapterFunctionalTest {
         AdapterDto actualAdapter1 = adapterFacade.getAdapter(adapterDto1.getName());
         ModelDto actualModel1 = modelFacade.getModel(model1.getName());
 
-        // verify adapter and model
         AdapterDto expectedAdapter1 = createAdapterDto("1");
         expectedAdapter1.setModels(List.of("model1"));
         Assertions.assertEquals(expectedAdapter1, actualAdapter1);
@@ -196,9 +197,34 @@ public abstract class AdapterFunctionalTest {
         expectedModel1.setDefaultRoleLimit(new LimitDto());
         Assertions.assertEquals(expectedModel1, actualModel1);
 
-        // remove model from adapter
+        // Cleanup by removing model from adapter
         adapterDto1.setModels(List.of());
 
+        // Verify model is assigned to adapter and model source is updated after adapter update
+        ModelDto detachedModel = createModelDto("3");
+        modelFacade.createModel(detachedModel);
+
+        adapterDto1.setModels(List.of(detachedModel.getName()));
+        adapterFacade.updateAdapter(adapterDto1.getName(), adapterDto1, "*");
+
+        AdapterDto actualAdapterWithDetachedModel = adapterFacade.getAdapter(adapterDto1.getName());
+        ModelDto actualDetachedModel = modelFacade.getModel(detachedModel.getName());
+
+        AdapterDto expectedAdapter1WithDetachedModel = createAdapterDto("1");
+        expectedAdapter1WithDetachedModel.setModels(List.of("model3"));
+        Assertions.assertEquals(expectedAdapter1WithDetachedModel, actualAdapterWithDetachedModel);
+
+        ModelDto expectedDetachedModel = createModelDto("3");
+        expectedDetachedModel.setSource(new ModelAdapterSourceDto("adapter1", "model3/chat/completions"));
+        expectedDetachedModel.setDefaults(Map.of());
+        expectedDetachedModel.setRoleLimits(Map.of());
+        expectedDetachedModel.setDefaultRoleLimit(new LimitDto());
+        Assertions.assertEquals(expectedDetachedModel, actualDetachedModel);
+
+        // Cleanup by removing model from adapter
+        adapterDto1.setModels(List.of());
+
+        // Verify model is de-attached from adapter after adapter update
         adapterFacade.updateAdapter(adapterDto1.getName(), adapterDto1, "*");
         AdapterDto actualAdapter2 = adapterFacade.getAdapter(adapterDto1.getName());
         ModelDto actualModel2 = modelFacade.getModel(model1.getName());


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #702 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
On adapter update, if adapter.models have new entries, each model is indirectly updated to use that adapter. This process should also include value population for 'adapterCompletionEndpointPath' since it is required when model source is adapter.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.