### PR TITLE
feat: add gap-filling for window aggregation queries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -350,6 +350,7 @@ ai-dial-admin-backend/secrets-utils/generate_h2_secrets.sh can help to generate 
 |  | METRICS_STORAGE_ORG | dial | No | metrics.enabled=true and default influx2 config used | InfluxDB 2 organization with metrics |
 |  | METRICS_STORAGE_DATABASE | analytics-realtime | No | metrics.enabled=true and default influx3 config used | InfluxDB 3 database with metrics |
 |  | METRICS_STORAGE_TOKEN | - | Yes | metrics.enabled=true and default metrics config used | Token for InfluxDB database connection |
+| metrics.gap-filler.max-buckets | METRICS_GAP_FILLER_MAX_BUCKETS | 10000 | No | metrics.enabled=true | Maximum number of time buckets generated when gap-filling window queries. Prevents excessive memory usage for small intervals over large time ranges |
 
 metrics/telemetry functionality in admin panel reads data produced by https://github.com/epam/ai-dial-analytics-realtime.
 

--- a/query-language/src/main/java/com/epam/aidial/ql/Engine.java
+++ b/query-language/src/main/java/com/epam/aidial/ql/Engine.java
@@ -13,5 +13,5 @@ public interface Engine {
     String getName();
     FunctionsDatasource getFunctions();
     Map<String, Table> getTables();
-    Data getData(Completable completable);
+    Data getData(Completable completable, boolean fillGaps);
 }

--- a/src/main/java/com/epam/aidial/metric/component/Influx3EngineFactory.java
+++ b/src/main/java/com/epam/aidial/metric/component/Influx3EngineFactory.java
@@ -5,6 +5,7 @@ import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.TokenAuthorizationDeclaration;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DataSourceDeclaration;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DatasetDeclaration;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.metric.service.influx3.Influx3Engine;
 import com.epam.aidial.metric.service.influx3.SqlQueryBuilderFactory;
 import com.epam.aidial.ql.Engine;
