### PR TITLE
fix: improve Influx3 query engine correctness and stability

### DIFF
--- a/src/main/java/com/epam/aidial/metric/service/AbstractQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/AbstractQueryBuilder.java
@@ -28,7 +28,7 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
     protected final Map<String, T> tableDeclarations;
     protected final AbstractDatasetConfiguration datasetConfiguration;
     protected final Map<Expression, String> expressionToOuterColumnNames = new HashMap<>();
-    protected final Map<String, Expression> aliasToExpression = new HashMap<>();
+    protected final Map<String, Expression> nameToExpression = new HashMap<>();
     protected final TemporalNameGenerator temporalNameGenerator;
 
     @SuppressWarnings("unchecked")
@@ -45,7 +45,6 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
         if (completable instanceof Query query) {
 
             resolveExpressionsToOuterColumnNames(query.getExpressions());
-            resolveAliases(query.getExpressions());
 
             if (isWindowColumnAggregationQuery(query)) {
                 return buildWindowColumnAggregationQuery(query);
@@ -99,7 +98,7 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
             return true;
         }
         if (expression instanceof Column column) {
-            var originalExpression = aliasToExpression.get(column.getName());
+            var originalExpression = nameToExpression.get(column.getName());
             return originalExpression instanceof GroupFunctionCall;
         }
         return false;
@@ -143,7 +142,7 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
         if (expression instanceof Alias alias) {
             return alias.getExpression();
         } else if (expression instanceof Column column) {
-            var aliasedExpression = aliasToExpression.get(column.getName());
+            var aliasedExpression = nameToExpression.get(column.getName());
             if (aliasedExpression instanceof GroupFunctionCall groupFunctionCall) {
                 return groupFunctionCall;
             }
@@ -230,13 +229,15 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
             if (expression instanceof Alias alias) {
                 expressionToOuterColumnNames.put(alias, alias.getName());
                 expressionToOuterColumnNames.put(alias.getExpression(), alias.getName());
+                nameToExpression.put(alias.getName(), alias.getExpression());
             } else if (expression instanceof Column column) {
-                var aliasedExpression = aliasToExpression.get(column.getName());
+                var aliasedExpression = nameToExpression.get(column.getName());
                 if (aliasedExpression instanceof GroupFunctionCall) {
                     expressionToOuterColumnNames.put(expression, getNewTemporaryName(TEMPORAL_COLUMN_NAME));
                 } else {
                     expressionToOuterColumnNames.put(expression, column.getName());
                 }
+                nameToExpression.put(column.getName(), expression);
             } else if (expression instanceof AggregationFunctionCall) {
                 expressionToOuterColumnNames.put(expression, getNewTemporaryName(TEMPORAL_COLUMN_NAME));
             } else if (expression instanceof GroupFunctionCall) {
@@ -247,12 +248,22 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
         }
     }
 
-    protected void resolveAliases(List<Expression> expressions) {
-        for (Expression expression : expressions) {
-            if (expression instanceof Alias alias) {
-                aliasToExpression.put(alias.getName(), alias.getExpression());
+    /**
+     * Resolves a sort/orderBy expression to its outer column name.
+     * First tries direct object lookup, then resolves by name through nameToExpression.
+     */
+    protected String resolveOrderByColumnName(Expression expression) {
+        var columnName = expressionToOuterColumnNames.get(expression);
+        if (columnName != null) {
+            return columnName;
+        }
+        if (expression instanceof Column column) {
+            var resolved = nameToExpression.get(column.getName());
+            if (resolved != null) {
+                return expressionToOuterColumnNames.get(resolved);
             }
         }
+        return null;
     }
 
     protected String getNewTemporaryName(String prefix) {

--- a/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
@@ -21,17 +21,21 @@ import com.epam.aidial.metric.model.influx.FluxQueryContext;
 import com.epam.aidial.metric.model.influx.FluxQueryPart;
 import com.epam.aidial.metric.service.AbstractQueryBuilder;
 import com.epam.aidial.metric.util.CollectorsUtils;
+import com.epam.aidial.ql.common.model.enums.SortDirection;
 import com.epam.aidial.ql.model.Filter;
 import com.epam.aidial.ql.model.From;
 import com.epam.aidial.ql.model.Query;
+import com.epam.aidial.ql.model.Sort;
 import com.epam.aidial.ql.model.Table;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
@@ -63,7 +67,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         var keepPart = createKeepPart(query.getFrom(), query.getExpressions());
         var renamePart = createRenamePart(query.getFrom(), query.getExpressions());
         var ungroupPart = SimpleFluxBuilder.createUngroupPart();
-        var sortPart = SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames);
+        var sortPart = buildSortPart(query.getOrderBy());
         var limitPart = SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize());
 
         var queryPartsCombined = new InfluxQueryPartCombiner()
@@ -116,7 +120,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         var ungroupPart = SimpleFluxBuilder.createUngroupPart();
         var distinctPart = SimpleFluxBuilder.createDistinctPart(tagName);
         var renamePart = SimpleFluxBuilder.createRenamePart(Map.of(VALUE_COLUMN, outerColumnName));
-        var sortPart = SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames);
+        var sortPart = buildSortPart(query.getOrderBy());
         var limitPart = SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize());
 
         var queryPartsCombined = new InfluxQueryPartCombiner()
@@ -151,7 +155,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         var distinctPart = SimpleFluxBuilder.createDistinctPart(VALUE_COLUMN);
         var keepPart = SimpleFluxBuilder.createKeepPart(List.of(outerColumnName));
         var renamePart = SimpleFluxBuilder.createRenamePart(Map.of(VALUE_COLUMN, outerColumnName));
-        var sortPart = SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames);
+        var sortPart = buildSortPart(query.getOrderBy());
         var limitPart = SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize());
 
         var queryPartsCombined = new InfluxQueryPartCombiner()
