### PR TITLE
fix: add code_verifier and code_challenge validation when empty code_challenge_method

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/normalizer/ResourceAuthSettingsNormalizer.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/normalizer/ResourceAuthSettingsNormalizer.java
@@ -20,15 +20,19 @@ public class ResourceAuthSettingsNormalizer {
 
     private void normalizePkceData(ResourceAuthSettings resourceAuthSettings) {
         String codeChallengeMethodStr = resourceAuthSettings.getCodeChallengeMethod();
-        if (StringUtils.isEmpty(codeChallengeMethodStr)) {
-            return;
-        }
 
         String codeVerifier = resourceAuthSettings.getCodeVerifier();
         String codeChallenge = resourceAuthSettings.getCodeChallenge();
 
         boolean hasVerifier = codeVerifier != null;
         boolean hasChallenge = codeChallenge != null;
+
+        if (StringUtils.isEmpty(codeChallengeMethodStr)) {
+            if (hasVerifier || hasChallenge) {
+                throw new IllegalArgumentException("Both code_verifier and code_challenge must not be provided when empty code_challenge_method");
+            }
+            return;
+        }
 
         // XOR condition: if one is present but not the other, it's an invalid state.
         if (hasVerifier ^ hasChallenge) {

--- a/src/test/java/com/epam/aidial/cfg/domain/normalizer/ResourceAuthSettingsNormalizerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/normalizer/ResourceAuthSettingsNormalizerTest.java
@@ -27,7 +27,7 @@ class ResourceAuthSettingsNormalizerTest {
 
     @ParameterizedTest
     @CsvSource(value = {"null", "''"}, nullValues = "null")
-    void normalize_shouldDoNothingWhenCodeChallengeMethodIsEmpty(String codeChallengeMethod) {
+    void normalize_shouldDoNothingWhenCodeChallengeMethodIsEmptyAndCodeVerifierAndCodeChallengeAreNotProvided(String codeChallengeMethod) {
         ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
         resourceAuthSettings.setCodeChallengeMethod(codeChallengeMethod);
 
@@ -35,6 +35,30 @@ class ResourceAuthSettingsNormalizerTest {
 
         Assertions.assertThat(resourceAuthSettings.getCodeVerifier()).isNull();
         Assertions.assertThat(resourceAuthSettings.getCodeChallenge()).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''"}, nullValues = "null")
+    void normalize_shouldThrowExceptionWhenCodeChallengeMethodIsEmptyAndCodeVerifierIsProvided(String codeChallengeMethod) {
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setCodeChallengeMethod(codeChallengeMethod);
+        resourceAuthSettings.setCodeVerifier("43_characters_verifier_____________________");
+
+        assertThatThrownBy(() -> normalizer.normalize(resourceAuthSettings))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Both code_verifier and code_challenge must not be provided when empty code_challenge_method");
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''"}, nullValues = "null")
+    void normalize_shouldThrowExceptionWhenCodeChallengeMethodIsEmptyAndCodeChallengeIsProvided(String codeChallengeMethod) {
+        ResourceAuthSettings resourceAuthSettings = new ResourceAuthSettings();
+        resourceAuthSettings.setCodeChallengeMethod(codeChallengeMethod);
+        resourceAuthSettings.setCodeChallenge("code-challenge");
+
+        assertThatThrownBy(() -> normalizer.normalize(resourceAuthSettings))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Both code_verifier and code_challenge must not be provided when empty code_challenge_method");
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #718

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.