### PR TITLE
feat: make InfluxDB HTTP client timeouts configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,6 +352,9 @@ ai-dial-admin-backend/secrets-utils/generate_h2_secrets.sh can help to generate 
 | metrics.config.type | METRICS_DATASOURCE_TYPE | influx2 | No | metrics.enabled=true and content/file are empty | Datasource type, selects default config: influx2 or influx3 |
 | metrics.influx2.defaultPageSize | METRICS_INFLUX2_DEFAULT_PAGE_SIZE | 100 | No | - | Default page size for InfluxDB 2 queries |
 | metrics.influx3.defaultPageSize | METRICS_INFLUX3_DEFAULT_PAGE_SIZE | 100 | No | - | Default page size for InfluxDB 3 queries |
+| metrics.influx.connectTimeout | METRICS_INFLUX_CONNECT_TIMEOUT | 10 | No | metrics.enabled=true | InfluxDB HTTP client connection timeout in seconds |
+| metrics.influx.readTimeout | METRICS_INFLUX_READ_TIMEOUT | 60 | No | metrics.enabled=true | InfluxDB HTTP client read timeout in seconds |
+| metrics.influx.writeTimeout | METRICS_INFLUX_WRITE_TIMEOUT | 60 | No | metrics.enabled=true | InfluxDB HTTP client write timeout in seconds |
 |  | METRICS_STORAGE_HOST | - | Yes | metrics.enabled=true and default metrics config used | URL for InfluxDB database connection |
 |  | METRICS_STORAGE_TOKEN | - | Yes | metrics.enabled=true and default metrics config used | Token for InfluxDB database connection |
 |  | METRICS_STORAGE_ORG | dial | No | metrics.enabled=true and default influx2 config used | InfluxDB 2 organization with metrics |

--- a/src/main/java/com/epam/aidial/metric/config/MetricDatasetConfiguration.java
+++ b/src/main/java/com/epam/aidial/metric/config/MetricDatasetConfiguration.java
@@ -47,11 +47,14 @@ public class MetricDatasetConfiguration {
     }
 
     @Bean("influxOkHttpClientBuilder")
-    public OkHttpClient.Builder influxOkHttpClientBuilder() {
+    public OkHttpClient.Builder influxOkHttpClientBuilder(
+            @Value("${metrics.influx.connectTimeout}") int connectTimeout,
+            @Value("${metrics.influx.readTimeout}") int readTimeout,
+            @Value("${metrics.influx.writeTimeout}") int writeTimeout) {
         return new OkHttpClient().newBuilder()
-                .connectTimeout(10, TimeUnit.SECONDS) // TODO: make configurable
-                .readTimeout(60, TimeUnit.SECONDS) // TODO: make configurable
-                .writeTimeout(60, TimeUnit.SECONDS); // TODO: make configurable
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS);
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -162,6 +162,9 @@ metrics.config.type=${METRICS_DATASOURCE_TYPE:influx2}
 # Engine-specific settings
 metrics.influx2.defaultPageSize=${METRICS_INFLUX2_DEFAULT_PAGE_SIZE:100}
 metrics.influx3.defaultPageSize=${METRICS_INFLUX3_DEFAULT_PAGE_SIZE:100}
+metrics.influx.connectTimeout=${METRICS_INFLUX_CONNECT_TIMEOUT:10}
+metrics.influx.readTimeout=${METRICS_INFLUX_READ_TIMEOUT:60}
+metrics.influx.writeTimeout=${METRICS_INFLUX_WRITE_TIMEOUT:60}
 metrics.gap-filler.max-buckets=${METRICS_GAP_FILLER_MAX_BUCKETS:10000}
 
 # Logging


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #773

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Replace hardcoded connect/read/write timeouts with Spring properties backed by environment variables, keeping the same defaults (10s/60s/60s).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.