@@ -260,7 +264,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
 
         combiner.add(SimpleFluxBuilder.createUngroupPart());
         combiner.add(createRenamePart(query.getFrom(), query.getExpressions()));
-        combiner.add(SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames));
+        combiner.add(buildSortPart(query.getOrderBy()));
         combiner.add(SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize()));
         var combined = combiner.build();
 
@@ -297,7 +301,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
                 TIME_COLUMN, expressionToOuterColumnNames.get(groupFunctionCall),
                 VALUE_COLUMN, expressionToOuterColumnNames.get(aggregationFunctionCall)
         ));
-        var sortPart = SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames);
+        var sortPart = buildSortPart(query.getOrderBy());
         var limitPart = SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize());
 
         var queryPartsCombined = new InfluxQueryPartCombiner()
@@ -380,7 +384,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         }
 
         combiner.add(SimpleFluxBuilder.createUngroupPart());
-        combiner.add(SimpleFluxBuilder.createSortPart(query.getOrderBy(), expressionToOuterColumnNames));
+        combiner.add(buildSortPart(query.getOrderBy()));
         combiner.add(SimpleFluxBuilder.createLimitPart(query, datasetConfiguration.getDefaultPageSize()));
         var combined = combiner.build();
 
@@ -393,6 +397,28 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
                 .query(combined.getQuery())
                 .columnNames(columnNames)
                 .build();
