### PR TITLE
hotfix: set responses defaults to null for secret config, extend CVE-2025-59250 expiration date in .trivyignore 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
 #Fixed version already in use, false positive per https://github.com/aquasecurity/trivy/discussions/9745
-CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-05-01
+CVE-2025-59250 pkg:maven/com.microsoft.sqlserver/mssql-jdbc exp:2026-12-31

--- a/src/main/java/com/epam/aidial/core/config/CoreModel.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreModel.java
@@ -35,6 +35,7 @@ public class CoreModel extends Deployment {
         coreModel.setFieldsHashingOrder(null);
         coreModel.setForwardAuthToken(null);
         coreModel.setDefaults(null);
+        coreModel.setResponsesDefaults(null);
         coreModel.setInterceptors(null);
         coreModel.setDescriptionKeywords(null);
         coreModel.setMaxRetryAttempts(null);

--- a/src/main/java/com/epam/aidial/core/config/CoreToolSet.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreToolSet.java
@@ -41,6 +41,7 @@ public class CoreToolSet extends CoreSecuredResource {
         coreToolSet.setAuthSettings(null);
         coreToolSet.setForwardAuthToken(null);
         coreToolSet.setDefaults(null);
+        coreToolSet.setResponsesDefaults(null);
         coreToolSet.setInterceptors(null);
         coreToolSet.setDescriptionKeywords(null);
         coreToolSet.setMaxRetryAttempts(null);


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.