### PR TITLE
fix: add missing `interceptorRunners` and `globalInterceptors` to export preview

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/ExportConfigPreviewDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportConfigPreviewDto.java
@@ -1,11 +1,9 @@
 package com.epam.aidial.cfg.dto;
 
-import com.epam.aidial.cfg.domain.model.InterceptorRunner;
 import lombok.Data;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 @Data
 public class ExportConfigPreviewDto {
@@ -19,7 +17,7 @@ public class ExportConfigPreviewDto {
     private Collection<ExportKeyInfoDto> keys;
     private Collection<ExportApplicationTypeSchemaInfoDto> applicationRunners;
     private Collection<ExportComponentInfoDto> interceptors;
-    private Map<String, InterceptorRunner> interceptorRunners;
-    private Collection<ExportComponentInfoDto> adapters;
     private List<String> globalInterceptors;
+    private Collection<ExportComponentInfoDto> interceptorRunners;
+    private Collection<ExportComponentInfoDto> adapters;
 }

--- a/src/main/java/com/epam/aidial/cfg/dto/ExportConfigPreviewDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ExportConfigPreviewDto.java
@@ -1,8 +1,11 @@
 package com.epam.aidial.cfg.dto;
 
+import com.epam.aidial.cfg.domain.model.InterceptorRunner;
 import lombok.Data;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 @Data
 public class ExportConfigPreviewDto {
@@ -16,5 +19,7 @@ public class ExportConfigPreviewDto {
     private Collection<ExportKeyInfoDto> keys;
     private Collection<ExportApplicationTypeSchemaInfoDto> applicationRunners;
     private Collection<ExportComponentInfoDto> interceptors;
+    private Map<String, InterceptorRunner> interceptorRunners;
     private Collection<ExportComponentInfoDto> adapters;
+    private List<String> globalInterceptors;
 }

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/ConfigControllerTest.java
@@ -7,6 +7,7 @@ import com.epam.aidial.cfg.domain.model.ExportApplicationTypeSchemaInfo;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import com.epam.aidial.cfg.domain.model.ExportConfigPreview;
+import com.epam.aidial.cfg.domain.model.ExportFormat;
 import com.epam.aidial.cfg.domain.model.ExportKeyInfo;
 import com.epam.aidial.cfg.domain.model.ImportComponent;
 import com.epam.aidial.cfg.domain.model.ImportConfigPreview;
@@ -16,6 +17,7 @@ import com.epam.aidial.cfg.dto.ExportConfigComponentTypeDto;
 import com.epam.aidial.cfg.dto.ExportFormatDto;
 import com.epam.aidial.cfg.dto.FullExportRequestDto;
 import com.epam.aidial.cfg.model.ConfigImportOptions;
+import com.epam.aidial.cfg.model.FullExportRequest;
 import com.epam.aidial.cfg.service.config.ConfigSyncErrorHandler;
 import com.epam.aidial.cfg.service.config.export.ConflictResolutionPolicy;
 import com.epam.aidial.cfg.service.config.export.CoreConfigReloadService;
@@ -366,6 +368,39 @@ class ConfigControllerTest extends AbstractControllerNoneSecureTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(expected, JsonCompareMode.LENIENT));
         verify(configTransfer).exportPreview(any());
+    }
+
+    @Test
+    void testExportPreview_InterceptorRunners_AdminFormat() throws Exception {
+        // given
+        FullExportRequestDto requestDto = new FullExportRequestDto();
+        requestDto.setExportFormat(ExportFormatDto.ADMIN);
+        requestDto.setComponentTypes(Set.of(ExportConfigComponentTypeDto.INTERCEPTOR_RUNNER));
+
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.ADMIN);
+        request.setComponentTypes(Set.of(ExportConfigComponentType.INTERCEPTOR_RUNNER));
+
+        ExportComponentInfo componentInfo = ExportComponentInfo.builder()
+                .type(ExportConfigComponentType.INTERCEPTOR_RUNNER)
+                .name("name1")
+                .description("description1")
+                .displayName("displayName1")
+                .build();
+
+        ExportConfigPreview exportConfigPreview = new ExportConfigPreview();
+        exportConfigPreview.setInterceptorRunners(List.of(componentInfo));
+
+        when(configTransfer.exportPreview(request)).thenReturn(exportConfigPreview);
+        String expected = ResourceUtils.readResource("/preview_interceptor_runner.json");
+
+        // when
+        mockMvc.perform(post("/api/v1/configs/export/preview")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(content().json(expected, JsonCompareMode.LENIENT));
     }
 
     @Test

--- a/src/test/resources/preview_interceptor_runner.json
+++ b/src/test/resources/preview_interceptor_runner.json
@@ -1,0 +1,10 @@
+{
+  "interceptorRunners": [
+    {
+      "type": "INTERCEPTOR_RUNNER",
+      "name": "name1",
+      "description": "description1",
+      "displayName": "displayName1"
+    }
+  ]
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/ai-dial-admin-frontend/issues/2814

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.