### PR TITLE
fix(metrics): multi-agg branch collapse, groupBy alias, $in/$nin filters

### DIFF
--- a/query-language/src/main/java/com/epam/aidial/ql/LanguageConverter.java
+++ b/query-language/src/main/java/com/epam/aidial/ql/LanguageConverter.java
@@ -101,7 +101,9 @@ public class LanguageConverter {
         for (int i = 0; i < expressions.size(); i++) {
             final Expression expression = expressions.get(i);
             final boolean aggregation = expression.isAggregation() || isGroupFunction(expression);
-            if (!aggregation && (groupExpressions.contains(expression) || groupExpressions.containsAll(expression.getDependentColumns()))) {
+            if (!aggregation && (groupExpressions.contains(expression)
+                    || groupExpressions.containsAll(expression.getDependentColumns())
+                    || isAliasCoveredByGroupBy(expression, groupExpressions))) {
                 continue;
             } else if (!aggregation) {
                 if (shouldGroup) {
@@ -125,6 +127,19 @@ public class LanguageConverter {
     private boolean isGroupFunction(Expression expression) {
         return expression instanceof Alias alias && alias.getExpression() instanceof GroupFunctionCall
                || expression instanceof GroupFunctionCall;
+    }
+
+    // The user may write `groupBy: ["proj"]` referencing the alias name from
+    // `expressions: ["project_id as proj"]`. The groupBy parser resolves "proj"
+    // to a fresh Column("proj") rather than the original Alias object, so neither
+    // direct membership nor dependent-column coverage matches. Treat the alias as
+    // covered when groupBy contains a Column whose name equals the alias name.
+    private boolean isAliasCoveredByGroupBy(Expression expression, Set<Expression> groupExpressions) {
+        if (!(expression instanceof Alias alias)) {
+            return false;
+        }
+        return groupExpressions.stream()
+                .anyMatch(g -> g instanceof Column column && alias.getName().equals(column.getName()));
     }
 
     private Query convert(final QueryDto query, final Map<String, Table> tables) throws ParseException {

--- a/src/main/java/com/epam/aidial/metric/model/influx/FluxStandardImports.java
+++ b/src/main/java/com/epam/aidial/metric/model/influx/FluxStandardImports.java
@@ -6,4 +6,5 @@ import lombok.experimental.UtilityClass;
 public class FluxStandardImports {
     public static final String SCHEMA = "import \"influxdata/influxdb/schema\"";
     public static final String REGEXP = "import \"regexp\"";
+    public static final String ARRAY = "import \"array\"";
 }

--- a/src/main/java/com/epam/aidial/metric/service/AbstractQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/AbstractQueryBuilder.java
@@ -249,6 +249,22 @@ public abstract class AbstractQueryBuilder<C, T extends TableDeclaration> {
     }
 
     /**
+     * Translates a groupBy column name to the underlying source column name. When the
+     * user writes `groupBy: ["proj"]` referencing an alias `"project_id as proj"` in
+     * `expressions`, the parser yields a Column("proj"), but the storage column is
+     * actually "project_id". `nameToExpression["proj"]` was set by
+     * {@link #resolveExpressionsToOuterColumnNames} to the aliased Column, so this
+     * unwinds the alias. For non-aliased names it is a no-op.
+     */
+    protected String resolveGroupBySourceName(String name) {
+        var expression = nameToExpression.get(name);
+        if (expression instanceof Column column) {
+            return column.getName();
+        }
+        return name;
+    }
+
+    /**
      * Resolves a sort/orderBy expression to its outer column name.
      * First tries direct object lookup, then resolves by name through nameToExpression.
      */

--- a/src/main/java/com/epam/aidial/metric/service/influx/FluxConditionPartBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/FluxConditionPartBuilder.java
@@ -9,6 +9,7 @@ import com.epam.aidial.metric.service.RangeFilterUtils;
 import com.epam.aidial.metric.util.CollectorsUtils;
 import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
 import com.epam.aidial.ql.model.Filter;
+import com.epam.aidial.ql.model.Tuple;
 import com.epam.aidial.ql.model.filters.And;
 import com.epam.aidial.ql.model.filters.BinaryComparisonFilter;
 import com.epam.aidial.ql.model.filters.Not;
@@ -127,13 +128,20 @@ public class FluxConditionPartBuilder {
         if (!(binaryComparisonFilter.getLeftExpression() instanceof Column column)) {
             throw new NotImplementedException("Left part of expression must be a column");
         }
-        if (!(binaryComparisonFilter.getRightExpression() instanceof Constant constant)) {
-            throw new NotImplementedException("Right part of expression must be a constant");
+
+        var operator = binaryComparisonFilter.getOperator();
+        var right = binaryComparisonFilter.getRightExpression();
+        if (operator == BinaryComparisonOperator.IN || operator == BinaryComparisonOperator.NOT_IN) {
+            if (!(right instanceof Tuple tuple)) {
+                throw new NotImplementedException("Right part of IN/NOT IN expression must be a tuple");
+            }
+            return createInFilter(column.getName(), tuple, operator);
         }
 
-        var columnName = column.getName();
-        var value = constant.getValue();
-        return createBinaryComparisonFilter(columnName, value, binaryComparisonFilter.getOperator(), regexCounter);
+        if (!(right instanceof Constant constant)) {
+            throw new NotImplementedException("Right part of expression must be a constant");
+        }
+        return createBinaryComparisonFilter(column.getName(), constant.getValue(), operator, regexCounter);
     }
 
     private FluxQueryPart createBinaryComparisonFilter(String columnName, Comparable<?> value,
@@ -149,9 +157,25 @@ public class FluxConditionPartBuilder {
             case LIKE -> createLikeFilter(columnName, value, regexCounter);
             case NOT_LIKE -> throw new NotImplementedException("NOT LIKE operator is not supported yet");
 
-            case IN -> throw new NotImplementedException("IN operator is not supported yet");
-            case NOT_IN -> throw new NotImplementedException("NOT IN operator is not supported yet");
+            case IN, NOT_IN -> throw new IllegalStateException("IN/NOT IN handled before this point");
         };
+    }
+
+    private FluxQueryPart createInFilter(String columnName, Tuple tuple, BinaryComparisonOperator operator) {
+        var values = tuple.getExpressions().stream()
+                .map(e -> {
+                    if (!(e instanceof Constant c)) {
+                        throw new NotImplementedException("IN values must be constants");
+                    }
+                    return quoteIfNeeded(c.getValue());
+                })
+                .collect(Collectors.joining(", ", "[", "]"));
+        var quotedColumn = SimpleFluxBuilder.quote(columnName);
+        var clause = "contains(value: r[%s], set: %s)".formatted(quotedColumn, values);
+        if (operator == BinaryComparisonOperator.NOT_IN) {
+            clause = "not " + clause;
+        }
+        return FluxQueryPart.of(clause);
     }
 
     private FluxQueryPart createEqualsFilter(String columnName, Comparable<?> comparable) {

--- a/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
@@ -9,6 +9,7 @@ import com.epam.aidial.expressions.Constant;
 import com.epam.aidial.expressions.Expression;
 import com.epam.aidial.expressions.FunctionCall;
 import com.epam.aidial.expressions.GroupFunctionCall;
+import com.epam.aidial.expressions.enums.Type;
 import com.epam.aidial.expressions.impl.ColumnImpl;
 import com.epam.aidial.expressions.impl.FunctionImpl;
 import com.epam.aidial.metric.component.TemporalNameGenerator;
@@ -20,6 +21,7 @@ import com.epam.aidial.metric.model.configuration.influx.InfluxDatasetDeclaratio
 import com.epam.aidial.metric.model.configuration.influx.InfluxTableDeclaration;
 import com.epam.aidial.metric.model.influx.FluxQueryContext;
 import com.epam.aidial.metric.model.influx.FluxQueryPart;
+import com.epam.aidial.metric.model.influx.FluxStandardImports;
 import com.epam.aidial.metric.service.AbstractQueryBuilder;
 import com.epam.aidial.metric.service.RangeFilterUtils;
 import com.epam.aidial.metric.util.CollectorsUtils;
@@ -41,9 +43,11 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
@@ -142,25 +146,23 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
             String columnName = innerQueryContext.getColumnNames().get(0);
             combiner.add(tempTableName + " = " + innerQueryContext.getQuery(), innerQueryContext.getImports(), innerQueryContext.getPreamble());
 
-            var finalGroupByColumnNames = groupByColumnNames;
             var fillNullJoinKeys = aggregationFunctionCalls.size() > 1 && !groupByColumnNames.isEmpty();
             aggregations = aggregationFunctionCalls.stream()
                     .map(f -> buildAggregationForTempTable(
                             tempTableName, columnName, expressionToOuterColumnNames.get(f),
-                            query.getWhere(), finalGroupByColumnNames, f, regexCounter, fillNullJoinKeys))
+                            query.getWhere(), groupByColumnNames, f, regexCounter, fillNullJoinKeys))
                     .toList();
         } else {
             var table = getTable(query);
-            var finalGroupByColumnNames = groupByColumnNames;
             var fillNullJoinKeys = aggregationFunctionCalls.size() > 1 && !groupByColumnNames.isEmpty();
             aggregations = aggregationFunctionCalls.stream()
                     .map(f -> buildAggregationForTable(
                             table.getName(), expressionToOuterColumnNames.get(f),
-                            query.getWhere(), finalGroupByColumnNames, f, regexCounter, fillNullJoinKeys))
+                            query.getWhere(), groupByColumnNames, f, regexCounter, fillNullJoinKeys))
                     .toList();
         }
 
-        combineAggregations(combiner, aggregations, groupByColumnNames);
+        combineAggregations(combiner, aggregations, aggregationFunctionCalls, groupByColumnNames);
 
         combiner.add(SimpleFluxBuilder.createUngroupPart());
         combiner.add(createRenamePart(query.getFrom(), query.getExpressions()));
@@ -251,7 +253,7 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         var joinColumns = new ArrayList<String>();
         joinColumns.add(windowOuterName);
         joinColumns.addAll(groupByColumnNames);
-        combineAggregations(combiner, aggregations, joinColumns);
+        combineAggregations(combiner, aggregations, aggregationFunctionCalls, joinColumns);
 
         combiner.add(SimpleFluxBuilder.createUngroupPart());
         combiner.add(buildSortPart(query.getOrderBy()));
@@ -522,12 +524,40 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
     // ---- Multi-aggregation join logic ----
 
     /**
+     * Wraps a single aggregation branch so it always emits exactly one row, then tags it
+     * with the synthetic join key. Unions the original pipeline with a one-row zero
+     * sentinel, re-groups, and re-sums over the output column. Both supported
+     * aggregations (count, sum) are additive, so adding a zero row is an identity
+     * operation when the branch has real data and yields 0 when it has none.
+     */
+    private FluxQueryPart wrapWithZeroFallback(FluxQueryPart agg, String outerColumn, Type type, String joinKey) {
+        var zero = zeroLiteralForType(type);
+        var quotedOuter = SimpleFluxBuilder.quote(outerColumn);
+        var wrappedQuery = "union(tables: [\n" + agg.getQuery()
+                + ",\narray.from(rows: [{" + outerColumn + ": " + zero + "}])\n])"
+                + "\n|> group()"
+                + "\n|> sum(column: " + quotedOuter + ")"
+                + "\n" + SimpleFluxBuilder.createSetPart(joinKey, "any");
+        var imports = new HashSet<>(agg.getImports());
+        imports.add(FluxStandardImports.ARRAY);
+        return FluxQueryPart.of(Set.copyOf(imports), agg.getPreamble(), wrappedQuery);
+    }
+
+    private static String zeroLiteralForType(Type type) {
+        return switch (type) {
+            case FLOAT, DOUBLE -> "0.0";
+            default -> "0";
+        };
+    }
+
+    /**
      * Combines multiple aggregation sub-pipelines into the combiner using temp tables
      * and sequential joins. For a single aggregation, no join is needed.
      */
     private void combineAggregations(
             InfluxQueryPartCombiner combiner,
             List<FluxQueryPart> aggregations,
+            List<AggregationFunctionCall> aggregationCalls,
             List<String> joinColumnNames
     ) {
         if (aggregations.isEmpty()) {
@@ -538,16 +568,22 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
             return;
         }
 
-        // When there are no group-by columns, add a synthetic join key.
+        // When there are no group-by columns, add a synthetic join key. Each branch may
+        // filter down to zero rows, in which case count()/sum() emit no row at all;
+        // the subsequent inner-join would then collapse the entire result and wipe out
+        // real values from non-empty branches. Wrap each branch in a zero-row union so
+        // every branch emits exactly one row (actual value or 0), letting the join
+        // preserve non-empty branches.
         if (joinColumnNames.isEmpty()) {
             var syntheticColumn = getNewTemporaryName(TEMPORAL_COLUMN_NAME);
             joinColumnNames = List.of(syntheticColumn);
-            var syntheticColumnName = syntheticColumn;
-            aggregations = aggregations.stream()
-                    .map(agg -> new InfluxQueryPartCombiner()
-                            .add(agg)
-                            .add(SimpleFluxBuilder.createSetPart(syntheticColumnName, "any"))
-                            .build())
+            var originalAggregations = aggregations;
+            aggregations = IntStream.range(0, originalAggregations.size())
+                    .mapToObj(i -> wrapWithZeroFallback(
+                            originalAggregations.get(i),
+                            expressionToOuterColumnNames.get(aggregationCalls.get(i)),
+                            aggregationCalls.get(i).getType(),
+                            syntheticColumn))
                     .toList();
         }
 

--- a/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
@@ -130,7 +130,10 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
 
     @Override
     protected FluxQueryContext buildAggregationQuery(Query query) {
-        var groupByColumnNames = getGroupByColumns(query.getGroupBy()).stream().map(Column::getName).toList();
+        var groupByColumnNames = getGroupByColumns(query.getGroupBy()).stream()
+                .map(Column::getName)
+                .map(this::resolveGroupBySourceName)
+                .toList();
         var aggregationFunctionCalls = query.getExpressions().stream()
                 .map(this::resolveAlias)
                 .filter(e -> e instanceof AggregationFunctionCall)
@@ -233,7 +236,9 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
     @Override
     protected FluxQueryContext buildWindowColumnAggregationQuery(Query query) {
         var groupFunctionCall = extractWindowFunction(query.getGroupBy());
-        var groupByColumnNames = extractGroupByColumnNames(query.getGroupBy());
+        var groupByColumnNames = extractGroupByColumnNames(query.getGroupBy()).stream()
+                .map(this::resolveGroupBySourceName)
+                .toList();
         var aggregationFunctionCalls = resolveAggregationFunctionCalls(query.getExpressions());
 
         var table = getTable(query);

--- a/src/main/java/com/epam/aidial/metric/service/influx3/SqlConditionBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/SqlConditionBuilder.java
@@ -6,6 +6,7 @@ import com.epam.aidial.metric.service.RangeFilterUtils;
 import com.epam.aidial.metric.util.CollectorsUtils;
 import com.epam.aidial.ql.common.model.enums.BinaryComparisonOperator;
 import com.epam.aidial.ql.model.Filter;
+import com.epam.aidial.ql.model.Tuple;
 import com.epam.aidial.ql.model.filters.And;
 import com.epam.aidial.ql.model.filters.BinaryComparisonFilter;
 import com.epam.aidial.ql.model.filters.Not;
@@ -14,6 +15,7 @@ import com.epam.aidial.ql.model.filters.UnaryComparisonFilter;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,13 +104,20 @@ public class SqlConditionBuilder {
         if (!(filter.getLeftExpression() instanceof Column column)) {
             throw new NotImplementedException("Left part of expression must be a column");
         }
-        if (!(filter.getRightExpression() instanceof Constant constant)) {
-            throw new NotImplementedException("Right part of expression must be a constant");
+
+        var operator = filter.getOperator();
+        var right = filter.getRightExpression();
+        if (operator == BinaryComparisonOperator.IN || operator == BinaryComparisonOperator.NOT_IN) {
+            if (!(right instanceof Tuple tuple)) {
+                throw new NotImplementedException("Right part of IN/NOT IN expression must be a tuple");
+            }
+            return createInFilter(column.getName(), tuple, operator, paramCounter);
         }
 
-        var columnName = column.getName();
-        var value = constant.getValue();
-        return createBinaryComparisonFilter(columnName, value, filter.getOperator(), paramCounter);
+        if (!(right instanceof Constant constant)) {
+            throw new NotImplementedException("Right part of expression must be a constant");
+        }
+        return createBinaryComparisonFilter(column.getName(), constant.getValue(), operator, paramCounter);
     }
 
     private static SqlConditionResult createBinaryComparisonFilter(String columnName, Comparable<?> value,
@@ -127,9 +136,25 @@ public class SqlConditionBuilder {
             case ENDS_WITH -> createLikePatternFilter(columnName, "%" + escapeLikeWildcards(value), paramCounter);
             case LIKE -> createLikeFilter(columnName, value, paramCounter);
             case NOT_LIKE -> throw new NotImplementedException("NOT LIKE operator is not supported yet");
-            case IN -> throw new NotImplementedException("IN operator is not supported yet");
-            case NOT_IN -> throw new NotImplementedException("NOT IN operator is not supported yet");
+            case IN, NOT_IN -> throw new IllegalStateException("IN/NOT IN handled before this point");
         };
+    }
+
+    private static SqlConditionResult createInFilter(String columnName, Tuple tuple,
+                                                     BinaryComparisonOperator operator, AtomicInteger paramCounter) {
+        var params = new HashMap<String, Object>();
+        var paramRefs = new ArrayList<String>();
+        for (var expression : tuple.getExpressions()) {
+            if (!(expression instanceof Constant constant)) {
+                throw new NotImplementedException("IN values must be constants");
+            }
+            var paramName = "p" + paramCounter.getAndIncrement();
+            params.put(paramName, constant.getValue());
+            paramRefs.add("$" + paramName);
+        }
+        var sqlOperator = operator == BinaryComparisonOperator.NOT_IN ? "NOT IN" : "IN";
+        var query = "\"%s\" %s (%s)".formatted(columnName, sqlOperator, String.join(", ", paramRefs));
+        return new SqlConditionResult(query, params);
     }
 
     private static SqlConditionResult createSimpleComparisonFilter(String columnName, Comparable<?> value,

--- a/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx3/SqlQueryBuilder.java
@@ -132,7 +132,13 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
         var paramCounter = new AtomicInteger(0);
         var allParams = new HashMap<String, Object>();
 
-        var groupByColumns = getGroupByColumns(query.getGroupBy()).stream().map(Column::getName).toList();
+        // Outer names are what the user wrote in groupBy (which may be aliases from
+        // expressions). Source names are what we emit in the SQL — alias references
+        // must be unwound to the underlying storage column.
+        var groupByOuterNames = getGroupByColumns(query.getGroupBy()).stream().map(Column::getName).toList();
+        var groupBySourceNames = groupByOuterNames.stream()
+                .map(this::resolveGroupBySourceName)
+                .toList();
         var aggregationFunctionCalls = query.getExpressions().stream()
                 .map(this::resolveAlias)
                 .filter(AggregationFunctionCall.class::isInstance)
@@ -162,10 +168,18 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
                 .collect(Collectors.toSet());
         var selectParts = new ArrayList<String>();
 
-        // Add group by columns to select only if they appear in expressions
-        for (var groupByCol : groupByColumns) {
-            if (expressionColumnNames.contains(groupByCol)) {
-                selectParts.add("\"" + groupByCol + "\"");
+        // Add group by columns to select only if they appear in expressions; render
+        // `"source" AS "outer"` when the user defined an alias.
+        for (int i = 0; i < groupByOuterNames.size(); i++) {
+            var outer = groupByOuterNames.get(i);
+            if (!expressionColumnNames.contains(outer)) {
+                continue;
+            }
+            var source = groupBySourceNames.get(i);
+            if (source.equals(outer)) {
+                selectParts.add("\"" + outer + "\"");
+            } else {
+                selectParts.add("\"" + source + "\" AS \"" + outer + "\"");
             }
         }
 
@@ -183,8 +197,8 @@ public class SqlQueryBuilder extends AbstractQueryBuilder<SqlQueryContext, Influ
         if (!innerWhereClause.isEmpty()) {
             sql.append(" WHERE ").append(innerWhereClause);
         }
-        if (!groupByColumns.isEmpty()) {
-            var groupByClause = groupByColumns.stream()
+        if (!groupBySourceNames.isEmpty()) {
+            var groupByClause = groupBySourceNames.stream()
                     .map(col -> "\"" + col + "\"")
                     .collect(Collectors.joining(", "));
             sql.append(" GROUP BY ").append(groupByClause);

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -164,6 +164,27 @@ public abstract class AbstractInfluxContainerTest {
             );
         }
 
+        @Test
+        void simpleSelectWithProjectIdAndDeploymentFilter() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["deployment", "project_id", "price"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "project_id", "right": "'proj1'"}},
+                          {"$eq": {"left": "deployment", "right": "'gpt-3.5'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("deployment", "project_id", "price");
+            assertThat(data.getData()).containsExactly(
+                    List.of("gpt-3.5", "proj1", 0.02)
+            );
+        }
+
     }
 
     @Nested
@@ -364,6 +385,34 @@ public abstract class AbstractInfluxContainerTest {
                     List.of("proj1", 1L, 2L),
                     List.of("proj2", 2L, 2L)
             );
+        }
+
+        @Test
+        void toolCallsForProjectAndDeployment() throws Exception {
+            // project_id=proj1 AND deployment=gpt-3.5 on mcp_analytics → only MCP #5.
+            // #5 has mcp_method=tools/list, so tool_calls=0, mcp_calls=1.
+            // Exercises a two-aggregation query with no group-by where the two aggregations
+            // take different build paths: count() uses the field-filter fast path, while
+            // sum(case when <tag>) uses the pivot path. The two branches must still join
+            // correctly through the synthetic key.
+            var data = queryFromJson("""
+                    {
+                      "expressions": [
+                        "sum(case when mcp_method = 'tools/call' then 1 else 0 end) as tool_calls",
+                        "count() as mcp_calls"
+                      ],
+                      "from": "mcp_analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "project_id", "right": "'proj1'"}},
+                          {"$eq": {"left": "deployment", "right": "'gpt-3.5'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("tool_calls", "mcp_calls");
+            assertThat(data.getData()).containsExactly(List.of(0L, 1L));
         }
 
         @Test
@@ -570,6 +619,46 @@ public abstract class AbstractInfluxContainerTest {
             assertThat(data.getData()).containsExactly(List.of(4L));
         }
 
+        @Test
+        void doubleEqualityFilterCount() throws Exception {
+            // project_id=proj1 AND deployment=gpt-4 → only INSIDE #1 matches.
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "project_id", "right": "'proj1'"}},
+                          {"$eq": {"left": "deployment", "right": "'gpt-4'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(1L));
+        }
+
+        @Test
+        void equalityAndNotEqualFilter() throws Exception {
+            // project_id=proj1 AND deployment!=gpt-4 → only INSIDE #3 (gpt-3.5, proj1) matches.
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "project_id", "right": "'proj1'"}},
+                          {"$ne": {"left": "deployment", "right": "'gpt-4'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(1L));
+        }
+
     }
 
     @Nested
@@ -755,6 +844,26 @@ public abstract class AbstractInfluxContainerTest {
 
             assertThat(columnNames(data)).containsExactly("deployment");
             assertThat(data.getData()).containsExactly(List.of("gpt-3.5"));
+        }
+
+        @Test
+        void startsWithAndEqualityFilter() throws Exception {
+            // deployment STARTS_WITH 'gpt-4' AND project_id='proj1' → only INSIDE #1.
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$starts_with": {"left": "deployment", "right": "'gpt-4'"}},
+                          {"$eq": {"left": "project_id", "right": "'proj1'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(1L));
         }
 
         @Test
@@ -1018,6 +1127,28 @@ public abstract class AbstractInfluxContainerTest {
 
             assertThat(columnNames(data)).containsExactly("cnt", "money", "tokens");
             assertThat(data.getData()).containsExactly(List.of(0L, 0.0, 0L));
+        }
+
+        @Test
+        void doubleEqualityNoIntersection() throws Exception {
+            // deployment=gpt-3.5 matches #3,#4 (user_hash=user1,user2).
+            // user_hash=user3 appears only on the OUT-OF-RANGE record.
+            // AND of both inside the time range → empty intersection.
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$eq": {"left": "deployment", "right": "'gpt-3.5'"}},
+                          {"$eq": {"left": "user_hash", "right": "'user3'"}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(0L));
         }
 
         @Test

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -680,6 +680,42 @@ public abstract class AbstractInfluxContainerTest {
             assertThat(data.getData()).containsExactly(List.of(1L));
         }
 
+        @Test
+        void inFilter() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$in": {"left": "user_hash", "right": ["'user1'", "'user2'"]}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(4L));
+        }
+
+        @Test
+        void notInFilter() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["count() as cnt"],
+                      "from": "analytics",
+                      "where": {
+                        "$and": [
+                          %s, %s,
+                          {"$nin": {"left": "user_hash", "right": ["'user1'"]}}
+                        ]
+                      }
+                    }""".formatted(TIME_GTE, TIME_LT));
+
+            assertThat(columnNames(data)).containsExactly("cnt");
+            assertThat(data.getData()).containsExactly(List.of(2L));
+        }
+
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -526,6 +526,27 @@ public abstract class AbstractInfluxContainerTest {
             );
         }
 
+        @Test
+        void groupByAliasInExpressionsAndOrderBy() throws Exception {
+            // groupBy references an alias defined in expressions ("proj" for project_id)
+            // and orderBy references the count alias ("cnt"). Both must resolve correctly.
+            // 4 in-range records — proj1: #1, #3 → 2; proj2: #2, #4 → 2.
+            var data = queryFromJson("""
+                    {
+                      "expressions": ["project_id as proj", "count() as cnt"],
+                      "from": "analytics",
+                      "groupBy": ["proj"],
+                      "where": {%s},
+                      "orderBy": [{"$desc": "cnt"}]
+                    }""".formatted(TIME_FILTER));
+
+            assertThat(columnNames(data)).containsExactly("proj", "cnt");
+            assertThat(data.getData()).containsExactlyInAnyOrder(
+                    List.of("proj1", 2L),
+                    List.of("proj2", 2L)
+            );
+        }
+
     }
 
     @Nested

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
@@ -404,34 +404,49 @@ class FluxQueryBuilderTest {
 
         var actual = fluxQueryBuilder.buildQueryContext(completable);
 
-        assertThat(actual.getImports()).isEmpty();
+        assertThat(actual.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(actual.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_0"})
+                |> rename(columns: {_value: "temp_column_0"}),
+                array.from(rows: [{temp_column_0: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_0")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_1"})
+                |> rename(columns: {_value: "temp_column_1"}),
+                array.from(rows: [{temp_column_1: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_1")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_2"})
+                |> rename(columns: {_value: "temp_column_2"}),
+                array.from(rows: [{temp_column_2: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_2")
                 |> set(key: "temp_column_3", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_3"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_3"])
@@ -475,9 +490,10 @@ class FluxQueryBuilderTest {
 
         var actual = fluxQueryBuilder.buildQueryContext(completable);
 
-        assertThat(actual.getImports()).isEmpty();
+        assertThat(actual.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(actual.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
@@ -485,9 +501,14 @@ class FluxQueryBuilderTest {
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_0"})
+                |> rename(columns: {_value: "temp_column_0"}),
+                array.from(rows: [{temp_column_0: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_0")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
@@ -495,9 +516,14 @@ class FluxQueryBuilderTest {
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_1"})
+                |> rename(columns: {_value: "temp_column_1"}),
+                array.from(rows: [{temp_column_1: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_1")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
@@ -505,7 +531,11 @@ class FluxQueryBuilderTest {
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_2"})
+                |> rename(columns: {_value: "temp_column_2"}),
+                array.from(rows: [{temp_column_2: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_2")
                 |> set(key: "temp_column_3", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_3"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_3"])
@@ -550,34 +580,49 @@ class FluxQueryBuilderTest {
 
         var actual = fluxQueryBuilder.buildQueryContext(completable);
 
-        assertThat(actual.getImports()).isEmpty();
+        assertThat(actual.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(actual.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "a"})
+                |> rename(columns: {_value: "a"}),
+                array.from(rows: [{a: 0}])
+                ])
+                |> group()
+                |> sum(column: "a")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "b"})
+                |> rename(columns: {_value: "b"}),
+                array.from(rows: [{b: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "b")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "c"})
+                |> rename(columns: {_value: "c"}),
+                array.from(rows: [{c: 0}])
+                ])
+                |> group()
+                |> sum(column: "c")
                 |> set(key: "temp_column_0", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_0"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_0"])
@@ -791,13 +836,14 @@ class FluxQueryBuilderTest {
 
         var actual = fluxQueryBuilder.buildQueryContext(completable);
 
-        assertThat(actual.getImports()).containsExactlyInAnyOrder(FluxStandardImports.REGEXP);
+        assertThat(actual.getImports()).containsExactlyInAnyOrder(FluxStandardImports.REGEXP, FluxStandardImports.ARRAY);
         assertThat(actual.getPreamble()).containsExactly(
                 "_re0 = regexp.compile(v: \"(?i)^ge\")",
                 "_re1 = regexp.compile(v: \"(?i)^ge\")"
         );
         assertThat(actual.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
@@ -805,9 +851,14 @@ class FluxQueryBuilderTest {
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_0"})
+                |> rename(columns: {_value: "temp_column_0"}),
+                array.from(rows: [{temp_column_0: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_0")
                 |> set(key: "temp_column_2", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "completion_tokens")
@@ -815,7 +866,11 @@ class FluxQueryBuilderTest {
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_1"})
+                |> rename(columns: {_value: "temp_column_1"}),
+                array.from(rows: [{temp_column_1: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_1")
                 |> set(key: "temp_column_2", value: "any")
                 temp_table_2 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_2"])
                 temp_table_2

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
@@ -407,34 +407,49 @@ class FluxQueryIntegrationTest {
                 SELECT count(), sum(price), sum(prompt_tokens) FROM analytics \
                 WHERE _time >= '2025-02-11T15:12:00Z' AND _time < '2025-02-11T16:20:00Z'""");
 
-        assertThat(result.getImports()).isEmpty();
+        assertThat(result.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(result.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_0"})
+                |> rename(columns: {_value: "temp_column_0"}),
+                array.from(rows: [{temp_column_0: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_0")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_1"})
+                |> rename(columns: {_value: "temp_column_1"}),
+                array.from(rows: [{temp_column_1: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_1")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_2"})
+                |> rename(columns: {_value: "temp_column_2"}),
+                array.from(rows: [{temp_column_2: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_2")
                 |> set(key: "temp_column_3", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_3"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_3"])
@@ -453,34 +468,49 @@ class FluxQueryIntegrationTest {
 
         var result = buildFromJson(queryDto);
 
-        assertThat(result.getImports()).isEmpty();
+        assertThat(result.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(result.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_0"})
+                |> rename(columns: {_value: "temp_column_0"}),
+                array.from(rows: [{temp_column_0: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_0")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_1"})
+                |> rename(columns: {_value: "temp_column_1"}),
+                array.from(rows: [{temp_column_1: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_1")
                 |> set(key: "temp_column_3", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "temp_column_2"})
+                |> rename(columns: {_value: "temp_column_2"}),
+                array.from(rows: [{temp_column_2: 0}])
+                ])
+                |> group()
+                |> sum(column: "temp_column_2")
                 |> set(key: "temp_column_3", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_3"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_3"])
@@ -497,34 +527,49 @@ class FluxQueryIntegrationTest {
                 SELECT count() AS a, sum(price) AS b, sum(prompt_tokens) AS c FROM analytics \
                 WHERE _time >= '2025-02-11T15:12:00Z' AND _time < '2025-02-11T16:20:00Z'""");
 
-        assertThat(result.getImports()).isEmpty();
+        assertThat(result.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(result.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "a"})
+                |> rename(columns: {_value: "a"}),
+                array.from(rows: [{a: 0}])
+                ])
+                |> group()
+                |> sum(column: "a")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "b"})
+                |> rename(columns: {_value: "b"}),
+                array.from(rows: [{b: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "b")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "c"})
+                |> rename(columns: {_value: "c"}),
+                array.from(rows: [{c: 0}])
+                ])
+                |> group()
+                |> sum(column: "c")
                 |> set(key: "temp_column_0", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_0"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_0"])
@@ -543,34 +588,49 @@ class FluxQueryIntegrationTest {
 
         var result = buildFromJson(queryDto);
 
-        assertThat(result.getImports()).isEmpty();
+        assertThat(result.getImports()).containsExactly(FluxStandardImports.ARRAY);
         assertThat(result.getQuery()).isEqualTo("""
-                temp_table_0 = from(bucket: "analytics-realtime")
+                temp_table_0 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "user_hash")
                 |> group(columns: [""])
                 |> count(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "a"})
+                |> rename(columns: {_value: "a"}),
+                array.from(rows: [{a: 0}])
+                ])
+                |> group()
+                |> sum(column: "a")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_1 = from(bucket: "analytics-realtime")
+                temp_table_1 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "price")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "b"})
+                |> rename(columns: {_value: "b"}),
+                array.from(rows: [{b: 0.0}])
+                ])
+                |> group()
+                |> sum(column: "b")
                 |> set(key: "temp_column_0", value: "any")
-                temp_table_2 = from(bucket: "analytics-realtime")
+                temp_table_2 = union(tables: [
+                from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["_field"] == "prompt_tokens")
                 |> group(columns: [""])
                 |> sum(column: "_value")
                 |> keep(columns: ["_value"])
-                |> rename(columns: {_value: "c"})
+                |> rename(columns: {_value: "c"}),
+                array.from(rows: [{c: 0}])
+                ])
+                |> group()
+                |> sum(column: "c")
                 |> set(key: "temp_column_0", value: "any")
                 temp_table_3 = join(tables: {t1: temp_table_0, t2: temp_table_1}, on: ["temp_column_0"])
                 temp_table_4 = join(tables: {t1: temp_table_3, t2: temp_table_2}, on: ["temp_column_0"])


### PR DESCRIPTION
### Description of changes

This branch lands three independent fixes/features in the metrics query layer. All are covered by new tests in `AbstractInfluxContainerTest` so both the InfluxDB 2 (Flux) and InfluxDB 3 (SQL) engines are exercised against real Testcontainers.

**1. Preserve non-empty branches in multi-aggregation no-group-by Flux queries (`cf7486c0`)**

When a multi-aggregation query had no `GROUP BY`, each aggregation ran in its own sub-pipeline joined via a synthetic key. A branch whose filter yielded no rows produced no `count()` / `sum()` output at all, and the inner join then collapsed the entire result, wiping out values from non-empty branches.

Each branch is now wrapped in `union(<branch>, array.from(rows: [{col: 0}])) |> group() |> sum(column: col)` so it always emits exactly one row (real value or 0). The zero literal is type-aware (`0.0` for FLOAT/DOUBLE, `0` otherwise).

**2. Resolve groupBy alias to source column in aggregation queries (`d1da151b`)**

A query like

```json
{
  "expressions": ["project_id as proj", "count() as cnt"],
  "from": "analytics",
  "groupBy": ["proj"],
  "orderBy": [{"$desc": "cnt"}]
}
```

failed at parse time (`Column 'project_id as proj' is not under aggregate function and not in grouping cause`) because the groupBy parser resolved `"proj"` to a fresh `Column("proj")` that matched neither the original `Alias` object nor its dependent `Column("project_id")`. Even with validation relaxed, both engines emitted `proj` verbatim into pipelines that only know `project_id`.

- `LanguageConverter.validateExpressions` now treats an alias as covered when groupBy contains a `Column` whose name equals the alias name.
- `AbstractQueryBuilder.resolveGroupBySourceName` unwinds an alias name to its underlying column via `nameToExpression`.
- `FluxQueryBuilder` translates groupBy outer names to source names so group/keep/join keys use storage names.
- `SqlQueryBuilder` keeps both outer and source name lists; SELECT renders `"source" AS "outer"` when they differ; GROUP BY uses the source name.

**3. Support `\$in` / `\$nin` filters in Flux and InfluxDB 3 SQL builders (`1b1271be`)**

Both engines previously threw `NotImplementedException` for `IN` / `NOT IN`. The right-hand side of an `\$in` filter is parsed as a `Tuple`, not a `Constant`, so the existing constant-only fast path also rejected it before the operator switch ever ran.

- `FluxConditionPartBuilder` now branches on operator before the constant check; `IN` / `NOT_IN` accept a `Tuple` and emit `contains(value: r["col"], set: [...])` (prepended with `not ` for `NOT_IN`).
- `SqlConditionBuilder` emits `"col" IN (\$p1, \$p2, ...)` (or `NOT IN`), binding each tuple value as a parameter.
- Comparison stays case-sensitive, matching `\$eq`.

### Tests

New tests in `AbstractInfluxContainerTest`, run against both `InfluxContainerTest` and `Influx3ContainerTest`:
- `EdgeCaseTests.multipleAggregationsWithNoMatchingFilter` and other zero-intersection / multi-aggregation cases (commit 1)
- `GroupByTests.groupByAliasInExpressionsAndOrderBy` (commit 2)
- `FilterTests.inFilter` and `FilterTests.notInFilter` (commit 3)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.