### PR TITLE
fix: normalize Influx3 timestamp values in simple SELECT queries

### DIFF
--- a/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/Influx3Engine.java
@@ -13,6 +13,7 @@ import com.influxdb.v3.client.query.QueryOptions;
 import com.influxdb.v3.client.query.QueryType;
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -20,6 +21,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class Influx3Engine extends AbstractQueryEngine {
+
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
 
     private final InfluxDBClient client;
     private final SqlQueryBuilderFactory queryBuilderFactory;
@@ -38,13 +41,15 @@ public class Influx3Engine extends AbstractQueryEngine {
         var queryContext = queryBuilderFactory.createQueryBuilder()
                 .buildQueryContext(completable);
 
+        var expressions = completable.getExpressions();
         var rows = new ArrayList<List<Object>>();
         var options = new QueryOptions(influx3Declaration.getSource().getDatabase(), QueryType.SQL);
         try (Stream<Object[]> stream = client.query(queryContext.getQuery(), queryContext.getParameters(), options)) {
             stream.forEach(record -> {
                 var row = new ArrayList<>(queryContext.getColumnNames().size());
                 for (int i = 0; i < queryContext.getColumnNames().size(); i++) {
-                    row.add(i < record.length ? normalizeValue(record[i]) : null);
+                    var type = i < expressions.size() ? expressions.get(i).getType() : null;
+                    row.add(i < record.length ? normalizeValue(record[i], type) : null);
                 }
                 rows.add(row);
             });
@@ -100,9 +105,13 @@ public class Influx3Engine extends AbstractQueryEngine {
         };
     }
 
-    private Object normalizeValue(Object value) {
+    private Object normalizeValue(Object value, Type type) {
         if (value instanceof LocalDateTime localDateTime) {
             return localDateTime.toInstant(ZoneOffset.UTC);
+        }
+        if (type == Type.TIMESTAMP && value instanceof Number number) {
+            long nanos = number.longValue();
+            return Instant.ofEpochSecond(nanos / NANOS_PER_SECOND, nanos % NANOS_PER_SECOND);
         }
         return value;
     }

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -140,6 +140,28 @@ public abstract class AbstractInfluxContainerTest {
     }
 
     @Nested
+    class SimpleSelectTests {
+
+        @Test
+        void simpleSelectWithTimeAlias() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["_time as completion_time", "deployment"],
+                      "from": "analytics",
+                      "where": {%s},
+                      "orderBy": [{"$asc": "_time"}],
+                      "limit": 1
+                    }""".formatted(TIME_FILTER));
+
+            assertThat(columnNames(data)).containsExactly("completion_time", "deployment");
+            assertThat(data.getData()).containsExactly(
+                    List.of(Instant.parse("2026-03-11T14:00:00Z"), "gpt-4")
+            );
+        }
+
+    }
+
+    @Nested
     class AggregationTests {
 
         @Test


### PR DESCRIPTION
## Summary
- InfluxDB 3 client returns `time` column as `BigInteger` (nanosecond epoch) in simple SELECT queries, while `DATE_BIN()` in window queries returns `LocalDateTime`. The existing `normalizeValue()` only handled `LocalDateTime`, so timestamps in simple queries passed through as raw nanosecond numbers.
- Made `normalizeValue()` type-aware using `Expression.getType()` to convert numeric timestamps (`Number`) to `Instant` when the column type is `TIMESTAMP`.
- Added regression test `simpleSelectWithTimeAlias` covering `_time as completion_time` for both InfluxDB v2 and v3 engines.

## Test plan
- [x] Existing tests pass (80 tests, all green)
- [x] New `simpleSelectWithTimeAlias` test verifies `Instant` is returned for both v2 and v3
- [x] Run `./gradlew :test --tests "*InfluxContainerTest" --tests "*Influx3ContainerTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)