### PR TITLE
chore: bump spring boot version from 3.5.10 to 3.5.14, bump io.netty:netty-codec-http2 transitive dependency from 4.2.10.Final to 4.2.11.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id "java"
     id 'checkstyle'
     id 'io.freefair.lombok' version '8.0.1'
-    id 'org.springframework.boot' version '3.5.10'
+    id 'org.springframework.boot' version '3.5.13'
 }
 
 group = 'com.epam.aidial'
@@ -184,7 +184,7 @@ dependencies {
         implementation ('io.projectreactor.netty:reactor-netty-http:1.2.8') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.4.Final') {
+        implementation ('io.netty:netty-codec-http2:4.2.11.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.