### PR TITLE
chore: refactor config filtering against core version

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
@@ -16,7 +16,6 @@ import com.epam.aidial.cfg.service.config.impl.storage.GcpVaultConfigSource;
 import com.epam.aidial.cfg.service.config.impl.storage.HashiVaultConfigSource;
 import com.epam.aidial.cfg.service.config.impl.storage.K8ConfigService;
 import com.epam.aidial.cfg.service.config.transfer.ConfigTransferLock;
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetrieverImpl;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetrieverSecuredImpl;
@@ -45,17 +44,15 @@ public class ExportConfiguration {
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "LOCAL_FILE")
-    public ConfigSourceFile configSourceJsonFile(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                 ObjectMapper objectMapper,
+    public ConfigSourceFile configSourceJsonFile(ObjectMapper objectMapper,
                                                  @Value("${config.export.outputFile.path}") String outputFilePath) {
-        return new ConfigSourceFile(versionAwareFieldFilter, objectMapper, outputFilePath);
+        return new ConfigSourceFile(objectMapper, outputFilePath);
     }
 
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "CONFIG_MAP")
-    public ConfigSourceConfigMap configSourceJsonConfigMap(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                           ConfigSplitter configSplitter,
+    public ConfigSourceConfigMap configSourceJsonConfigMap(ConfigSplitter configSplitter,
                                                            ConfigMerger configMerger,
                                                            @Value("${config.export.configMap.maxSize:1048576}") int maxSize,
                                                            @Value("${config.export.configMap.name:}") String configMapName,
@@ -67,14 +64,13 @@ public class ExportConfiguration {
             throw new IllegalArgumentException("Config map name and names are both specified");
         }
         List<String> names = resolveNames(configMapName, configMapNames);
-        return new ConfigSourceConfigMap(versionAwareFieldFilter, configSplitter, configMerger, names, maxSize, k8ConfigService, configKey, objectMapper);
+        return new ConfigSourceConfigMap(configSplitter, configMerger, names, maxSize, k8ConfigService, configKey, objectMapper);
     }
 
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "KUBE_SECRET")
-    public ConfigSourceKubeSecret configSourceJsonKubeSecret(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                             ConfigSplitter configSplitter,
+    public ConfigSourceKubeSecret configSourceJsonKubeSecret(ConfigSplitter configSplitter,
                                                              ConfigMerger configMerger,
                                                              @Value("${config.export.kubeSecret.maxSize:1048576}") int maxSize,
                                                              @Value("${config.export.kubeSecret.name:}") String kubeSecretName,
@@ -86,7 +82,7 @@ public class ExportConfiguration {
             throw new IllegalArgumentException("Kube secret name and names are both specified");
         }
         List<String> names = resolveNames(kubeSecretName, kubeSecretNames);
-        return new ConfigSourceKubeSecret(versionAwareFieldFilter, configSplitter, configMerger, names, maxSize, k8ConfigService, kubeSecretKey, objectMapper);
+        return new ConfigSourceKubeSecret(configSplitter, configMerger, names, maxSize, k8ConfigService, kubeSecretKey, objectMapper);
     }
 
     @Bean
@@ -128,52 +124,48 @@ public class ExportConfiguration {
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "azure")
-    public AzureKeyVaultConfigSource azureKeyVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                               ObjectMapper objectMapper,
+    public AzureKeyVaultConfigSource azureKeyVaultConfigSource(ObjectMapper objectMapper,
                                                                SecretClient secretClient,
                                                                @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                                @Value("${config.export.keyvault.expiration.unit}") String expirationTimeUnit,
                                                                @Value("${config.export.keyvault.expiration.period}") Long expirationPeriod,
                                                                ConfigSplitter configSplitter,
                                                                ConfigMerger configMerger) {
-        return new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, secretNames, secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
+        return new AzureKeyVaultConfigSource(configSplitter, configMerger, secretNames, secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "vault")
-    public HashiVaultConfigSource hashiVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                         ObjectMapper objectMapper,
+    public HashiVaultConfigSource hashiVaultConfigSource(ObjectMapper objectMapper,
                                                          @Value("${config.export.keyvault.secretPath}") String secretPath,
                                                          VaultTemplate vaultTemplate) {
-        return new HashiVaultConfigSource(versionAwareFieldFilter, vaultTemplate, secretPath, objectMapper);
+        return new HashiVaultConfigSource(vaultTemplate, secretPath, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "aws")
-    public AwsVaultConfigSource awsVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                     ObjectMapper objectMapper,
+    public AwsVaultConfigSource awsVaultConfigSource(ObjectMapper objectMapper,
                                                      SecretsManagerClient secretsManagerClient,
                                                      @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                      @Value("${config.export.keyvault.expiration.unit}") String expirationTimeUnit,
                                                      @Value("${config.export.keyvault.expiration.period}") Long expirationPeriod,
                                                      ConfigSplitter configSplitter,
                                                      ConfigMerger configMerger) {
-        return new AwsVaultConfigSource(versionAwareFieldFilter, secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper);
+        return new AwsVaultConfigSource(secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "gcp")
-    public GcpVaultConfigSource gcpVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                                     ObjectMapper objectMapper,
+    public GcpVaultConfigSource gcpVaultConfigSource(ObjectMapper objectMapper,
                                                      SecretManagerServiceClient secretsManagerClient,
                                                      @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                      @Value("${gcp.keyvault.projectId}") String projectId,
                                                      ConfigSplitter configSplitter,
                                                      ConfigMerger configMerger) {
-        return new GcpVaultConfigSource(versionAwareFieldFilter, secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper, projectId);
+        return new GcpVaultConfigSource(secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper, projectId);
     }
 
     private List<String> resolveNames(String name, List<String> names) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportFacade.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.service.config.export;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.service.config.normalizer.CoreConfigNormalizer;
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,16 +17,19 @@ public class ConfigExportFacade {
 
     private final CoreConfigAggregatorService configService;
     private final ConfigExportService configExportService;
+    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final List<CoreConfigNormalizer> normalizers;
 
     private final boolean createResources;
 
     public ConfigExportFacade(CoreConfigAggregatorService configService,
                               ConfigExportService configExportService,
+                              VersionAwareFieldFilter versionAwareFieldFilter,
                               List<CoreConfigNormalizer> normalizers,
                               @Value("${config.export.createResources}") boolean createResources) {
         this.configService = configService;
         this.configExportService = configExportService;
+        this.versionAwareFieldFilter = versionAwareFieldFilter;
         this.normalizers = normalizers;
         this.createResources = createResources;
     }
@@ -34,7 +38,8 @@ public class ConfigExportFacade {
         Config config = configService.getConfig();
         log.debug("Exporting current Configuration settings.");
         normalizers.forEach(n -> n.normalize(config));
-        configExportService.export(config, createResources);
+        Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(config);
+        configExportService.export(versionedConfig, createResources);
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AwsVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AwsVaultConfigSource.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
@@ -23,13 +22,12 @@ public class AwsVaultConfigSource extends CompositeConfigSource {
     private final ObjectMapper objectMapper;
     private final SecretsManagerClient secretsManagerClient;
 
-    public AwsVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                SecretsManagerClient secretsManagerClient,
+    public AwsVaultConfigSource(SecretsManagerClient secretsManagerClient,
                                 ConfigSplitter configSplitter,
                                 ConfigMerger configMerger,
                                 List<String> secretNames,
                                 ObjectMapper objectMapper) {
-        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.objectMapper = objectMapper;
         this.secretsManagerClient = secretsManagerClient;
     }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSource.java
@@ -4,7 +4,6 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.azure.security.keyvault.secrets.models.SecretProperties;
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
@@ -25,15 +24,14 @@ public class AzureKeyVaultConfigSource extends CompositeConfigSource {
     private final long expirationPeriod;
     private final ObjectMapper objectMapper;
 
-    public AzureKeyVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                     ConfigSplitter configSplitter,
+    public AzureKeyVaultConfigSource(ConfigSplitter configSplitter,
                                      ConfigMerger configMerger,
                                      List<String> secretNames,
                                      SecretClient secretClient,
                                      String expirationTimeUnit,
                                      long expirationPeriod,
                                      ObjectMapper objectMapper) {
-        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.secretClient = secretClient;
         this.expirationTimeUnit = expirationTimeUnit;
         this.expirationPeriod = expirationPeriod;

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class CompositeConfigSource implements ConfigSource {
 
-    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final ConfigSplitter configSplitter;
     private final ConfigMerger configMerger;
     private final List<String> sourceNames;
@@ -48,8 +46,7 @@ public abstract class CompositeConfigSource implements ConfigSource {
 
     @Override
     public void writeConfig(Config configBody, boolean createResources) {
-        Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(configBody);
-        List<SourceValue> sourceValues = resolveSourceNames(versionedConfig);
+        List<SourceValue> sourceValues = resolveSourceNames(configBody);
 
         for (SourceValue sourceValue : sourceValues) {
             setSource(sourceValue, createResources);

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceConfigMap.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceConfigMap.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.util.HttpStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,15 +18,14 @@ public class ConfigSourceConfigMap extends CompositeConfigSource {
     private final String configKey;
     private final ObjectMapper objectMapper;
 
-    public ConfigSourceConfigMap(VersionAwareFieldFilter versionAwareFieldFilter,
-                                 ConfigSplitter configSplitter,
+    public ConfigSourceConfigMap(ConfigSplitter configSplitter,
                                  ConfigMerger configMerger,
                                  List<String> secretNames,
                                  int maxSecretSize,
                                  K8ConfigService k8ConfigService,
                                  String configKey,
                                  ObjectMapper objectMapper) {
-        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, maxSecretSize);
+        super(configSplitter, configMerger, secretNames, maxSecretSize);
         this.k8ConfigService = k8ConfigService;
         this.configKey = configKey;
         this.objectMapper = objectMapper;

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceFile.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceFile.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import java.util.Map;
 @Slf4j
 public class ConfigSourceFile implements ConfigSource {
 
-    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final ObjectMapper objectMapper;
     private final String outputFilePath;
 
@@ -57,9 +55,8 @@ public class ConfigSourceFile implements ConfigSource {
     @Override
     public void writeConfig(Config configBody, boolean createResources) {
         try {
-            Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(configBody);
             createDirectoryIfNeed();
-            objectMapper.writeValue(new File(outputFilePath), versionedConfig);
+            objectMapper.writeValue(new File(outputFilePath), configBody);
         } catch (IOException e) {
             log.error("Can't serialize configuration", e);
         }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceKubeSecret.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceKubeSecret.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.util.HttpStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,15 +18,14 @@ public class ConfigSourceKubeSecret extends CompositeConfigSource {
     private final String secretKey;
     private final ObjectMapper objectMapper;
 
-    public ConfigSourceKubeSecret(VersionAwareFieldFilter versionAwareFieldFilter,
-                                  ConfigSplitter configSplitter,
+    public ConfigSourceKubeSecret(ConfigSplitter configSplitter,
                                   ConfigMerger configMerger,
                                   List<String> secretNames,
                                   int maxSecretSize,
                                   K8ConfigService k8ConfigService,
                                   String secretKey,
                                   ObjectMapper objectMapper) {
-        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, maxSecretSize);
+        super(configSplitter, configMerger, secretNames, maxSecretSize);
         this.k8ConfigService = k8ConfigService;
         this.secretKey = secretKey;
         this.objectMapper = objectMapper;

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSource.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.rpc.ApiException;
@@ -26,13 +25,12 @@ public class GcpVaultConfigSource extends CompositeConfigSource {
     private final SecretManagerServiceClient secretManagerServiceClient;
     private final String projectId;
 
-    public GcpVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
-                                SecretManagerServiceClient secretManagerServiceClient,
+    public GcpVaultConfigSource(SecretManagerServiceClient secretManagerServiceClient,
                                 ConfigSplitter configSplitter,
                                 ConfigMerger configMerger,
                                 List<String> secretNames,
                                 ObjectMapper objectMapper, String projectId) {
-        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.objectMapper = objectMapper;
         this.secretManagerServiceClient = secretManagerServiceClient;
         this.projectId = projectId;

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class HashiVaultConfigSource implements ConfigSource {
 
-    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final VaultTemplate vaultTemplate;
     private final String secretPath;
     private final ObjectMapper objectMapper;
@@ -44,15 +42,13 @@ public class HashiVaultConfigSource implements ConfigSource {
 
     @Override
     public void writeConfig(Config configBody, boolean createResources) {
-        Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(configBody);
-
         Optional<Config> persistedOptional = readConfigOptional();
         if (persistedOptional.isEmpty() && !createResources) {
             throw new IllegalStateException("Secret is not found " + secretPath);
         }
 
         Config persisted = persistedOptional.orElse(null);
-        Config secretConfig = ConfigUtils.secretsConfig(versionedConfig);
+        Config secretConfig = ConfigUtils.secretsConfig(configBody);
         if (!Objects.equals(persisted, secretConfig)) {
             vaultTemplate.write(secretPath, Map.of("data", secretConfig));
         }

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
@@ -3,7 +3,6 @@ package com.epam.aidial.cfg.service.config.impl.storage;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -42,12 +41,10 @@ class AzureKeyVaultConfigSourceTest {
     private ConfigSplitter configSplitter;
     @Mock
     private ConfigMerger configMerger;
-    @Mock
-    private VersionAwareFieldFilter versionAwareFieldFilter;
 
     @Test
     void writeConfig_shouldWriteSecret() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -55,8 +52,6 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.getSecret(any(String.class))).thenReturn(new KeyVaultSecret("secret", "{}"));
         Config secretConfig = new Config();
@@ -75,7 +70,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldWriteWithoutSplit() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1", "secret2"),
+        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1", "secret2"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -83,8 +78,6 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.getSecret(any(String.class))).thenReturn(new KeyVaultSecret("secret", "{}"));
         Config secretConfig = new Config();
@@ -106,7 +99,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionNotEnoughSpace() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1", "secret2"),
+        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1", "secret2"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -114,8 +107,6 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         Config secretConfig = new Config();
         secretConfig.setKeys(Map.of("key1", key));
@@ -128,7 +119,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldCreateResourceWhenTrue() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -136,8 +127,6 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));
@@ -154,7 +143,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionWhenResourceNotFoundAndCreateResourcesFalse() {
-        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -162,8 +151,6 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -47,20 +46,16 @@ class GcpVaultConfigSourceTest {
     private ConfigSplitter configSplitter;
     @Mock
     private ConfigMerger configMerger;
-    @Mock
-    private VersionAwareFieldFilter versionAwareFieldFilter;
 
     @Test
     void writeConfig_shouldWriteSecret() throws JsonProcessingException, UnsupportedEncodingException {
-        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         ByteString body = ByteString.copyFrom("{}", "utf-8");
         SecretPayload payload = SecretPayload.newBuilder().setData(body).build();
@@ -81,15 +76,13 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldWriteWithoutSplit() throws JsonProcessingException, UnsupportedEncodingException {
-        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         ByteString body = ByteString.copyFrom("{}", "utf-8");
         SecretPayload payload = SecretPayload.newBuilder().setData(body).build();
@@ -113,15 +106,13 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionNotEnoughSpace() throws JsonProcessingException {
-        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         Config secretConfig = new Config();
         secretConfig.setKeys(Map.of("key1", key));
@@ -134,15 +125,13 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldCreateResourceWhenTrue() throws JsonProcessingException {
-        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));
@@ -158,15 +147,13 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionWhenResourceNotFoundAndCreateResourcesFalse() {
-        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
-
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(config);
 
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
Moved config filtering against core version into general `ConfiExportFacade` instead of each specific source

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.