@@ -19,9 +20,12 @@ import static org.springframework.beans.factory.config.ConfigurableBeanFactory.S
 public class Influx3EngineFactory implements EngineFactory {
 
     private final Influx3DatasetConfiguration datasetConfiguration;
+    private final WindowGapFiller windowGapFiller;
 
-    public Influx3EngineFactory(Influx3DatasetConfiguration datasetConfiguration) {
+    public Influx3EngineFactory(Influx3DatasetConfiguration datasetConfiguration,
+                                WindowGapFiller windowGapFiller) {
         this.datasetConfiguration = datasetConfiguration;
+        this.windowGapFiller = windowGapFiller;
     }
 
     @Override
@@ -35,7 +39,7 @@ public class Influx3EngineFactory implements EngineFactory {
         var influx3DbClient = createInflux3DbClient(influx3DatasetDeclaration.getSource());
         var builderFactory = new SqlQueryBuilderFactory(influx3DatasetDeclaration, datasetConfiguration);
 
-        return new Influx3Engine(influx3DatasetDeclaration, influx3DbClient, builderFactory);
+        return new Influx3Engine(influx3DatasetDeclaration, influx3DbClient, builderFactory, windowGapFiller);
     }
 
     private InfluxDBClient createInflux3DbClient(Influx3DataSourceDeclaration source) {

--- a/src/main/java/com/epam/aidial/metric/component/InfluxEngineFactory.java
+++ b/src/main/java/com/epam/aidial/metric/component/InfluxEngineFactory.java
@@ -5,6 +5,7 @@ import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.TokenAuthorizationDeclaration;
 import com.epam.aidial.metric.model.configuration.influx.InfluxDataSourceDeclaration;
 import com.epam.aidial.metric.model.configuration.influx.InfluxDatasetDeclaration;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.metric.service.influx.FluxQueryBuilder;
 import com.epam.aidial.metric.service.influx.FluxQueryBuilderFactory;
 import com.epam.aidial.metric.service.influx.InfluxEngine;
@@ -25,11 +26,14 @@ public class InfluxEngineFactory implements EngineFactory {
 
     private final OkHttpClient.Builder clientBuilder;
     private final InfluxDatasetConfiguration datasetConfiguration;
+    private final WindowGapFiller windowGapFiller;
 
     public InfluxEngineFactory(@Qualifier("influxOkHttpClientBuilder") OkHttpClient.Builder clientBuilder,
-                               InfluxDatasetConfiguration datasetConfiguration) {
+                               InfluxDatasetConfiguration datasetConfiguration,
+                               WindowGapFiller windowGapFiller) {
         this.clientBuilder = clientBuilder;
         this.datasetConfiguration = datasetConfiguration;
+        this.windowGapFiller = windowGapFiller;
     }
 
     @Override
@@ -43,7 +47,7 @@ public class InfluxEngineFactory implements EngineFactory {
         var influxDbClient = createInfluxDbClient(influxDatasetDeclaration.getSource());
         var builderFactory = createFluxQueryBuilderFactory(influxDatasetDeclaration);
 
-        return new InfluxEngine(influxDatasetDeclaration, influxDbClient, builderFactory);
+        return new InfluxEngine(influxDatasetDeclaration, influxDbClient, builderFactory, windowGapFiller);
     }
 
     private InfluxDBClient createInfluxDbClient(InfluxDataSourceDeclaration source) {

--- a/src/main/java/com/epam/aidial/metric/service/MetricService.java
+++ b/src/main/java/com/epam/aidial/metric/service/MetricService.java
@@ -53,12 +53,12 @@ public class MetricService {
         return null;
     }
 
-    public Data getData(String datasetName, CompletableDto completableDto) {
+    public Data getData(String datasetName, CompletableDto completableDto, boolean fillGaps) {
         var engine = getEngine(datasetName);
         var completable = languageConverters.get(datasetName)
                 .convert(completableDto, engine.getTables());
 
-        return getEngine(datasetName).getData(completable);
+        return engine.getData(completable, fillGaps);
     }
 
     private Engine getEngine(String datasetName) {

--- a/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
+++ b/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
@@ -9,7 +9,8 @@ import com.epam.aidial.expressions.NumberConstant;
 import com.epam.aidial.expressions.enums.Type;
 import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
 import com.epam.aidial.ql.model.Query;
-import lombok.experimental.UtilityClass;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -22,9 +23,16 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
-@UtilityClass
+@Service
 public class WindowGapFiller {
+
+    private final int maxBuckets;
+
+    public WindowGapFiller(@Value("${metrics.gap-filler.max-buckets:10000}") int maxBuckets) {
+        this.maxBuckets = maxBuckets;
+    }
 
     public static Object defaultForType(Type type) {
         return switch (type) {
@@ -40,7 +48,7 @@ public class WindowGapFiller {
         return extractWindowFunction(query.getGroupBy()) != null;
     }
 
-    public static List<List<Object>> fillGaps(List<List<Object>> rows, Query query) {
+    public List<List<Object>> fillGaps(List<List<Object>> rows, Query query) {
         var windowFunction = extractWindowFunction(query.getGroupBy());
         if (windowFunction == null) {
             return rows;
@@ -162,15 +170,24 @@ public class WindowGapFiller {
         return new Interval(value, unit);
     }
 
-    private static List<Instant> generateTimeBuckets(Instant start, Instant end, Interval interval) {
+    private List<Instant> generateTimeBuckets(Instant start, Instant end, Interval interval) {
         var firstBucket = alignToStart(start, interval);
         var step = toStepFunction(interval);
 
         var buckets = new ArrayList<Instant>();
         var current = firstBucket;
         while (current.toInstant().isBefore(end)) {
+            if (buckets.size() >= maxBuckets) {
+                throw new IllegalArgumentException(
+                        "Time range produces too many buckets (>%s). Use a larger interval or narrower time range."
+                                .formatted(maxBuckets));
+            }
             buckets.add(current.toInstant());
-            current = step.apply(current);
+            var next = step.apply(current);
+            if (!next.isAfter(current)) {
+                throw new IllegalStateException("Step function did not advance time; aborting to prevent infinite loop.");
+            }
+            current = next;
         }
         return buckets;
     }
@@ -191,7 +208,7 @@ public class WindowGapFiller {
         };
     }
 
-    private static java.util.function.UnaryOperator<ZonedDateTime> toStepFunction(Interval interval) {
+    private static UnaryOperator<ZonedDateTime> toStepFunction(Interval interval) {
         var value = interval.value();
         return switch (interval.unit().toLowerCase()) {
             case "s" -> b -> b.plusSeconds(value);

--- a/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
+++ b/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -122,13 +123,14 @@ public class WindowGapFiller {
         return switch (interval.unit().toLowerCase()) {
             case "y" -> startZoned.withMonth(1).withDayOfMonth(1).toLocalDate().atStartOfDay(ZoneOffset.UTC);
             case "mo" -> startZoned.withDayOfMonth(1).toLocalDate().atStartOfDay(ZoneOffset.UTC);
-            default -> {
-                // Fixed-duration units (s, m, h, d, w): align to epoch like DATE_BIN
+            case "s", "m", "h", "d", "w" -> {
+                // Fixed-duration units: align to epoch like DATE_BIN
                 var epochMillis = toDuration(interval).toMillis();
                 var startMillis = start.toEpochMilli();
                 var aligned = startMillis - Math.floorMod(startMillis, epochMillis);
                 yield Instant.ofEpochMilli(aligned).atZone(ZoneOffset.UTC);
             }
+            default -> throw new IllegalArgumentException("Unsupported interval unit: " + interval.unit());
         };
     }
 
@@ -157,6 +159,21 @@ public class WindowGapFiller {
         };
     }
 
+    /**
+     * Classifies each SELECT expression by its role in the result row:
+     * <ul>
+     *   <li>{@code timeIndex} — the window bucket timestamp (the {@link GroupFunctionCall}, currently always {@code window(...)})</li>
+     *   <li>{@code groupColumnIndices} — group-by key columns (e.g., {@code deployment})</li>
+     *   <li>{@code aggregationIndices} — aggregated value columns (e.g., {@code sum(tokens)})</li>
+     * </ul>
+     *
+     * <p>Group-by columns are identified by name because the parser creates separate {@link Expression}
+     * objects for the same column in SELECT and GROUP BY clauses, so reference equality cannot be used.
+     *
+     * <p>The returned {@link ColumnLayout} tells {@link #fillGaps} how to construct zero-filled rows
+     * for missing time buckets: where to place the timestamp, which positions to copy group key values
+     * into, and which positions get default zero values.
+     */
     private static ColumnLayout analyzeExpressions(List<Expression> expressions, List<Expression> groupBy) {
         // Collect non-window group-by column names so we can identify them among SELECT expressions
         var groupColumnNames = new LinkedHashSet<String>();
@@ -193,18 +210,31 @@ public class WindowGapFiller {
         return new ColumnLayout(timeIndex, groupColumnIndices, aggregationIndices);
     }
 
+    /**
+     * Produces a complete time-series grid by filling missing time buckets with zero-valued rows.
+     *
+     * <p>For each distinct group key (e.g., {@code ["gpt-4"]}, {@code ["gpt-4.5"]}) discovered in the
+     * actual data, ensures every time bucket has a corresponding row. Missing combinations get a
+     * zero-filled row built by {@link #buildDefaultRow}.
+     *
+     * <p>For window-only queries (no group-by columns), a single implicit group key is used, so the
+     * result is one row per bucket. For window+column queries with no data at all, returns empty
+     * because the set of group key values (e.g., which deployments exist) is unknown.
+     *
+     * <p>Example: {@code SELECT window(1h), deployment, sum(tokens)} over 3 buckets with 2 deployments
+     * produces a 6-row grid (3 buckets x 2 deployments), even if the DB only returned 4 rows.
+     */
     private static List<List<Object>> fillGaps(
             List<List<Object>> rows,
             List<Instant> buckets,
             List<Expression> expressions,
             ColumnLayout layout) {
 
-        // Window+column queries with no data: we can't fill gaps because the group key values
-        // (e.g., which deployments exist) are unknown — return empty
         if (rows.isEmpty() && !layout.groupColumnIndices().isEmpty()) {
             return rows;
         }
 
+        // Index existing rows by (groupKey, timestamp) for O(1) lookup
         var groupKeys = new LinkedHashSet<List<Object>>();
         var dataMap = new LinkedHashMap<List<Object>, Map<Instant, List<Object>>>();
 
@@ -216,10 +246,12 @@ public class WindowGapFiller {
             dataMap.computeIfAbsent(groupKey, k -> new LinkedHashMap<>()).put(time, row);
         }
 
+        // Window-only queries have no group columns — use a single empty key
         if (groupKeys.isEmpty()) {
             groupKeys.add(List.of());
         }
 
+        // Build the complete grid: for every (bucket, groupKey), use existing row or fill with zeros
         var result = new ArrayList<List<Object>>();
         for (var bucket : buckets) {
             for (var groupKey : groupKeys) {
@@ -243,16 +275,22 @@ public class WindowGapFiller {
         return key;
     }
 
+    /**
+     * Constructs a zero-filled row for a missing time bucket. Allocates a row of nulls matching
+     * the SELECT list size, then populates each position based on its role:
+     * <ol>
+     *   <li>Timestamp position → the bucket time</li>
+     *   <li>Group column positions → the group key values (e.g., {@code "gpt-4"})</li>
+     *   <li>Aggregation positions → type-appropriate zero ({@code 0L} for integers, {@code 0.0} for floats)</li>
+     * </ol>
+     */
     private static List<Object> buildDefaultRow(
             List<Expression> expressions,
             ColumnLayout layout,
             Instant bucketTime,
             List<Object> groupValues) {
 
-        var row = new ArrayList<>(expressions.size());
-        for (int i = 0; i < expressions.size(); i++) {
-            row.add(null);
-        }
+        var row = new ArrayList<>(Collections.nCopies(expressions.size(), (Object) null));
 
         row.set(layout.timeIndex(), bucketTime);
 

--- a/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
+++ b/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
@@ -61,6 +61,63 @@ public class WindowGapFiller {
         return fillGaps(rows, buckets, query.getExpressions(), layout);
     }
 
+    /**
+     * Produces a complete time-series grid by filling missing time buckets with zero-valued rows.
+     *
+     * <p>For each distinct group key (e.g., {@code ["gpt-4"]}, {@code ["gpt-4.5"]}) discovered in the
+     * actual data, ensures every time bucket has a corresponding row. Missing combinations get a
+     * zero-filled row built by {@link #buildDefaultRow}.
+     *
+     * <p>For window-only queries (no group-by columns), a single implicit group key is used, so the
+     * result is one row per bucket. For window+column queries with no data at all, returns empty
+     * because the set of group key values (e.g., which deployments exist) is unknown.
+     *
+     * <p>Example: {@code SELECT window(1h), deployment, sum(tokens)} over 3 buckets with 2 deployments
+     * produces a 6-row grid (3 buckets x 2 deployments), even if the DB only returned 4 rows.
+     */
+    private static List<List<Object>> fillGaps(
+            List<List<Object>> rows,
+            List<Instant> buckets,
+            List<Expression> expressions,
+            ColumnLayout layout) {
+
+        if (rows.isEmpty() && !layout.groupColumnIndices().isEmpty()) {
+            return rows;
+        }
+
+        // Index existing rows by (groupKey, timestamp) for O(1) lookup
+        var groupKeys = new LinkedHashSet<List<Object>>();
+        var dataMap = new LinkedHashMap<List<Object>, Map<Instant, List<Object>>>();
+
+        for (var row : rows) {
+            var groupKey = extractGroupKey(row, layout.groupColumnIndices());
+            groupKeys.add(groupKey);
+
+            var time = (Instant) row.get(layout.timeIndex());
+            dataMap.computeIfAbsent(groupKey, k -> new LinkedHashMap<>()).put(time, row);
+        }
+
+        // Window-only queries have no group columns — use a single empty key
+        if (groupKeys.isEmpty()) {
+            groupKeys.add(List.of());
+        }
+
+        // Build the complete grid: for every (bucket, groupKey), use existing row or fill with zeros
+        var result = new ArrayList<List<Object>>();
+        for (var bucket : buckets) {
+            for (var groupKey : groupKeys) {
+                var timeMap = dataMap.get(groupKey);
+                var existing = timeMap != null ? timeMap.get(bucket) : null;
+                if (existing != null) {
+                    result.add(existing);
+                } else {
+                    result.add(buildDefaultRow(expressions, layout, bucket, groupKey));
+                }
+            }
+        }
+        return result;
+    }
+
     record TimeRange(Instant start, Instant end) {}
 
     record Interval(long value, String unit) {}
@@ -210,63 +267,6 @@ public class WindowGapFiller {
         return new ColumnLayout(timeIndex, groupColumnIndices, aggregationIndices);
     }
 
-    /**
-     * Produces a complete time-series grid by filling missing time buckets with zero-valued rows.
-     *
-     * <p>For each distinct group key (e.g., {@code ["gpt-4"]}, {@code ["gpt-4.5"]}) discovered in the
-     * actual data, ensures every time bucket has a corresponding row. Missing combinations get a
-     * zero-filled row built by {@link #buildDefaultRow}.
-     *
-     * <p>For window-only queries (no group-by columns), a single implicit group key is used, so the
-     * result is one row per bucket. For window+column queries with no data at all, returns empty
-     * because the set of group key values (e.g., which deployments exist) is unknown.
-     *
-     * <p>Example: {@code SELECT window(1h), deployment, sum(tokens)} over 3 buckets with 2 deployments
-     * produces a 6-row grid (3 buckets x 2 deployments), even if the DB only returned 4 rows.
-     */
-    private static List<List<Object>> fillGaps(
-            List<List<Object>> rows,
-            List<Instant> buckets,
-            List<Expression> expressions,
-            ColumnLayout layout) {
-
-        if (rows.isEmpty() && !layout.groupColumnIndices().isEmpty()) {
-            return rows;
-        }
-
-        // Index existing rows by (groupKey, timestamp) for O(1) lookup
-        var groupKeys = new LinkedHashSet<List<Object>>();
-        var dataMap = new LinkedHashMap<List<Object>, Map<Instant, List<Object>>>();
-
-        for (var row : rows) {
-            var groupKey = extractGroupKey(row, layout.groupColumnIndices());
-            groupKeys.add(groupKey);
-
-            var time = (Instant) row.get(layout.timeIndex());
-            dataMap.computeIfAbsent(groupKey, k -> new LinkedHashMap<>()).put(time, row);
-        }
-
-        // Window-only queries have no group columns — use a single empty key
-        if (groupKeys.isEmpty()) {
-            groupKeys.add(List.of());
-        }
-
-        // Build the complete grid: for every (bucket, groupKey), use existing row or fill with zeros
-        var result = new ArrayList<List<Object>>();
-        for (var bucket : buckets) {
-            for (var groupKey : groupKeys) {
-                var timeMap = dataMap.get(groupKey);
-                var existing = timeMap != null ? timeMap.get(bucket) : null;
-                if (existing != null) {
-                    result.add(existing);
-                } else {
-                    result.add(buildDefaultRow(expressions, layout, bucket, groupKey));
-                }
-            }
-        }
-        return result;
-    }
-
     private static List<Object> extractGroupKey(List<Object> row, List<Integer> groupColumnIndices) {
         var key = new ArrayList<>(groupColumnIndices.size());
         for (var idx : groupColumnIndices) {
@@ -290,7 +290,7 @@ public class WindowGapFiller {
             Instant bucketTime,
             List<Object> groupValues) {
 
-        var row = new ArrayList<>(Collections.nCopies(expressions.size(), (Object) null));
+        var row = new ArrayList<>(Collections.nCopies(expressions.size(), null));
 
         row.set(layout.timeIndex(), bucketTime);
 

--- a/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
+++ b/src/main/java/com/epam/aidial/metric/service/WindowGapFiller.java
@@ -1,0 +1,269 @@
+package com.epam.aidial.metric.service;
+
+import com.epam.aidial.expressions.Alias;
+import com.epam.aidial.expressions.Column;
+import com.epam.aidial.expressions.Constant;
+import com.epam.aidial.expressions.Expression;
+import com.epam.aidial.expressions.GroupFunctionCall;
+import com.epam.aidial.expressions.NumberConstant;
+import com.epam.aidial.expressions.enums.Type;
+import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
+import com.epam.aidial.ql.model.Query;
+import lombok.experimental.UtilityClass;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@UtilityClass
+public class WindowGapFiller {
+
+    public static Object defaultForType(Type type) {
+        return switch (type) {
+            case FLOAT, DOUBLE -> 0.0;
+            default -> 0L;
+        };
+    }
+
+    public static boolean isWindowQuery(Query query) {
+        if (query.getGroupBy() == null || query.getGroupBy().isEmpty()) {
+            return false;
+        }
+        return extractWindowFunction(query.getGroupBy()) != null;
+    }
+
+    public static List<List<Object>> fillGaps(List<List<Object>> rows, Query query) {
+        var windowFunction = extractWindowFunction(query.getGroupBy());
+        if (windowFunction == null) {
+            return rows;
+        }
+
+        var timeRange = extractTimeRange(query);
+        if (timeRange.isEmpty()) {
+            return rows;
+        }
+
+        var interval = extractInterval(windowFunction);
+        var buckets = generateTimeBuckets(timeRange.get().start(), timeRange.get().end(), interval);
+        if (buckets.isEmpty()) {
+            return rows;
+        }
+
+        var layout = analyzeExpressions(query.getExpressions(), query.getGroupBy());
+        return fillGaps(rows, buckets, query.getExpressions(), layout);
+    }
+
+    record TimeRange(Instant start, Instant end) {}
+
+    record Interval(long value, String unit) {}
+
+    record ColumnLayout(int timeIndex, List<Integer> groupColumnIndices, List<Integer> aggregationIndices) {}
+
+    private static GroupFunctionCall extractWindowFunction(List<Expression> groupBy) {
+        return groupBy.stream()
+                .filter(GroupFunctionCall.class::isInstance)
+                .map(GroupFunctionCall.class::cast)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Optional<TimeRange> extractTimeRange(Query query) {
+        var rangeFilters = RangeFilterUtils.extractRangeFilter(query.getWhere());
+        if (rangeFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Instant start = null;
+        Instant end = null;
+
+        for (var filter : rangeFilters) {
+            if (filter.getOperator() == BinaryComparisonOperator.GREATER_OR_EQUALS) {
+                start = Instant.ofEpochMilli(RangeFilterUtils.getInstant(filter.getRightExpression()));
+            } else if (filter.getOperator() == BinaryComparisonOperator.LESS) {
+                end = Instant.ofEpochMilli(RangeFilterUtils.getInstant(filter.getRightExpression()));
+            }
+        }
+
+        if (start == null || end == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TimeRange(start, end));
+    }
+
+    private static Interval extractInterval(GroupFunctionCall windowFunction) {
+        var value = ((NumberConstant) windowFunction.getArgs().get(1)).getNumberValue().longValue();
+        var unit = (String) ((Constant) windowFunction.getArgs().get(2)).getValue();
+        return new Interval(value, unit);
+    }
+
+    private static List<Instant> generateTimeBuckets(Instant start, Instant end, Interval interval) {
+        var firstBucket = alignToStart(start, interval);
+        var step = toStepFunction(interval);
+
+        var buckets = new ArrayList<Instant>();
+        var current = firstBucket;
+        while (current.toInstant().isBefore(end)) {
+            buckets.add(current.toInstant());
+            current = step.apply(current);
+        }
+        return buckets;
+    }
+
+    private static ZonedDateTime alignToStart(Instant start, Interval interval) {
+        var startZoned = start.atZone(ZoneOffset.UTC);
+        return switch (interval.unit().toLowerCase()) {
+            case "y" -> startZoned.withMonth(1).withDayOfMonth(1).toLocalDate().atStartOfDay(ZoneOffset.UTC);
+            case "mo" -> startZoned.withDayOfMonth(1).toLocalDate().atStartOfDay(ZoneOffset.UTC);
+            default -> {
+                // Fixed-duration units (s, m, h, d, w): align to epoch like DATE_BIN
+                var epochMillis = toDuration(interval).toMillis();
+                var startMillis = start.toEpochMilli();
+                var aligned = startMillis - Math.floorMod(startMillis, epochMillis);
+                yield Instant.ofEpochMilli(aligned).atZone(ZoneOffset.UTC);
+            }
+        };
+    }
+
+    private static java.util.function.UnaryOperator<ZonedDateTime> toStepFunction(Interval interval) {
+        var value = interval.value();
+        return switch (interval.unit().toLowerCase()) {
+            case "s" -> b -> b.plusSeconds(value);
+            case "m" -> b -> b.plusMinutes(value);
+            case "h" -> b -> b.plusHours(value);
+            case "d" -> b -> b.plusDays(value);
+            case "w" -> b -> b.plusWeeks(value);
+            case "mo" -> b -> b.plusMonths(value);
+            case "y" -> b -> b.plusYears(value);
+            default -> throw new IllegalArgumentException("Unsupported interval unit: " + interval.unit());
+        };
+    }
+
+    private static Duration toDuration(Interval interval) {
+        return switch (interval.unit().toLowerCase()) {
+            case "s" -> Duration.ofSeconds(interval.value());
+            case "m" -> Duration.ofMinutes(interval.value());
+            case "h" -> Duration.ofHours(interval.value());
+            case "d" -> Duration.ofDays(interval.value());
+            case "w" -> Duration.ofDays(interval.value() * 7);
+            default -> throw new IllegalArgumentException("Unsupported interval unit for duration: " + interval.unit());
+        };
+    }
+
+    private static ColumnLayout analyzeExpressions(List<Expression> expressions, List<Expression> groupBy) {
+        // Collect non-window group-by column names so we can identify them among SELECT expressions
+        var groupColumnNames = new LinkedHashSet<String>();
+        for (var expr : groupBy) {
+            if (expr instanceof Column col && !(expr instanceof GroupFunctionCall)) {
+                groupColumnNames.add(col.getName());
+            }
+        }
+
+        int timeIndex = 0;
+        var groupColumnIndices = new ArrayList<Integer>();
+        var aggregationIndices = new ArrayList<Integer>();
+
+        for (int i = 0; i < expressions.size(); i++) {
+            var expr = expressions.get(i);
+
+            if (expr instanceof GroupFunctionCall
+                    || (expr instanceof Alias alias && alias.getExpression() instanceof GroupFunctionCall)) {
+                timeIndex = i;
+                continue;
+            }
+
+            if (expr.isAggregation()) {
+                aggregationIndices.add(i);
+                continue;
+            }
+
+            // Alias extends Column, so this covers both plain columns and aliased columns
+            if (expr instanceof Column col && groupColumnNames.contains(col.getName())) {
+                groupColumnIndices.add(i);
+            }
+        }
+
+        return new ColumnLayout(timeIndex, groupColumnIndices, aggregationIndices);
+    }
+
+    private static List<List<Object>> fillGaps(
+            List<List<Object>> rows,
+            List<Instant> buckets,
+            List<Expression> expressions,
+            ColumnLayout layout) {
+
+        // Window+column queries with no data: we can't fill gaps because the group key values
+        // (e.g., which deployments exist) are unknown — return empty
+        if (rows.isEmpty() && !layout.groupColumnIndices().isEmpty()) {
+            return rows;
+        }
+
+        var groupKeys = new LinkedHashSet<List<Object>>();
+        var dataMap = new LinkedHashMap<List<Object>, Map<Instant, List<Object>>>();
+
+        for (var row : rows) {
+            var groupKey = extractGroupKey(row, layout.groupColumnIndices());
+            groupKeys.add(groupKey);
+
+            var time = (Instant) row.get(layout.timeIndex());
+            dataMap.computeIfAbsent(groupKey, k -> new LinkedHashMap<>()).put(time, row);
+        }
+
+        if (groupKeys.isEmpty()) {
+            groupKeys.add(List.of());
+        }
+
+        var result = new ArrayList<List<Object>>();
+        for (var bucket : buckets) {
+            for (var groupKey : groupKeys) {
+                var timeMap = dataMap.get(groupKey);
+                var existing = timeMap != null ? timeMap.get(bucket) : null;
+                if (existing != null) {
+                    result.add(existing);
+                } else {
+                    result.add(buildDefaultRow(expressions, layout, bucket, groupKey));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static List<Object> extractGroupKey(List<Object> row, List<Integer> groupColumnIndices) {
+        var key = new ArrayList<>(groupColumnIndices.size());
+        for (var idx : groupColumnIndices) {
+            key.add(row.get(idx));
+        }
+        return key;
+    }
+
+    private static List<Object> buildDefaultRow(
+            List<Expression> expressions,
+            ColumnLayout layout,
+            Instant bucketTime,
+            List<Object> groupValues) {
+
+        var row = new ArrayList<>(expressions.size());
+        for (int i = 0; i < expressions.size(); i++) {
+            row.add(null);
+        }
+
+        row.set(layout.timeIndex(), bucketTime);
+
+        for (int i = 0; i < layout.groupColumnIndices().size(); i++) {
+            row.set(layout.groupColumnIndices().get(i), groupValues.get(i));
+        }
+
+        for (var idx : layout.aggregationIndices()) {
+            row.set(idx, defaultForType(expressions.get(idx).getType()));
+        }
+
+        return row;
+    }
+}

--- a/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
@@ -29,7 +29,7 @@ public class InfluxEngine extends AbstractQueryEngine {
     }
 
     @Override
-    public Data getData(Completable completable) {
+    public Data getData(Completable completable, boolean fillGaps) {
         var queryContext = queryBuilderFactory.createQueryBuilder()
                 .buildQueryContext(completable);
         var tables = client.getQueryApi().query(queryContext.buildFullQuery());
@@ -39,7 +39,7 @@ public class InfluxEngine extends AbstractQueryEngine {
             rows.add(buildDefaultAggregationRow(completable.getExpressions()));
         }
 
-        if (completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
+        if (fillGaps && completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
             rows = new ArrayList<>(WindowGapFiller.fillGaps(rows, query));
         }
 

--- a/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
@@ -20,12 +20,14 @@ public class InfluxEngine extends AbstractQueryEngine {
 
     private final InfluxDBClient client;
     private final FluxQueryBuilderFactory queryBuilderFactory;
+    private final WindowGapFiller windowGapFiller;
 
     public InfluxEngine(InfluxDatasetDeclaration declaration, InfluxDBClient client,
-                        FluxQueryBuilderFactory queryBuilderFactory) {
+                        FluxQueryBuilderFactory queryBuilderFactory, WindowGapFiller windowGapFiller) {
         super(declaration);
         this.client = client;
         this.queryBuilderFactory = queryBuilderFactory;
+        this.windowGapFiller = windowGapFiller;
     }
 
     @Override
@@ -40,7 +42,7 @@ public class InfluxEngine extends AbstractQueryEngine {
         }
 
         if (fillGaps && completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
-            rows = new ArrayList<>(WindowGapFiller.fillGaps(rows, query));
+            rows = new ArrayList<>(windowGapFiller.fillGaps(rows, query));
         }
 
         return DataImpl.builder()

--- a/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/InfluxEngine.java
@@ -4,6 +4,7 @@ import com.epam.aidial.expressions.Expression;
 import com.epam.aidial.expressions.enums.Type;
 import com.epam.aidial.metric.model.configuration.influx.InfluxDatasetDeclaration;
 import com.epam.aidial.metric.service.AbstractQueryEngine;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.model.Completable;
 import com.epam.aidial.ql.model.Data;
 import com.epam.aidial.ql.model.Query;
@@ -36,6 +37,10 @@ public class InfluxEngine extends AbstractQueryEngine {
 
         if (rows.isEmpty() && isUngroupedAggregation(completable)) {
             rows.add(buildDefaultAggregationRow(completable.getExpressions()));
+        }
+
+        if (completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
+            rows = new ArrayList<>(WindowGapFiller.fillGaps(rows, query));
         }
 
         return DataImpl.builder()

--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -35,7 +35,7 @@ public class Influx3Engine extends AbstractQueryEngine {
     }
 
     @Override
-    public Data getData(Completable completable) {
+    public Data getData(Completable completable, boolean fillGaps) {
         var queryContext = queryBuilderFactory.createQueryBuilder()
                 .buildQueryContext(completable);
 
@@ -58,7 +58,7 @@ public class Influx3Engine extends AbstractQueryEngine {
         }
 
         List<List<Object>> resultRows = rows;
-        if (completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
+        if (fillGaps && completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
             resultRows = WindowGapFiller.fillGaps(rows, query);
         }
 

--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -28,13 +28,15 @@ public class Influx3Engine extends AbstractQueryEngine {
     private final InfluxDBClient client;
     private final SqlQueryBuilderFactory queryBuilderFactory;
     private final Influx3DatasetDeclaration influx3Declaration;
+    private final WindowGapFiller windowGapFiller;
 
     public Influx3Engine(Influx3DatasetDeclaration declaration, InfluxDBClient client,
-                         SqlQueryBuilderFactory queryBuilderFactory) {
+                         SqlQueryBuilderFactory queryBuilderFactory, WindowGapFiller windowGapFiller) {
         super(declaration);
         this.influx3Declaration = declaration;
         this.client = client;
         this.queryBuilderFactory = queryBuilderFactory;
+        this.windowGapFiller = windowGapFiller;
     }
 
     @Override
@@ -64,7 +66,7 @@ public class Influx3Engine extends AbstractQueryEngine {
 
         List<List<Object>> resultRows = rows;
         if (fillGaps && completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
-            resultRows = WindowGapFiller.fillGaps(rows, query);
+            resultRows = windowGapFiller.fillGaps(rows, query);
         }
 
         return DataImpl.builder()

--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -4,6 +4,7 @@ import com.epam.aidial.expressions.Expression;
 import com.epam.aidial.expressions.enums.Type;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DatasetDeclaration;
 import com.epam.aidial.metric.service.AbstractQueryEngine;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.model.Completable;
 import com.epam.aidial.ql.model.Data;
 import com.epam.aidial.ql.model.Query;
@@ -56,9 +57,14 @@ public class Influx3Engine extends AbstractQueryEngine {
             rows.set(0, normalizeAggregationRow(rows.get(0), completable.getExpressions()));
         }
 
+        List<List<Object>> resultRows = rows;
+        if (completable instanceof Query query && WindowGapFiller.isWindowQuery(query)) {
+            resultRows = WindowGapFiller.fillGaps(rows, query);
+        }
+
         return DataImpl.builder()
                 .expressions(completable.getExpressions())
-                .data(rows)
+                .data(resultRows)
                 .build();
     }
 

--- a/src/main/java/com/epam/aidial/metric/web/controller/MetricController.java
+++ b/src/main/java/com/epam/aidial/metric/web/controller/MetricController.java
@@ -109,7 +109,7 @@ public class MetricController {
     public ResponseEntity<byte[]> getCsvDataBy(@PathVariable("dataset") String datasetName,
                                                @RequestBody @Valid DataQuery query) throws IOException {
         var completableDto = getCompletableDto(query);
-        var data = metricService.getData(datasetName, completableDto);
+        var data = metricService.getData(datasetName, completableDto, query.isFillGaps());
         var body = toByteArray(data);
         return ResponseEntity.ok(body);
     }
@@ -120,7 +120,7 @@ public class MetricController {
     public ResponseEntity<DataDto> getJsonData(@PathVariable("dataset") String datasetName,
                                                @RequestBody @Valid DataQuery query) {
         var completableDto = getCompletableDto(query);
-        var data = metricService.getData(datasetName, completableDto);
+        var data = metricService.getData(datasetName, completableDto, query.isFillGaps());
         var body = toDataDto(data);
         return ResponseEntity.ok(body);
     }
@@ -130,7 +130,7 @@ public class MetricController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DataDto> getJsonData(@PathVariable("dataset") String datasetName,
                                                @RequestBody @Valid String query) {
-        return getJsonData(datasetName, new SqlDataQuery(query));
+        return getJsonData(datasetName, new SqlDataQuery(query, false));
     }
 
     private CompletableDto getCompletableDto(DataQuery query) {

--- a/src/main/java/com/epam/aidial/metric/web/dto/DataQuery.java
+++ b/src/main/java/com/epam/aidial/metric/web/dto/DataQuery.java
@@ -10,5 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = SqlDataQuery.class, name = "sql"),
 })
 public interface DataQuery {
-
+    default boolean isFillGaps() {
+        return false;
+    }
 }

--- a/src/main/java/com/epam/aidial/metric/web/dto/JsonDataQuery.java
+++ b/src/main/java/com/epam/aidial/metric/web/dto/JsonDataQuery.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @Data
 public class JsonDataQuery implements DataQuery {
     private CompletableDto query;
+    private boolean fillGaps;
 }

--- a/src/main/java/com/epam/aidial/metric/web/dto/SqlDataQuery.java
+++ b/src/main/java/com/epam/aidial/metric/web/dto/SqlDataQuery.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SqlDataQuery implements DataQuery {
     private String query;
+    private boolean fillGaps;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -162,6 +162,7 @@ metrics.config.type=${METRICS_DATASOURCE_TYPE:influx2}
 # Engine-specific settings
 metrics.influx2.defaultPageSize=${METRICS_INFLUX2_DEFAULT_PAGE_SIZE:100}
 metrics.influx3.defaultPageSize=${METRICS_INFLUX3_DEFAULT_PAGE_SIZE:100}
+metrics.gap-filler.max-buckets=${METRICS_GAP_FILLER_MAX_BUCKETS:10000}
 
 # Logging
 logging.level.org.springframework.security=INFO

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -144,21 +144,59 @@ public abstract class AbstractInfluxContainerTest {
 
         @Test
         void windowAggregation() throws Exception {
+            // Use 1-day window over ~2 day range
+            // Time range: [2026-03-11T13:33:38.680Z, 2026-03-13T13:33:38.680Z)
+            // DATE_BIN aligns to epoch, so 1-day buckets start at midnight UTC:
+            //   2026-03-11T00:00:00Z (record #1 at 14:00)
+            //   2026-03-12T00:00:00Z (records #2 at 10:00, #3 at 18:00)
+            //   2026-03-13T00:00:00Z (record #4 at 10:00)
             var data = queryFromJson("""
                     {
-                      "expressions": ["window(_time, 1, 'm') as time", "count() as requests"],
+                      "expressions": ["window(_time, 1, 'd') as time", "count() as requests"],
                       "from": "analytics",
-                      "groupBy": ["window(_time, 1, 'm')"],
+                      "groupBy": ["window(_time, 1, 'd')"],
                       "where": {%s},
                       "orderBy": [{"$asc": "time"}]
                     }""".formatted(TIME_FILTER));
 
             assertThat(columnNames(data)).containsExactly("time", "requests");
             assertThat(data.getData()).containsExactly(
-                    List.of(Instant.parse("2026-03-11T14:00:00Z"), 1L),
-                    List.of(Instant.parse("2026-03-12T10:00:00Z"), 1L),
-                    List.of(Instant.parse("2026-03-12T18:00:00Z"), 1L),
-                    List.of(Instant.parse("2026-03-13T10:00:00Z"), 1L)
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), 2L),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), 1L)
+            );
+        }
+
+        @Test
+        void windowAggregationFillsGaps() throws Exception {
+            // Use 8-hour window over ~2 day range
+            // Time range: [2026-03-11T13:33:38.680Z, 2026-03-13T13:33:38.680Z)
+            // 8-hour buckets aligned to epoch:
+            //   2026-03-11T08:00:00Z  -> record #1 at 14:00 -> count=1
+            //   2026-03-11T16:00:00Z  -> no data             -> count=0 (gap filled)
+            //   2026-03-12T00:00:00Z  -> no data             -> count=0 (gap filled)
+            //   2026-03-12T08:00:00Z  -> record #2 at 10:00 -> count=1
+            //   2026-03-12T16:00:00Z  -> record #3 at 18:00 -> count=1
+            //   2026-03-13T00:00:00Z  -> no data             -> count=0 (gap filled)
+            //   2026-03-13T08:00:00Z  -> record #4 at 10:00 -> count=1
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["window(_time, 8, 'h') as time", "count() as requests"],
+                      "from": "analytics",
+                      "groupBy": ["window(_time, 8, 'h')"],
+                      "where": {%s},
+                      "orderBy": [{"$asc": "time"}]
+                    }""".formatted(TIME_FILTER));
+
+            assertThat(columnNames(data)).containsExactly("time", "requests");
+            assertThat(data.getData()).containsExactly(
+                    List.of(Instant.parse("2026-03-11T08:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-11T16:00:00Z"), 0L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), 0L),
+                    List.of(Instant.parse("2026-03-12T08:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T16:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), 0L),
+                    List.of(Instant.parse("2026-03-13T08:00:00Z"), 1L)
             );
         }
 
@@ -392,9 +430,9 @@ public abstract class AbstractInfluxContainerTest {
         void windowAndColumnAggregation() throws Exception {
             // 4 in-range records across 3 days and 2 deployments.
             // GROUP BY 1-day window + deployment:
-            //   day1 (03-11): gpt-4=1
+            //   day1 (03-11): gpt-4=1, gpt-3.5=0 (gap filled)
             //   day2 (03-12): gpt-4=1, gpt-3.5=1
-            //   day3 (03-13): gpt-3.5=1
+            //   day3 (03-13): gpt-4=0 (gap filled), gpt-3.5=1
             var data = queryFromJson("""
                     {
                       "expressions": ["window(_time, 1, 'd') as time", "deployment", "count() as requests"],
@@ -406,8 +444,10 @@ public abstract class AbstractInfluxContainerTest {
             assertThat(columnNames(data)).containsExactly("time", "deployment", "requests");
             assertThat(data.getData()).containsExactlyInAnyOrder(
                     List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4", 1L),
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-3.5", 0L),
                     List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4", 1L),
                     List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5", 1L),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-4", 0L),
                     List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-3.5", 1L)
             );
         }

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -126,11 +126,15 @@ public abstract class AbstractInfluxContainerTest {
     protected abstract Engine getEngine();
 
     protected Data queryFromJson(String json) throws Exception {
+        return queryFromJson(json, true);
+    }
+
+    protected Data queryFromJson(String json, boolean fillGaps) throws Exception {
         var engine = getEngine();
         var languageConverter = new LanguageConverter(engine);
         var dto = QUERY_MAPPER.readValue(json, CompletableDto.class);
         var completable = languageConverter.convert(dto, engine.getTables());
-        return engine.getData(completable, true);
+        return engine.getData(completable, fillGaps);
     }
 
     protected static List<String> columnNames(Data data) {
@@ -997,6 +1001,53 @@ public abstract class AbstractInfluxContainerTest {
 
             assertThat(columnNames(data)).containsExactly("money", "requests");
             assertThat(data.getData()).hasSize(1);
+        }
+    }
+
+    @Nested
+    class GapFillingDisabledTests {
+
+        @Test
+        void windowAggregationNoGapFill() throws Exception {
+            // Same 8-hour window query as windowAggregationFillsGaps, but with fillGaps=false.
+            // Should return only buckets that have actual data (no zero-filled rows).
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["window(_time, 8, 'h') as time", "count() as requests"],
+                      "from": "analytics",
+                      "groupBy": ["window(_time, 8, 'h')"],
+                      "where": {%s},
+                      "orderBy": [{"$asc": "time"}]
+                    }""".formatted(TIME_FILTER), false);
+
+            assertThat(columnNames(data)).containsExactly("time", "requests");
+            assertThat(data.getData()).containsExactly(
+                    List.of(Instant.parse("2026-03-11T08:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T08:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-12T16:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-13T08:00:00Z"), 1L)
+            );
+        }
+
+        @Test
+        void windowAndColumnAggregationNoGapFill() throws Exception {
+            // Same query as windowAndColumnAggregation, but with fillGaps=false.
+            // Should return only rows with actual data (no zero-filled deployment rows).
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["window(_time, 1, 'd') as time", "deployment", "count() as requests"],
+                      "from": "analytics",
+                      "groupBy": ["window(_time, 1, 'd')", "deployment"],
+                      "where": {%s}
+                    }""".formatted(TIME_FILTER), false);
+
+            assertThat(columnNames(data)).containsExactly("time", "deployment", "requests");
+            assertThat(data.getData()).containsExactlyInAnyOrder(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4", 1L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4", 1L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5", 1L),
+                    List.of(Instant.parse("2026-03-13T00:00:00Z"), "gpt-3.5", 1L)
+            );
         }
     }
 

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractInfluxContainerTest {
         var languageConverter = new LanguageConverter(engine);
         var dto = QUERY_MAPPER.readValue(json, CompletableDto.class);
         var completable = languageConverter.convert(dto, engine.getTables());
-        return engine.getData(completable, false);
+        return engine.getData(completable, true);
     }
 
     protected static List<String> columnNames(Data data) {

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractInfluxContainerTest {
         var languageConverter = new LanguageConverter(engine);
         var dto = QUERY_MAPPER.readValue(json, CompletableDto.class);
         var completable = languageConverter.convert(dto, engine.getTables());
-        return engine.getData(completable);
+        return engine.getData(completable, false);
     }
 
     protected static List<String> columnNames(Data data) {

--- a/src/test/java/com/epam/aidial/metric/service/WindowGapFillerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/WindowGapFillerTest.java
@@ -1,0 +1,367 @@
+package com.epam.aidial.metric.service;
+
+import com.epam.aidial.expressions.Expression;
+import com.epam.aidial.expressions.enums.Type;
+import com.epam.aidial.expressions.impl.AggregationFunctionCallImpl;
+import com.epam.aidial.expressions.impl.AliasImpl;
+import com.epam.aidial.expressions.impl.ColumnImpl;
+import com.epam.aidial.expressions.impl.ConstantImpl;
+import com.epam.aidial.expressions.impl.FunctionImpl;
+import com.epam.aidial.expressions.impl.GroupFunctionCallImpl;
+import com.epam.aidial.expressions.impl.NumberConstantImpl;
+import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
+import com.epam.aidial.ql.model.Query;
+import com.epam.aidial.ql.model.filters.impl.AndImpl;
+import com.epam.aidial.ql.model.filters.impl.BinaryComparisonFilterImpl;
+import com.epam.aidial.ql.model.impl.QueryImpl;
+import com.epam.aidial.ql.model.impl.TableImpl;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WindowGapFillerTest {
+
+    private final WindowGapFiller gapFiller = new WindowGapFiller(10_000);
+
+    @Nested
+    class DefaultForTypeTests {
+
+        @Test
+        void floatReturnsZeroDouble() {
+            assertThat(WindowGapFiller.defaultForType(Type.FLOAT)).isEqualTo(0.0);
+        }
+
+        @Test
+        void doubleReturnsZeroDouble() {
+            assertThat(WindowGapFiller.defaultForType(Type.DOUBLE)).isEqualTo(0.0);
+        }
+
+        @Test
+        void integerReturnsZeroLong() {
+            assertThat(WindowGapFiller.defaultForType(Type.INT_64)).isEqualTo(0L);
+        }
+
+        @Test
+        void timestampReturnsZeroLong() {
+            assertThat(WindowGapFiller.defaultForType(Type.TIMESTAMP)).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    class IsWindowQueryTests {
+
+        @Test
+        void returnsTrueWhenGroupByContainsWindowFunction() {
+            var query = buildWindowQuery("1", "h",
+                    Instant.parse("2026-03-11T00:00:00Z"),
+                    Instant.parse("2026-03-12T00:00:00Z"));
+            assertThat(WindowGapFiller.isWindowQuery(query)).isTrue();
+        }
+
+        @Test
+        void returnsFalseWhenGroupByIsEmpty() {
+            var query = QueryImpl.builder()
+                    .expressions(List.of(countExpression()))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .groupBy(List.of())
+                    .build();
+            assertThat(WindowGapFiller.isWindowQuery(query)).isFalse();
+        }
+
+        @Test
+        void returnsFalseWhenGroupByIsNull() {
+            var query = QueryImpl.builder()
+                    .expressions(List.of(countExpression()))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .build();
+            assertThat(WindowGapFiller.isWindowQuery(query)).isFalse();
+        }
+
+        @Test
+        void returnsFalseWhenGroupByHasOnlyColumns() {
+            var query = QueryImpl.builder()
+                    .expressions(List.of(new ColumnImpl(Type.STRING, "deployment"), countExpression()))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .groupBy(List.of(new ColumnImpl(Type.STRING, "deployment")))
+                    .build();
+            assertThat(WindowGapFiller.isWindowQuery(query)).isFalse();
+        }
+    }
+
+    @Nested
+    class FillGapsTests {
+
+        @Test
+        void fillsGapsInWindowOnlyQuery() {
+            // 3-hour window over 9 hours: expect 3 buckets
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-11T09:00:00Z");
+            var query = buildWindowQuery("3", "h", start, end);
+
+            // Only provide data for first and last bucket
+            var rows = new ArrayList<List<Object>>();
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-11T00:00:00Z"), 5L)));
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-11T06:00:00Z"), 3L)));
+
+            var result = gapFiller.fillGaps(rows, query);
+
+            assertThat(result).containsExactly(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), 5L),
+                    List.of(Instant.parse("2026-03-11T03:00:00Z"), 0L),
+                    List.of(Instant.parse("2026-03-11T06:00:00Z"), 3L)
+            );
+        }
+
+        @Test
+        void fillsGapsInWindowAndColumnQuery() {
+            // 1-day window over 2 days with deployment column
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-13T00:00:00Z");
+            var query = buildWindowColumnQuery("1", "d", start, end);
+
+            // day1: only gpt-4, day2: only gpt-3.5
+            var rows = new ArrayList<List<Object>>();
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4", 2L)));
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5", 1L)));
+
+            var result = gapFiller.fillGaps(rows, query);
+
+            assertThat(result).containsExactlyInAnyOrder(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-4", 2L),
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), "gpt-3.5", 0L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-4", 0L),
+                    List.of(Instant.parse("2026-03-12T00:00:00Z"), "gpt-3.5", 1L)
+            );
+        }
+
+        @Test
+        void returnsEmptyWhenNoDataAndGroupColumnsPresent() {
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-13T00:00:00Z");
+            var query = buildWindowColumnQuery("1", "d", start, end);
+
+            var result = gapFiller.fillGaps(List.of(), query);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void returnsRowsUnchangedWhenNoWindowFunction() {
+            var query = QueryImpl.builder()
+                    .expressions(List.of(new ColumnImpl(Type.STRING, "deployment"), countExpression()))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .groupBy(List.of(new ColumnImpl(Type.STRING, "deployment")))
+                    .where(timeRangeFilter(
+                            Instant.parse("2026-03-11T00:00:00Z"),
+                            Instant.parse("2026-03-12T00:00:00Z")))
+                    .build();
+
+            var rows = List.<List<Object>>of(
+                    List.of("gpt-4", 5L),
+                    List.of("gpt-3.5", 3L)
+            );
+
+            var result = gapFiller.fillGaps(rows, query);
+
+            assertThat(result).isEqualTo(rows);
+        }
+
+        @Test
+        void handlesAliasedWindowExpression() {
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-11T06:00:00Z");
+
+            var windowFunc = windowFunction("3", "h");
+            var aliasedWindow = new AliasImpl("time", windowFunc);
+
+            var query = QueryImpl.builder()
+                    .expressions(List.of(aliasedWindow, countExpression()))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .groupBy(List.of(windowFunc))
+                    .where(timeRangeFilter(start, end))
+                    .build();
+
+            // Only first bucket has data
+            var rows = new ArrayList<List<Object>>();
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-11T00:00:00Z"), 1L)));
+
+            var result = gapFiller.fillGaps(rows, query);
+
+            assertThat(result).containsExactly(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), 1L),
+                    List.of(Instant.parse("2026-03-11T03:00:00Z"), 0L)
+            );
+        }
+
+        @Test
+        void fillsZeroDoubleForFloatAggregations() {
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-11T06:00:00Z");
+            var windowFunc = windowFunction("3", "h");
+
+            var sumExpr = new AggregationFunctionCallImpl(
+                    new FunctionImpl("sum", Type.DOUBLE, true),
+                    List.of(),
+                    List.of(new ColumnImpl(Type.DOUBLE, "price"))
+            );
+
+            var query = QueryImpl.builder()
+                    .expressions(List.of(windowFunc, sumExpr))
+                    .from(TableImpl.builder().name("analytics").build())
+                    .groupBy(List.of(windowFunc))
+                    .where(timeRangeFilter(start, end))
+                    .build();
+
+            var rows = new ArrayList<List<Object>>();
+            rows.add(new ArrayList<>(List.of(Instant.parse("2026-03-11T00:00:00Z"), 5.0)));
+
+            var result = gapFiller.fillGaps(rows, query);
+
+            assertThat(result).containsExactly(
+                    List.of(Instant.parse("2026-03-11T00:00:00Z"), 5.0),
+                    List.of(Instant.parse("2026-03-11T03:00:00Z"), 0.0)
+            );
+        }
+    }
+
+    @Nested
+    class BucketLimitTests {
+
+        @Test
+        void throwsWhenTooManyBuckets() {
+            // 1-second window over a range that would produce > 10,000 buckets
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-11T04:00:00Z"); // 14400 seconds > 10000
+            var query = buildWindowQuery("1", "s", start, end);
+
+            assertThatThrownBy(() -> gapFiller.fillGaps(List.of(), query))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("too many buckets");
+        }
+
+        @Test
+        void respectsCustomMaxBuckets() {
+            var smallLimitFiller = new WindowGapFiller(5);
+            // 1-hour window over 6 hours = 6 buckets > 5
+            var start = Instant.parse("2026-03-11T00:00:00Z");
+            var end = Instant.parse("2026-03-11T06:00:00Z");
+            var query = buildWindowQuery("1", "h", start, end);
+
+            assertThatThrownBy(() -> smallLimitFiller.fillGaps(List.of(), query))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("too many buckets");
+        }
+    }
+
+    @Nested
+    class BucketAlignmentTests {
+
+        @Test
+        void hourlyBucketsAlignToEpoch() {
+            // Start at 13:33, 8-hour buckets should align to 08:00
+            var start = Instant.parse("2026-03-11T13:33:00Z");
+            var end = Instant.parse("2026-03-12T01:00:00Z");
+            var query = buildWindowQuery("8", "h", start, end);
+
+            var result = gapFiller.fillGaps(List.of(), query);
+
+            assertThat(result).extracting(row -> row.get(0)).containsExactly(
+                    Instant.parse("2026-03-11T08:00:00Z"),
+                    Instant.parse("2026-03-11T16:00:00Z"),
+                    Instant.parse("2026-03-12T00:00:00Z")
+            );
+        }
+
+        @Test
+        void dailyBucketsAlignToMidnight() {
+            var start = Instant.parse("2026-03-11T14:00:00Z");
+            var end = Instant.parse("2026-03-13T10:00:00Z");
+            var query = buildWindowQuery("1", "d", start, end);
+
+            var result = gapFiller.fillGaps(List.of(), query);
+
+            assertThat(result).extracting(row -> row.get(0)).containsExactly(
+                    Instant.parse("2026-03-11T00:00:00Z"),
+                    Instant.parse("2026-03-12T00:00:00Z"),
+                    Instant.parse("2026-03-13T00:00:00Z")
+            );
+        }
+
+        @Test
+        void monthlyBucketsAlignToFirstOfMonth() {
+            var start = Instant.parse("2026-03-15T00:00:00Z");
+            var end = Instant.parse("2026-06-01T00:00:00Z");
+            var query = buildWindowQuery("1", "mo", start, end);
+
+            var result = gapFiller.fillGaps(List.of(), query);
+
+            assertThat(result).extracting(row -> row.get(0)).containsExactly(
+                    Instant.parse("2026-03-01T00:00:00Z"),
+                    Instant.parse("2026-04-01T00:00:00Z"),
+                    Instant.parse("2026-05-01T00:00:00Z")
+            );
+        }
+    }
+
+    // -- Helper methods --
+
+    private static GroupFunctionCallImpl windowFunction(String value, String unit) {
+        return new GroupFunctionCallImpl(
+                new FunctionImpl("window", null, true),
+                List.of(),
+                List.of(
+                        new ColumnImpl(Type.TIMESTAMP, "_time"),
+                        NumberConstantImpl.valueOf(Long.parseLong(value)),
+                        new ConstantImpl(Type.STRING, unit)
+                )
+        );
+    }
+
+    private static Expression countExpression() {
+        return new AggregationFunctionCallImpl(
+                new FunctionImpl("count", Type.UINT_64, true),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private static AndImpl timeRangeFilter(Instant start, Instant end) {
+        return AndImpl.of(List.of(
+                BinaryComparisonFilterImpl.of(
+                        new ColumnImpl(Type.TIMESTAMP, "_time"),
+                        BinaryComparisonOperator.GREATER_OR_EQUALS,
+                        new ConstantImpl(Type.TIMESTAMP, start.toEpochMilli())),
+                BinaryComparisonFilterImpl.of(
+                        new ColumnImpl(Type.TIMESTAMP, "_time"),
+                        BinaryComparisonOperator.LESS,
+                        new ConstantImpl(Type.TIMESTAMP, end.toEpochMilli()))
+        ));
+    }
+
+    private static Query buildWindowQuery(String value, String unit, Instant start, Instant end) {
+        var windowFunc = windowFunction(value, unit);
+        return QueryImpl.builder()
+                .expressions(List.of(windowFunc, countExpression()))
+                .from(TableImpl.builder().name("analytics").build())
+                .groupBy(List.of(windowFunc))
+                .where(timeRangeFilter(start, end))
+                .build();
+    }
+
+    private static Query buildWindowColumnQuery(String value, String unit, Instant start, Instant end) {
+        var windowFunc = windowFunction(value, unit);
+        var deploymentCol = new ColumnImpl(Type.STRING, "deployment");
+        return QueryImpl.builder()
+                .expressions(List.of(windowFunc, deploymentCol, countExpression()))
+                .from(TableImpl.builder().name("analytics").build())
+                .groupBy(List.of(windowFunc, deploymentCol))
+                .where(timeRangeFilter(start, end))
+                .build();
+    }
+}

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
@@ -7,6 +7,7 @@ import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.influx.InfluxDatasetDeclaration;
 import com.epam.aidial.metric.model.influx.FluxQueryContext;
 import com.epam.aidial.metric.model.influx.FluxStandardImports;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.LanguageConverter;
 import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
 import com.epam.aidial.ql.common.model.enums.SortDirection;
@@ -45,8 +46,10 @@ class FluxQueryIntegrationTest {
         var datasetConfiguration = new InfluxDatasetConfiguration();
         datasetConfiguration.setDefaultPageSize(50);
 
+        var windowGapFiller = new WindowGapFiller(10_000);
+
         fluxQueryBuilderFactory = new FluxQueryBuilderFactory(datasetDeclaration, datasetConfiguration);
-        engine = new InfluxEngine(datasetDeclaration, null, fluxQueryBuilderFactory);
+        engine = new InfluxEngine(datasetDeclaration, null, fluxQueryBuilderFactory, windowGapFiller);
         languageConverter = new LanguageConverter(engine);
     }
 

--- a/src/test/java/com/epam/aidial/metric/service/influx/InfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/InfluxContainerTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.metric.config.InfluxDatasetConfiguration;
 import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.influx.InfluxDatasetDeclaration;
 import com.epam.aidial.metric.service.AbstractInfluxContainerTest;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.Engine;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.influxdb.client.InfluxDBClient;
@@ -69,7 +70,8 @@ class InfluxContainerTest extends AbstractInfluxContainerTest {
         datasetConfiguration.setDefaultPageSize(50);
 
         var queryBuilderFactory = new FluxQueryBuilderFactory(datasetDeclaration, datasetConfiguration);
-        engine = new InfluxEngine(datasetDeclaration, influxClient, queryBuilderFactory);
+        var windowGapFiller = new WindowGapFiller(10_000);
+        engine = new InfluxEngine(datasetDeclaration, influxClient, queryBuilderFactory, windowGapFiller);
     }
 
     @Override

--- a/src/test/java/com/epam/aidial/metric/service/influx3/Influx3ContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx3/Influx3ContainerTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.metric.config.Influx3DatasetConfiguration;
 import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DatasetDeclaration;
 import com.epam.aidial.metric.service.AbstractInfluxContainerTest;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.Engine;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.influxdb.v3.client.InfluxDBClient;
@@ -62,7 +63,8 @@ class Influx3ContainerTest extends AbstractInfluxContainerTest {
         datasetConfiguration.setDefaultPageSize(50);
 
         var queryBuilderFactory = new SqlQueryBuilderFactory(datasetDeclaration, datasetConfiguration);
-        engine = new Influx3Engine(datasetDeclaration, influx3Client, queryBuilderFactory);
+        var windowGapFiller = new WindowGapFiller(10_000);
+        engine = new Influx3Engine(datasetDeclaration, influx3Client, queryBuilderFactory, windowGapFiller);
     }
 
     @Override

--- a/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx3/SqlQueryIntegrationTest.java
@@ -6,6 +6,7 @@ import com.epam.aidial.metric.config.Influx3DatasetConfiguration;
 import com.epam.aidial.metric.model.configuration.DatasetDeclaration;
 import com.epam.aidial.metric.model.configuration.influx3.Influx3DatasetDeclaration;
 import com.epam.aidial.metric.model.influx3.SqlQueryContext;
+import com.epam.aidial.metric.service.WindowGapFiller;
 import com.epam.aidial.ql.LanguageConverter;
 import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
 import com.epam.aidial.ql.common.model.enums.SortDirection;
@@ -46,8 +47,10 @@ class SqlQueryIntegrationTest {
         var datasetConfiguration = new Influx3DatasetConfiguration();
         datasetConfiguration.setDefaultPageSize(50);
 
+        var windowGapFiller = new WindowGapFiller(10_000);
+
         sqlQueryBuilderFactory = new SqlQueryBuilderFactory(datasetDeclaration, datasetConfiguration);
-        engine = new Influx3Engine(datasetDeclaration, null, sqlQueryBuilderFactory);
+        engine = new Influx3Engine(datasetDeclaration, null, sqlQueryBuilderFactory, windowGapFiller);
         languageConverter = new LanguageConverter(engine);
     }
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #744

### Description of changes

<!-- Please explain the changes you made right below this line. -->
  1. New fillGaps boolean field added to DataQuery, JsonDataQuery, and SqlDataQuery DTOs —
  defaults to false, so existing behavior is unchanged.
  2. New WindowGapFiller utility class (~307 lines) — the core logic:
    - Detects if a query uses a window() group-by function
    - Extracts the time range from WHERE filters and the interval from window() args
    - Generates aligned time buckets (epoch-aligned for fixed units, calendar-aligned for
  months/years)
    - Fills missing (bucket, group-key) combinations with zero-valued rows (0L for integers,
   0.0 for floats)
  3. Engine.getData() signature change — added boolean fillGaps parameter, threaded through
  MetricService, InfluxEngine, and Influx3Engine.
  4. Both Influx engines apply WindowGapFiller.fillGaps() post-query when fillGaps=true and
  the query is a windowed aggregation.
  5. Tests updated — existing window aggregation tests adjusted for correct bucket
  alignment; new windowAggregationFillsGaps test verifies 8-hour buckets get zero-filled;
  windowAndColumnAggregation test now expects gap-filled rows per group key.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.