### PR TITLE
chore: bump com.fasterxml.jackson.core:jackson-core from 2.20.0 to 2.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,9 @@ dependencies {
         implementation ('org.springframework:spring-core:6.2.11') {
             because("previous versions have vulnerabilities")
         }
+        implementation ('com.fasterxml.jackson.core:jackson-core:2.21.1') {
+            because("previous versions have vulnerabilities")
+        }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.