+    }
+
+    private String buildSortPart(List<Sort> orderBy) {
+        if (CollectionUtils.isEmpty(orderBy)) {
+            return "";
+        }
+
+        var direction = orderBy.stream().map(Sort::getDirection).distinct()
+                .collect(CollectorsUtils.toSingleton(() -> new IllegalArgumentException("Only one sort direction is allowed")))
+                .orElseThrow();
+
+        var columnNames = orderBy.stream()
+                .map(sort -> resolveOrderByColumnName(sort.getExpression()))
+                .toList();
+
+        var noMapping = columnNames.stream().anyMatch(Objects::isNull);
+        if (noMapping) {
+            throw new NotImplementedException("Only sort for specified columns is supported");
+        }
+
+        var desc = direction == SortDirection.DESC;
+        return SimpleFluxBuilder.createSortPart(columnNames, desc);
     }
 
     private FluxQueryPart buildWindowColumnAggregationPart(

--- a/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
@@ -2,6 +2,7 @@ package com.epam.aidial.metric.service.influx;
 
 
 import com.epam.aidial.expressions.AggregationFunctionCall;
+import com.epam.aidial.expressions.Column;
 import com.epam.aidial.expressions.Constant;
 import com.epam.aidial.expressions.Expression;
 import com.epam.aidial.expressions.GroupFunctionCall;
@@ -59,7 +60,7 @@ public class SimpleFluxBuilder {
                 .orElseThrow();
 
         var columnNames = orderBy.stream().map(Sort::getExpression)
-                .map(expression2ColumnNames::get)
+                .map(expression -> resolveColumnName(expression, expression2ColumnNames))
                 .toList();
 
         var noMapping = columnNames.stream().anyMatch(Objects::isNull);
@@ -125,7 +126,7 @@ public class SimpleFluxBuilder {
 
         var functionName = aggregationFunctionCall.getFunction().getName();
 
-        return "|> aggregateWindow(every: %s, fn: %s, createEmpty: false)".formatted(duration, functionName);
+        return "|> aggregateWindow(every: %s, fn: %s, createEmpty: false, timeSrc: \"_start\")".formatted(duration, functionName);
     }
 
     public static String createWindowPart(GroupFunctionCall groupFunctionCall) {
@@ -166,6 +167,20 @@ public class SimpleFluxBuilder {
 
     public static String quote(String value) {
         return "\"" + value + "\"";
+    }
+
+    private static String resolveColumnName(Expression expression, Map<Expression, String> expression2ColumnNames) {
+        var columnName = expression2ColumnNames.get(expression);
+        if (columnName != null) {
+            return columnName;
+        }
+        // Fallback: sort expressions referencing aliases by name
+        if (expression instanceof Column column) {
+            if (expression2ColumnNames.containsValue(column.getName())) {
+                return column.getName();
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
@@ -98,14 +98,21 @@ public class SimpleFluxBuilder {
 
         var functionName = aggregationFunctionCall.getFunction().getName();
 
-        return "|> aggregateWindow(every: %s, fn: %s, createEmpty: false, timeSrc: \"_start\")".formatted(duration, functionName);
+        return "|> aggregateWindow(every: %s, fn: %s, createEmpty: false, timeSrc: \"_start\")\n".formatted(duration, functionName)
+                + createTruncateMapPart("_time", duration);
     }
 
     public static String createWindowPart(GroupFunctionCall groupFunctionCall) {
         var value = ((NumberConstant) groupFunctionCall.getArgs().get(1)).getNumberValue();
         var unit = (String) ((Constant) groupFunctionCall.getArgs().get(2)).getValue();
         var duration = createDuration(value, unit);
-        return "|> window(every: %s)".formatted(duration);
+        return "|> window(every: %s)\n".formatted(duration)
+                + createTruncateMapPart("_start", duration);
+    }
+
+    private static String createTruncateMapPart(String column, String duration) {
+        return "|> map(fn: (r) => ({r with %s: time(v: int(v: r.%s) - int(v: r.%s) %% int(v: %s))}))".formatted(
+                column, column, column, duration);
     }
 
     public static String createSetPart(String columnName, String value) {

--- a/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
@@ -2,21 +2,15 @@ package com.epam.aidial.metric.service.influx;
 
 
 import com.epam.aidial.expressions.AggregationFunctionCall;
-import com.epam.aidial.expressions.Column;
 import com.epam.aidial.expressions.Constant;
-import com.epam.aidial.expressions.Expression;
 import com.epam.aidial.expressions.GroupFunctionCall;
 import com.epam.aidial.expressions.NumberConstant;
 import com.epam.aidial.metric.model.influx.FluxQueryPart;
 import com.epam.aidial.metric.model.influx.FluxStandardImports;
-import com.epam.aidial.metric.util.CollectorsUtils;
-import com.epam.aidial.ql.common.model.enums.SortDirection;
 import com.epam.aidial.ql.model.Query;
-import com.epam.aidial.ql.model.Sort;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.List;
 import java.util.Map;
@@ -50,29 +44,7 @@ public class SimpleFluxBuilder {
         return "|> group(columns: %s)".formatted(compactWithQuoting(columnNames));
     }
 
-    public static String createSortPart(List<Sort> orderBy, Map<Expression, String> expression2ColumnNames) {
-        if (CollectionUtils.isEmpty(orderBy)) {
-            return "";
-        }
-
-        var direction = orderBy.stream().map(Sort::getDirection).distinct()
-                .collect(CollectorsUtils.toSingleton(() -> new IllegalArgumentException("Only one sort direction is allowed")))
-                .orElseThrow();
-
-        var columnNames = orderBy.stream().map(Sort::getExpression)
-                .map(expression -> resolveColumnName(expression, expression2ColumnNames))
-                .toList();
-
-        var noMapping = columnNames.stream().anyMatch(Objects::isNull);
-        if (noMapping) {
-            throw new NotImplementedException("Only sort for specified columns is supported");
-        }
-
-        var desc = direction == SortDirection.DESC;
-        return SimpleFluxBuilder.createSortPart(columnNames, desc);
-    }
-
-    private static String createSortPart(List<String> columnNames, boolean desc) {
+    public static String createSortPart(List<String> columnNames, boolean desc) {
         if (CollectionUtils.isEmpty(columnNames)) {
             return "";
         }
@@ -167,20 +139,6 @@ public class SimpleFluxBuilder {
 
     public static String quote(String value) {
         return "\"" + value + "\"";
-    }
-
-    private static String resolveColumnName(Expression expression, Map<Expression, String> expression2ColumnNames) {
-        var columnName = expression2ColumnNames.get(expression);
-        if (columnName != null) {
-            return columnName;
-        }
-        // Fallback: sort expressions referencing aliases by name
-        if (expression instanceof Column column) {
-            if (expression2ColumnNames.containsValue(column.getName())) {
-                return column.getName();
-            }
-        }
-        return null;
     }
 
 }

--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -9,7 +9,10 @@ import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.influxdb.v3.client.query.QueryType;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class Influx3Engine extends AbstractQueryEngine {
@@ -31,13 +34,13 @@ public class Influx3Engine extends AbstractQueryEngine {
         var queryContext = queryBuilderFactory.createQueryBuilder()
                 .buildQueryContext(completable);
 
-        var rows = new ArrayList<java.util.List<Object>>();
+        var rows = new ArrayList<List<Object>>();
         var options = new QueryOptions(influx3Declaration.getSource().getDatabase(), QueryType.SQL);
         try (Stream<Object[]> stream = client.query(queryContext.getQuery(), queryContext.getParameters(), options)) {
             stream.forEach(record -> {
                 var row = new ArrayList<>(queryContext.getColumnNames().size());
                 for (int i = 0; i < queryContext.getColumnNames().size(); i++) {
-                    row.add(i < record.length ? record[i] : null);
+                    row.add(i < record.length ? normalizeValue(record[i]) : null);
                 }
                 rows.add(row);
             });
@@ -47,5 +50,12 @@ public class Influx3Engine extends AbstractQueryEngine {
                 .expressions(completable.getExpressions())
                 .data(rows)
                 .build();
+    }
+
+    private Object normalizeValue(Object value) {
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime.toInstant(ZoneOffset.UTC);
+        }
+        return value;
     }
 }

--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -1,13 +1,17 @@
 package com.epam.aidial.metric.service.influx3;
 
+import com.epam.aidial.expressions.Expression;
+import com.epam.aidial.expressions.enums.Type;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DatasetDeclaration;
 import com.epam.aidial.metric.service.AbstractQueryEngine;
 import com.epam.aidial.ql.model.Completable;
 import com.epam.aidial.ql.model.Data;
+import com.epam.aidial.ql.model.Query;
 import com.epam.aidial.ql.model.impl.DataImpl;
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.influxdb.v3.client.query.QueryType;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -46,10 +50,54 @@ public class Influx3Engine extends AbstractQueryEngine {
             });
         }
 
+        if (rows.isEmpty() && isUngroupedAggregation(completable)) {
+            rows.add(buildDefaultAggregationRow(completable.getExpressions()));
+        } else if (rows.size() == 1 && isUngroupedAggregation(completable)) {
+            rows.set(0, normalizeAggregationRow(rows.get(0), completable.getExpressions()));
+        }
+
         return DataImpl.builder()
                 .expressions(completable.getExpressions())
                 .data(rows)
                 .build();
+    }
+
+    private boolean isUngroupedAggregation(Completable completable) {
+        if (!(completable instanceof Query query)) {
+            return false;
+        }
+        if (!CollectionUtils.isEmpty(query.getGroupBy())) {
+            return false;
+        }
+        return query.getExpressions().stream().anyMatch(Expression::isAggregation);
+    }
+
+    private List<Object> normalizeAggregationRow(List<Object> row, List<Expression> expressions) {
+        var normalized = new ArrayList<>(row.size());
+        for (int i = 0; i < expressions.size(); i++) {
+            var value = i < row.size() ? row.get(i) : null;
+            if (value == null && expressions.get(i).isAggregation()) {
+                normalized.add(defaultForType(expressions.get(i).getType()));
+            } else {
+                normalized.add(value);
+            }
+        }
+        return normalized;
+    }
+
+    private List<Object> buildDefaultAggregationRow(List<Expression> expressions) {
+        var row = new ArrayList<>();
+        for (var expression : expressions) {
+            row.add(expression.isAggregation() ? defaultForType(expression.getType()) : null);
+        }
+        return row;
+    }
+
+    private Object defaultForType(Type type) {
+        return switch (type) {
+            case FLOAT, DOUBLE -> 0.0;
+            default -> 0L;
+        };
     }
 
     private Object normalizeValue(Object value) {

--- a/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
@@ -484,24 +484,6 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
                 .collect(Collectors.joining(", "));
     }
 
-    private String resolveOrderByColumnName(Expression expression) {
-        // Direct lookup by object identity
-        var columnName = expressionToOuterColumnNames.get(expression);
-        if (columnName != null) {
-            return columnName;
-        }
-
-        // Fallback: lookup by column name (for sort expressions referencing aliases/columns)
-        if (expression instanceof Column column) {
-            // Check if it matches an outer column name directly
-            if (expressionToOuterColumnNames.containsValue(column.getName())) {
-                return column.getName();
-            }
-        }
-
-        return null;
-    }
-
     private String buildLimitClause(Query query) {
         var limit = query.getLimit();
         var offset = query.getOffset();

--- a/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
@@ -226,6 +226,9 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
         var windowOuterName = expressionToOuterColumnNames.get(groupFunctionCall);
         var aggOuterName = expressionToOuterColumnNames.get(aggregationFunctionCall);
 
+        // Use a temp name in SQL to avoid colliding with InfluxDB's reserved "time" column
+        var windowSqlAlias = getNewTemporaryName(TEMPORAL_COLUMN_NAME);
+
         var paramCounter = new AtomicInteger(0);
         var allParams = new HashMap<String, Object>();
 
@@ -241,16 +244,16 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
 
         var sql = new StringBuilder();
         sql.append("SELECT ");
-        sql.append(windowExpr).append(" AS \"").append(windowOuterName).append("\"");
+        sql.append(windowExpr).append(" AS \"").append(windowSqlAlias).append("\"");
         sql.append(", ").append(aggSql).append(" AS \"").append(aggOuterName).append("\"");
         sql.append(" FROM \"").append(tableName).append("\"");
         if (!whereClause.isEmpty()) {
             sql.append(" WHERE ").append(whereClause);
         }
-        sql.append(" GROUP BY \"").append(windowOuterName).append("\"");
+        sql.append(" GROUP BY \"").append(windowSqlAlias).append("\"");
 
-        // Build ORDER BY
-        var orderByClause = buildOrderByClause(query.getOrderBy());
+        // Build ORDER BY — map user alias to SQL alias for the window column
+        var orderByClause = buildOrderByClause(query.getOrderBy(), Map.of(windowOuterName, windowSqlAlias));
         if (!orderByClause.isEmpty()) {
             sql.append(" ORDER BY ").append(orderByClause);
         }
@@ -276,7 +279,6 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
     protected SqlQueryContext buildWindowColumnAggregationQuery(Query query) {
         var groupFunctionCall = extractWindowFunction(query.getGroupBy());
         var groupByColumnNames = extractGroupByColumnNames(query.getGroupBy());
-        var aggregationFunctionCalls = resolveAggregationFunctionCalls(query.getExpressions());
 
         var table = getTable(query);
         var tableDeclaration = getTableDeclaration(table.getName());
@@ -291,7 +293,10 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
         // Build window expression
         var windowInterval = buildWindowInterval(groupFunctionCall);
         var windowExpr = "DATE_BIN(%s, \"time\", TIMESTAMP '1970-01-01T00:00:00Z')".formatted(windowInterval);
+
+        // Use a temp name in SQL to avoid colliding with InfluxDB's reserved "time" column
         var windowOuterName = expressionToOuterColumnNames.get(groupFunctionCall);
+        var windowSqlAlias = getNewTemporaryName(TEMPORAL_COLUMN_NAME);
 
         // Build SELECT — preserve expression order
         var selectParts = new ArrayList<String>();
@@ -299,7 +304,7 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
             var resolved = resolveAlias(expression);
             var outerName = expressionToOuterColumnNames.get(expression);
             if (resolved instanceof com.epam.aidial.expressions.GroupFunctionCall) {
-                selectParts.add(windowExpr + " AS \"" + outerName + "\"");
+                selectParts.add(windowExpr + " AS \"" + windowSqlAlias + "\"");
             } else if (resolved instanceof AggregationFunctionCall aggCall) {
                 var function = (FunctionImpl) aggCall.getFunction();
                 var aggSql = buildAggregationExpression(function, aggCall.getArgs(), paramCounter, allParams);
@@ -311,7 +316,7 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
 
         // Build GROUP BY: window alias + column names
         var groupByParts = new ArrayList<String>();
-        groupByParts.add("\"" + windowOuterName + "\"");
+        groupByParts.add("\"" + windowSqlAlias + "\"");
         for (var colName : groupByColumnNames) {
             groupByParts.add("\"" + colName + "\"");
         }
@@ -324,8 +329,8 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
         }
         sql.append(" GROUP BY ").append(String.join(", ", groupByParts));
 
-        // Build ORDER BY
-        var orderByClause = buildOrderByClause(query.getOrderBy());
+        // Build ORDER BY — map user alias to SQL alias for the window column
+        var orderByClause = buildOrderByClause(query.getOrderBy(), Map.of(windowOuterName, windowSqlAlias));
         if (!orderByClause.isEmpty()) {
             sql.append(" ORDER BY ").append(orderByClause);
         }
@@ -458,6 +463,10 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
     }
 
     private String buildOrderByClause(List<Sort> orderBy) {
+        return buildOrderByClause(orderBy, Map.of());
+    }
+
+    private String buildOrderByClause(List<Sort> orderBy, Map<String, String> sqlAliasOverrides) {
         if (CollectionUtils.isEmpty(orderBy)) {
             return "";
         }
@@ -468,6 +477,7 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
                     if (columnName == null) {
                         throw new NotImplementedException("Only sort for specified columns is supported");
                     }
+                    columnName = sqlAliasOverrides.getOrDefault(columnName, columnName);
                     var direction = sort.getDirection() == SortDirection.DESC ? " DESC" : " ASC";
                     return "\"" + columnName + "\"" + direction;
                 })

--- a/src/main/java/com/epam/aidial/metric/web/controller/MetricController.java
+++ b/src/main/java/com/epam/aidial/metric/web/controller/MetricController.java
@@ -162,7 +162,7 @@ public class MetricController {
     private DataDto toDataDto(Data data) {
         var headers = getHeaders(data.getExpressions());
         var stringifiedData = data.getData().stream()
-                .map(list -> list.stream().map(Objects::toString).toList())
+                .map(list -> list.stream().map(v -> v == null ? null : Objects.toString(v)).toList())
                 .toList();
         return DataDto.builder()
                 .headers(headers)

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -901,6 +901,42 @@ public abstract class AbstractInfluxContainerTest {
         }
 
         @Test
+        void sumWithNoMatchingFilter() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["sum(deployment_price) as total"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "deployment", "right": "'nonexistent'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("total");
+            assertThat(data.getData()).containsExactly(List.of(0.0));
+        }
+
+        @Test
+        void multipleAggregationsWithNoMatchingFilter() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt", "sum(deployment_price) as money", "sum(prompt_tokens) as tokens"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "deployment", "right": "'nonexistent'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt", "money", "tokens");
+            assertThat(data.getData()).containsExactly(List.of(0L, 0.0, 0L));
+        }
+
+        @Test
         void expressionAliasesPreserved() throws Exception {
             var data = queryFromJson("""
                     {

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -405,22 +404,11 @@ public abstract class AbstractInfluxContainerTest {
                     }""".formatted(TIME_FILTER));
 
             assertThat(columnNames(data)).containsExactly("time", "deployment", "requests");
-            assertThat(data.getData()).hasSize(4)
-                    .allSatisfy(row -> {
-                        assertThat(row.get(0)).isInstanceOf(Instant.class);
-                        assertThat(row.get(2)).isEqualTo(1L);
-                    });
-
-            // Truncate to days: both engines agree at day granularity for 1-day windows
-            // (Flux clips first window to range start, SQL aligns to epoch)
-            var rows = data.getData().stream()
-                    .map(row -> List.of(((Instant) row.get(0)).truncatedTo(ChronoUnit.DAYS), row.get(1)))
-                    .toList();
-            assertThat(rows).containsExactlyInAnyOrder(
-                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4"),
-                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4"),
-                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5"),
-                    List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-3.5")
+            assertThat(data.getData()).containsExactlyInAnyOrder(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4", 1L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4", 1L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5", 1L),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-3.5", 1L)
             );
         }
 

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -36,16 +38,16 @@ public abstract class AbstractInfluxContainerTest {
     private static final List<String> MCP_RECORDS_NO_PROJECT = List.of(
             // INSIDE #1: 2026-03-11T14:00:00Z
             "mcp_analytics,deployment=gpt-4,mcp_method=tools/call "
-                    + "execution_path=\"path1\",chat_id=\"chat1\",user_hash=\"user1\" "
-                    + "1773237600000000000",
+            + "execution_path=\"path1\",chat_id=\"chat1\",user_hash=\"user1\" "
+            + "1773237600000000000",
             // INSIDE #2: 2026-03-12T10:00:00Z
             "mcp_analytics,deployment=gpt-4,mcp_method=tools/list "
-                    + "execution_path=\"path2\",chat_id=\"chat2\",user_hash=\"user2\" "
-                    + "1773309600000000000",
+            + "execution_path=\"path2\",chat_id=\"chat2\",user_hash=\"user2\" "
+            + "1773309600000000000",
             // INSIDE #3: 2026-03-12T18:00:00Z
             "mcp_analytics,deployment=gpt-3.5,mcp_method=tools/call "
-                    + "execution_path=\"path3\",chat_id=\"chat3\",user_hash=\"user1\" "
-                    + "1773338400000000000"
+            + "execution_path=\"path3\",chat_id=\"chat3\",user_hash=\"user1\" "
+            + "1773338400000000000"
     );
 
     // mcp_analytics records WITH project_id tag — enables per-project aggregation.
@@ -53,20 +55,20 @@ public abstract class AbstractInfluxContainerTest {
     private static final List<String> MCP_RECORDS_WITH_PROJECT = List.of(
             // INSIDE #4: 2026-03-11T15:00:00Z
             "mcp_analytics,deployment=gpt-4,mcp_method=tools/call,project_id=proj1 "
-                    + "execution_path=\"path4\",chat_id=\"chat4\",user_hash=\"user1\" "
-                    + "1773241200000000000",
+            + "execution_path=\"path4\",chat_id=\"chat4\",user_hash=\"user1\" "
+            + "1773241200000000000",
             // INSIDE #5: 2026-03-12T11:00:00Z
             "mcp_analytics,deployment=gpt-3.5,mcp_method=tools/list,project_id=proj1 "
-                    + "execution_path=\"path5\",chat_id=\"chat5\",user_hash=\"user2\" "
-                    + "1773313200000000000",
+            + "execution_path=\"path5\",chat_id=\"chat5\",user_hash=\"user2\" "
+            + "1773313200000000000",
             // INSIDE #6: 2026-03-12T15:00:00Z
             "mcp_analytics,deployment=gpt-4,mcp_method=tools/call,project_id=proj2 "
-                    + "execution_path=\"path6\",chat_id=\"chat6\",user_hash=\"user1\" "
-                    + "1773327600000000000",
+            + "execution_path=\"path6\",chat_id=\"chat6\",user_hash=\"user1\" "
+            + "1773327600000000000",
             // INSIDE #7: 2026-03-13T09:00:00Z
             "mcp_analytics,deployment=gpt-3.5,mcp_method=tools/call,project_id=proj2 "
-                    + "execution_path=\"path7\",chat_id=\"chat7\",user_hash=\"user2\" "
-                    + "1773392400000000000"
+            + "execution_path=\"path7\",chat_id=\"chat7\",user_hash=\"user2\" "
+            + "1773392400000000000"
     );
 
     // Time range: [2026-03-11T13:33:38.680Z, 2026-03-13T13:33:38.680Z)
@@ -74,34 +76,34 @@ public abstract class AbstractInfluxContainerTest {
     private static final List<String> ANALYTICS_RECORDS = List.of(
             // OUTSIDE (before range): 2026-03-10T12:00:00Z
             "analytics,deployment=gpt-4,model=gpt-4,project_id=proj1 "
-                    + "user_hash=\"user1\",price=0.08,deployment_price=0.07,"
-                    + "prompt_tokens=300i,completion_tokens=100i "
-                    + "1773144000000000000",
+            + "user_hash=\"user1\",price=0.08,deployment_price=0.07,"
+            + "prompt_tokens=300i,completion_tokens=100i "
+            + "1773144000000000000",
             // INSIDE #1: 2026-03-11T14:00:00Z
             "analytics,deployment=gpt-4,model=gpt-4,project_id=proj1 "
-                    + "user_hash=\"user1\",price=0.05,deployment_price=0.04,"
-                    + "prompt_tokens=200i,completion_tokens=80i "
-                    + "1773237600000000000",
+            + "user_hash=\"user1\",price=0.05,deployment_price=0.04,"
+            + "prompt_tokens=200i,completion_tokens=80i "
+            + "1773237600000000000",
             // INSIDE #2: 2026-03-12T10:00:00Z
             "analytics,deployment=gpt-4,model=gpt-4,project_id=proj2 "
-                    + "user_hash=\"user2\",price=0.10,deployment_price=0.09,"
-                    + "prompt_tokens=100i,completion_tokens=50i "
-                    + "1773309600000000000",
+            + "user_hash=\"user2\",price=0.10,deployment_price=0.09,"
+            + "prompt_tokens=100i,completion_tokens=50i "
+            + "1773309600000000000",
             // INSIDE #3: 2026-03-12T18:00:00Z
             "analytics,deployment=gpt-3.5,model=gpt-3.5,project_id=proj1 "
-                    + "user_hash=\"user1\",price=0.02,deployment_price=0.01,"
-                    + "prompt_tokens=50i,completion_tokens=30i "
-                    + "1773338400000000000",
+            + "user_hash=\"user1\",price=0.02,deployment_price=0.01,"
+            + "prompt_tokens=50i,completion_tokens=30i "
+            + "1773338400000000000",
             // INSIDE #4: 2026-03-13T10:00:00Z
             "analytics,deployment=gpt-3.5,model=gpt-3.5,project_id=proj2 "
-                    + "user_hash=\"user2\",price=0.03,deployment_price=0.05,"
-                    + "prompt_tokens=150i,completion_tokens=60i "
-                    + "1773396000000000000",
+            + "user_hash=\"user2\",price=0.03,deployment_price=0.05,"
+            + "prompt_tokens=150i,completion_tokens=60i "
+            + "1773396000000000000",
             // OUTSIDE (after range): 2026-03-13T14:00:00Z
             "analytics,deployment=gpt-4,model=gpt-4,project_id=proj1 "
-                    + "user_hash=\"user3\",price=0.15,deployment_price=0.12,"
-                    + "prompt_tokens=400i,completion_tokens=200i "
-                    + "1773410400000000000"
+            + "user_hash=\"user3\",price=0.15,deployment_price=0.12,"
+            + "prompt_tokens=400i,completion_tokens=200i "
+            + "1773410400000000000"
     );
 
     protected static final List<String> TEST_RECORDS;
@@ -148,12 +150,17 @@ public abstract class AbstractInfluxContainerTest {
                       "expressions": ["window(_time, 1, 'm') as time", "count() as requests"],
                       "from": "analytics",
                       "groupBy": ["window(_time, 1, 'm')"],
-                      "where": {%s}
+                      "where": {%s},
+                      "orderBy": [{"$asc": "time"}]
                     }""".formatted(TIME_FILTER));
 
             assertThat(columnNames(data)).containsExactly("time", "requests");
-            assertThat(data.getData()).hasSize(4)
-                    .allSatisfy(row -> assertThat(row.get(1)).isEqualTo(1L));
+            assertThat(data.getData()).containsExactly(
+                    List.of(Instant.parse("2026-03-11T14:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T10:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T18:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-13T10:00:00Z"), 1L)
+            );
         }
 
         @Test
@@ -399,7 +406,22 @@ public abstract class AbstractInfluxContainerTest {
 
             assertThat(columnNames(data)).containsExactly("time", "deployment", "requests");
             assertThat(data.getData()).hasSize(4)
-                    .allSatisfy(row -> assertThat(row.get(2)).isEqualTo(1L));
+                    .allSatisfy(row -> {
+                        assertThat(row.get(0)).isInstanceOf(Instant.class);
+                        assertThat(row.get(2)).isEqualTo(1L);
+                    });
+
+            // Truncate to days: both engines agree at day granularity for 1-day windows
+            // (Flux clips first window to range start, SQL aligns to epoch)
+            var rows = data.getData().stream()
+                    .map(row -> List.of(((Instant) row.get(0)).truncatedTo(ChronoUnit.DAYS), row.get(1)))
+                    .toList();
+            assertThat(rows).containsExactlyInAnyOrder(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4"),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4"),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5"),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-3.5")
+            );
         }
 
     }

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
@@ -919,7 +919,8 @@ class FluxQueryBuilderTest {
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group()
-                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false)
+                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false, timeSrc: "_start")
+                |> map(fn: (r) => ({r with _time: time(v: int(v: r._time) - int(v: r._time) % int(v: 10m))}))
                 |> rename(columns: {_time: "temp_column_0", _value: "temp_column_1"})""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("temp_column_0", "temp_column_1"));
     }
@@ -977,7 +978,8 @@ class FluxQueryBuilderTest {
                 |> filter(fn: (r) => r["deployment"] == "dep_value")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group()
-                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false)
+                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false, timeSrc: "_start")
+                |> map(fn: (r) => ({r with _time: time(v: int(v: r._time) - int(v: r._time) % int(v: 10m))}))
                 |> rename(columns: {_time: "temp_column_0", _value: "temp_column_1"})""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("temp_column_0", "temp_column_1"));
     }
@@ -1036,7 +1038,8 @@ class FluxQueryBuilderTest {
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group()
-                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false)
+                |> aggregateWindow(every: 10m, fn: sum, createEmpty: false, timeSrc: "_start")
+                |> map(fn: (r) => ({r with _time: time(v: int(v: r._time) - int(v: r._time) % int(v: 10m))}))
                 |> rename(columns: {_time: "a", _value: "b"})""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("a", "b"));
     }
@@ -1088,6 +1091,7 @@ class FluxQueryBuilderTest {
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group()
                 |> window(every: 10m)
+                |> map(fn: (r) => ({r with _start: time(v: int(v: r._start) - int(v: r._start) % int(v: 10m))}))
                 |> group(columns: ["_start", "_stop", "deployment"])
                 |> count(column: "_value")
                 |> keep(columns: ["_start", "deployment", "_value"])

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
@@ -663,7 +663,8 @@ class FluxQueryIntegrationTest {
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group()
-                |> aggregateWindow(every: 1h, fn: count, createEmpty: false)
+                |> aggregateWindow(every: 1h, fn: count, createEmpty: false, timeSrc: "_start")
+                |> map(fn: (r) => ({r with _time: time(v: int(v: r._time) - int(v: r._time) % int(v: 1h))}))
                 |> rename(columns: {_time: "time_window", _value: "total"})""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("time_window", "total"));
     }
@@ -686,7 +687,8 @@ class FluxQueryIntegrationTest {
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group()
-                |> aggregateWindow(every: 1h, fn: count, createEmpty: false)
+                |> aggregateWindow(every: 1h, fn: count, createEmpty: false, timeSrc: "_start")
+                |> map(fn: (r) => ({r with _time: time(v: int(v: r._time) - int(v: r._time) % int(v: 1h))}))
                 |> rename(columns: {_time: "time_window", _value: "total"})""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("time_window", "total"));
     }

--- a/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilderTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilderTest.java
@@ -239,12 +239,12 @@ class SqlQueryBuilderTest {
         var actual = sqlQueryBuilder.buildQueryContext(query);
 
         assertThat(actual.getQuery()).isEqualTo("""
-                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "window"\
+                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "temp_column_0"\
                 , COUNT(*) AS "total" \
                 FROM "analytics" \
                 WHERE "time" >= $p0 AND "time" < $p1 \
-                GROUP BY "window" \
-                ORDER BY "window" ASC""");
+                GROUP BY "temp_column_0" \
+                ORDER BY "temp_column_0" ASC""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("window", "total"));
     }
 
@@ -319,13 +319,13 @@ class SqlQueryBuilderTest {
         var actual = sqlQueryBuilder.buildQueryContext(query);
 
         assertThat(actual.getQuery()).isEqualTo("""
-                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "window"\
+                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "temp_column_0"\
                 , "deployment"\
                 , COUNT(*) AS "total" \
                 FROM "analytics" \
                 WHERE "time" >= $p0 AND "time" < $p1 \
-                GROUP BY "window", "deployment" \
-                ORDER BY "window" ASC""");
+                GROUP BY "temp_column_0", "deployment" \
+                ORDER BY "temp_column_0" ASC""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("window", "deployment", "total"));
     }
 
@@ -350,13 +350,13 @@ class SqlQueryBuilderTest {
         var actual = sqlQueryBuilder.buildQueryContext(query);
 
         assertThat(actual.getQuery()).isEqualTo("""
-                SELECT DATE_BIN(INTERVAL '1 day', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "window"\
+                SELECT DATE_BIN(INTERVAL '1 day', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "temp_column_0"\
                 , "deployment"\
                 , "project_id"\
                 , COUNT(*) AS "total" \
                 FROM "analytics" \
                 WHERE "time" >= $p0 AND "time" < $p1 \
-                GROUP BY "window", "deployment", "project_id\"""");
+                GROUP BY "temp_column_0", "deployment", "project_id\"""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("window", "deployment", "project_id", "total"));
     }
 

--- a/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryIntegrationTest.java
@@ -330,12 +330,12 @@ class SqlQueryIntegrationTest {
                 GROUP BY time_window ORDER BY time_window ASC""");
 
         assertThat(actual.getQuery()).isEqualTo("""
-                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "time_window"\
+                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "temp_column_0"\
                 , COUNT(*) AS "total" \
                 FROM "analytics" \
                 WHERE "time" >= $p0 AND "time" < $p1 \
-                GROUP BY "time_window" \
-                ORDER BY "time_window" ASC""");
+                GROUP BY "temp_column_0" \
+                ORDER BY "temp_column_0" ASC""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("time_window", "total"));
     }
 
@@ -350,12 +350,12 @@ class SqlQueryIntegrationTest {
         var actual = buildFromJson(queryDto);
 
         assertThat(actual.getQuery()).isEqualTo("""
-                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "time_window"\
+                SELECT DATE_BIN(INTERVAL '1 hour', "time", TIMESTAMP '1970-01-01T00:00:00Z') AS "temp_column_0"\
                 , COUNT(*) AS "total" \
                 FROM "analytics" \
                 WHERE "time" >= $p0 AND "time" < $p1 \
-                GROUP BY "time_window" \
-                ORDER BY "time_window" ASC""");
+                GROUP BY "temp_column_0" \
+                ORDER BY "temp_column_0" ASC""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("time_window", "total"));
     }
 


### PR DESCRIPTION
### Applicable issues

- fixes #744

### Description of changes

- **fix: time alias breaks window aggregation** — Window aggregation queries in Influx3 (SQL) now use a temporary column alias instead of the user-facing name (e.g. `time`), preventing collisions with InfluxDB's reserved `time` column that broke `GROUP BY` / `ORDER BY` clauses.
- **fix: preserve null values in JSON API response** — `MetricController.toDataDto` no longer stringifies `null` to `"null"`; actual `null` values are passed through to the JSON response.
- **fix: normalize ungrouped aggregation nulls to zeros in Influx3Engine** — When an ungrouped aggregation query returns no rows or rows with null aggregation values (e.g. `sum` over zero matching records), the engine now returns `0` / `0.0` instead of null or an empty result, matching Flux behavior.
- **chore: refactoring** — Moved sort-resolution logic (`resolveOrderByColumnName`) from `SqlQueryBuilder` up to `AbstractQueryBuilder` so both Flux and SQL builders share the same alias-aware resolution. Renamed `aliasToExpression` → `nameToExpression` and consolidated alias/column registration into `resolveExpressionsToOuterColumnNames`. `SimpleFluxBuilder.createSortPart` simplified to accept pre-resolved column names. `LocalDateTime` values from Influx3 are normalized to `Instant` (UTC).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.