### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -81,6 +81,7 @@ jobs:
           base-ref: ${{ steps.get-pr.outputs.base_sha }}
           head-ref: ${{ steps.get-pr.outputs.head_sha }}
           warn-only: true # we don't want to fail the workflow, just to report the issues via comment
+          show-patched-versions: true
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         name: Save dependency review output report
         run: |
@@ -103,5 +104,5 @@ jobs:
           number: ${{ steps.get-pr.outputs.number }}
           header: dependency-review
           hide_and_recreate: true
-          message: "⚠️ Dependency review workflow failed - results may be outdated. [Check logs](${{ github.event.workflow_run.html_url }})"
+          message: "⚠️ Dependency review workflow failed - results may be outdated. [Check logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,8 +1,8 @@
 name: Deploy development
 
 on:
-  workflow_dispatch:
-  registry_package:
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
 
 jobs:
   trigger:
@@ -19,7 +19,7 @@ jobs:
             gitlab-project-id: "2545"
 
     name: Deploy to ${{ matrix.environment-name }}
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.0
     with:
       gitlab-project-id: ${{ matrix.gitlab-project-id }}
       environment-name: ${{ matrix.environment-name }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,8 +7,7 @@ on:
       - edited
       - reopened
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -16,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@4.0.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release Workflow
 on:
   push:
     branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
 
 permissions:
   contents: write
@@ -15,5 +21,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@4.0.0
+    with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -17,6 +17,7 @@ jobs:
             [
               {
                 "command": "deploy-review",
+                "permission": "write",
                 "issue_type": "pull-request",
                 "repository": "epam/ai-dial-ci",
                 "static_args": [

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.epam.aidial'
-version = "0.16.0-rc"
+version = "0.0.0"
 
 java {
     toolchain {


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in build.gradle file to dev marker (`0.0.0`)
- minor workflow-related fixes & alignments