### PR TITLE
chore: improve config filtering against core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,10 @@ dependencies {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
-            because("previous versions have vulnerabilities)")
+            because("previous versions have vulnerabilities")
+        }
+        implementation("org.bouncycastle:bcprov-jdk18on:1.84") {
+            because("previous versions have vulnerabilities")
         }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")

--- a/build.gradle
+++ b/build.gradle
@@ -176,10 +176,7 @@ dependencies {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
-            because("previous versions have vulnerabilities")
-        }
-        implementation("org.bouncycastle:bcprov-jdk18on:1.84") {
-            because("previous versions have vulnerabilities")
+            because("previous versions have vulnerabilities)")
         }
         testImplementation('org.apache.commons:commons-compress:1.27.1') {
             because("previous versions have vulnerabilities")

--- a/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/ExportConfiguration.java
@@ -16,6 +16,7 @@ import com.epam.aidial.cfg.service.config.impl.storage.GcpVaultConfigSource;
 import com.epam.aidial.cfg.service.config.impl.storage.HashiVaultConfigSource;
 import com.epam.aidial.cfg.service.config.impl.storage.K8ConfigService;
 import com.epam.aidial.cfg.service.config.transfer.ConfigTransferLock;
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetriever;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetrieverImpl;
 import com.epam.aidial.cfg.service.config.transfer.exporter.CoreConfigRetrieverSecuredImpl;
@@ -44,15 +45,17 @@ public class ExportConfiguration {
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "LOCAL_FILE")
-    public ConfigSourceFile configSourceJsonFile(ObjectMapper objectMapper,
+    public ConfigSourceFile configSourceJsonFile(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                 ObjectMapper objectMapper,
                                                  @Value("${config.export.outputFile.path}") String outputFilePath) {
-        return new ConfigSourceFile(objectMapper, outputFilePath);
+        return new ConfigSourceFile(versionAwareFieldFilter, objectMapper, outputFilePath);
     }
 
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "CONFIG_MAP")
-    public ConfigSourceConfigMap configSourceJsonConfigMap(ConfigSplitter configSplitter,
+    public ConfigSourceConfigMap configSourceJsonConfigMap(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                           ConfigSplitter configSplitter,
                                                            ConfigMerger configMerger,
                                                            @Value("${config.export.configMap.maxSize:1048576}") int maxSize,
                                                            @Value("${config.export.configMap.name:}") String configMapName,
@@ -64,13 +67,14 @@ public class ExportConfiguration {
             throw new IllegalArgumentException("Config map name and names are both specified");
         }
         List<String> names = resolveNames(configMapName, configMapNames);
-        return new ConfigSourceConfigMap(configSplitter, configMerger, names, maxSize, k8ConfigService, configKey, objectMapper);
+        return new ConfigSourceConfigMap(versionAwareFieldFilter, configSplitter, configMerger, names, maxSize, k8ConfigService, configKey, objectMapper);
     }
 
     @Bean("configSource")
     @Qualifier("configSource")
     @ConditionalOnProperty(value = "config.export.storageType", havingValue = "KUBE_SECRET")
-    public ConfigSourceKubeSecret configSourceJsonKubeSecret(ConfigSplitter configSplitter,
+    public ConfigSourceKubeSecret configSourceJsonKubeSecret(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                             ConfigSplitter configSplitter,
                                                              ConfigMerger configMerger,
                                                              @Value("${config.export.kubeSecret.maxSize:1048576}") int maxSize,
                                                              @Value("${config.export.kubeSecret.name:}") String kubeSecretName,
@@ -82,7 +86,7 @@ public class ExportConfiguration {
             throw new IllegalArgumentException("Kube secret name and names are both specified");
         }
         List<String> names = resolveNames(kubeSecretName, kubeSecretNames);
-        return new ConfigSourceKubeSecret(configSplitter, configMerger, names, maxSize, k8ConfigService, kubeSecretKey, objectMapper);
+        return new ConfigSourceKubeSecret(versionAwareFieldFilter, configSplitter, configMerger, names, maxSize, k8ConfigService, kubeSecretKey, objectMapper);
     }
 
     @Bean
@@ -124,48 +128,52 @@ public class ExportConfiguration {
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "azure")
-    public AzureKeyVaultConfigSource azureKeyVaultConfigSource(ObjectMapper objectMapper,
+    public AzureKeyVaultConfigSource azureKeyVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                               ObjectMapper objectMapper,
                                                                SecretClient secretClient,
                                                                @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                                @Value("${config.export.keyvault.expiration.unit}") String expirationTimeUnit,
                                                                @Value("${config.export.keyvault.expiration.period}") Long expirationPeriod,
                                                                ConfigSplitter configSplitter,
                                                                ConfigMerger configMerger) {
-        return new AzureKeyVaultConfigSource(configSplitter, configMerger, secretNames, secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
+        return new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, secretNames, secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "vault")
-    public HashiVaultConfigSource hashiVaultConfigSource(ObjectMapper objectMapper,
+    public HashiVaultConfigSource hashiVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                         ObjectMapper objectMapper,
                                                          @Value("${config.export.keyvault.secretPath}") String secretPath,
                                                          VaultTemplate vaultTemplate) {
-        return new HashiVaultConfigSource(vaultTemplate, secretPath, objectMapper);
+        return new HashiVaultConfigSource(versionAwareFieldFilter, vaultTemplate, secretPath, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "aws")
-    public AwsVaultConfigSource awsVaultConfigSource(ObjectMapper objectMapper,
+    public AwsVaultConfigSource awsVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                     ObjectMapper objectMapper,
                                                      SecretsManagerClient secretsManagerClient,
                                                      @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                      @Value("${config.export.keyvault.expiration.unit}") String expirationTimeUnit,
                                                      @Value("${config.export.keyvault.expiration.period}") Long expirationPeriod,
                                                      ConfigSplitter configSplitter,
                                                      ConfigMerger configMerger) {
-        return new AwsVaultConfigSource(secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper);
+        return new AwsVaultConfigSource(versionAwareFieldFilter, secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper);
     }
 
     @Bean("securedConfigSource")
     @Qualifier("securedConfigSource")
     @ConditionalOnProperty(value = "config.export.keyvault.type", havingValue = "gcp")
-    public GcpVaultConfigSource gcpVaultConfigSource(ObjectMapper objectMapper,
+    public GcpVaultConfigSource gcpVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                                     ObjectMapper objectMapper,
                                                      SecretManagerServiceClient secretsManagerClient,
                                                      @Value("${config.export.keyvault.secretNames}") List<String> secretNames,
                                                      @Value("${gcp.keyvault.projectId}") String projectId,
                                                      ConfigSplitter configSplitter,
                                                      ConfigMerger configMerger) {
-        return new GcpVaultConfigSource(secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper, projectId);
+        return new GcpVaultConfigSource(versionAwareFieldFilter, secretsManagerClient, configSplitter, configMerger, secretNames, objectMapper, projectId);
     }
 
     private List<String> resolveNames(String name, List<String> names) {

--- a/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
+++ b/src/main/java/com/epam/aidial/cfg/configuration/JsonMapperConfiguration.java
@@ -41,11 +41,6 @@ public class JsonMapperConfiguration {
         return createCoreJsonMapper();
     }
 
-    @Bean
-    public JsonMapper nullIncludedJsonMapper() {
-        return createNullIncludedJsonMapper();
-    }
-
     public static JsonMapper createJsonMapper() {
         return createDefaultJsonMapperBuilder()
                 .build();
@@ -54,12 +49,6 @@ public class JsonMapperConfiguration {
     public static JsonMapper createPrettyJsonMapper() {
         return createDefaultJsonMapperBuilder()
                 .enable(SerializationFeature.INDENT_OUTPUT)
-                .build();
-    }
-
-    public static JsonMapper createNullIncludedJsonMapper() {
-        return createDefaultJsonMapperBuilder()
-                .serializationInclusion(JsonInclude.Include.ALWAYS)
                 .build();
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportFacade.java
@@ -2,7 +2,6 @@ package com.epam.aidial.cfg.service.config.export;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.service.config.normalizer.CoreConfigNormalizer;
-import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,19 +16,16 @@ public class ConfigExportFacade {
 
     private final CoreConfigAggregatorService configService;
     private final ConfigExportService configExportService;
-    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final List<CoreConfigNormalizer> normalizers;
 
     private final boolean createResources;
 
     public ConfigExportFacade(CoreConfigAggregatorService configService,
                               ConfigExportService configExportService,
-                              VersionAwareFieldFilter versionAwareFieldFilter,
                               List<CoreConfigNormalizer> normalizers,
                               @Value("${config.export.createResources}") boolean createResources) {
         this.configService = configService;
         this.configExportService = configExportService;
-        this.versionAwareFieldFilter = versionAwareFieldFilter;
         this.normalizers = normalizers;
         this.createResources = createResources;
     }
@@ -38,8 +34,7 @@ public class ConfigExportFacade {
         Config config = configService.getConfig();
         log.debug("Exporting current Configuration settings.");
         normalizers.forEach(n -> n.normalize(config));
-        Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(config);
-        configExportService.export(versionedConfig, createResources);
+        configExportService.export(config, createResources);
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AwsVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AwsVaultConfigSource.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -22,12 +24,13 @@ public class AwsVaultConfigSource extends CompositeConfigSource {
     private final ObjectMapper objectMapper;
     private final SecretsManagerClient secretsManagerClient;
 
-    public AwsVaultConfigSource(SecretsManagerClient secretsManagerClient,
+    public AwsVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                SecretsManagerClient secretsManagerClient,
                                 ConfigSplitter configSplitter,
                                 ConfigMerger configMerger,
                                 List<String> secretNames,
                                 ObjectMapper objectMapper) {
-        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.objectMapper = objectMapper;
         this.secretsManagerClient = secretsManagerClient;
     }
@@ -78,7 +81,7 @@ public class AwsVaultConfigSource extends CompositeConfigSource {
 
     @Override
     @SneakyThrows
-    protected String encode(Config body) {
+    protected String encode(JsonNode body) {
         return objectMapper.writeValueAsString(body);
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSource.java
@@ -4,7 +4,9 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.azure.security.keyvault.secrets.models.SecretProperties;
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -24,14 +26,15 @@ public class AzureKeyVaultConfigSource extends CompositeConfigSource {
     private final long expirationPeriod;
     private final ObjectMapper objectMapper;
 
-    public AzureKeyVaultConfigSource(ConfigSplitter configSplitter,
+    public AzureKeyVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                     ConfigSplitter configSplitter,
                                      ConfigMerger configMerger,
                                      List<String> secretNames,
                                      SecretClient secretClient,
                                      String expirationTimeUnit,
                                      long expirationPeriod,
                                      ObjectMapper objectMapper) {
-        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.secretClient = secretClient;
         this.expirationTimeUnit = expirationTimeUnit;
         this.expirationPeriod = expirationPeriod;
@@ -81,7 +84,7 @@ public class AzureKeyVaultConfigSource extends CompositeConfigSource {
 
     @Override
     @SneakyThrows
-    protected String encode(Config body) {
+    protected String encode(JsonNode body) {
         return objectMapper.writeValueAsString(body);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class CompositeConfigSource implements ConfigSource {
 
+    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final ConfigSplitter configSplitter;
     private final ConfigMerger configMerger;
     private final List<String> sourceNames;
@@ -54,16 +57,16 @@ public abstract class CompositeConfigSource implements ConfigSource {
     }
 
     @SneakyThrows
-    protected List<SourceValue> resolveSourceNames(Config configBody) {
+    private List<SourceValue> resolveSourceNames(Config configBody) {
         if (CollectionUtils.isEmpty(sourceNames)) {
             throw new IllegalStateException("Unable to store source, names is not configured.");
         }
         if (sourceNames.size() == 1) {
-            String newValue = encode(configBody);
+            String newValue = encodeConfig(configBody);
             return List.of(new SourceValue(sourceNames.get(0), newValue));
         }
 
-        List<ConfigPart> configs = configSplitter.splitConfig(configBody, this::encode, maxSourceSize, sourceNames.size());
+        List<ConfigPart> configs = configSplitter.splitConfig(configBody, this::encodeConfig, maxSourceSize, sourceNames.size());
 
         if (configs.size() > sourceNames.size()) {
             log.info("configs size {}, names size {}", configs.size(), sourceNames.size());
@@ -81,25 +84,21 @@ public abstract class CompositeConfigSource implements ConfigSource {
     }
 
     private ConfigPart emptyConfigPart() {
-        Config config = createConfig();
-        return new ConfigPart(config, encode(config));
+        Config config = new Config();
+        return new ConfigPart(config, encodeConfig(config));
     }
 
-    protected Config createConfig() {
-        return new Config();
+    private String encodeConfig(Config body) {
+        JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(body);
+        return encode(versionedConfig);
     }
-
 
     protected abstract void setSource(SourceValue source, boolean createIfNotExists);
-    
-    protected void setSource(SourceValue source) {
-        setSource(source, true);
-    }
 
     protected abstract String getSource(String sourceName);
 
 
-    protected abstract String encode(Config body);
+    protected abstract String encode(JsonNode body);
 
     protected abstract Config decode(String encoded);
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceConfigMap.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceConfigMap.java
@@ -1,7 +1,9 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.util.HttpStatus;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.SneakyThrows;
@@ -18,14 +20,15 @@ public class ConfigSourceConfigMap extends CompositeConfigSource {
     private final String configKey;
     private final ObjectMapper objectMapper;
 
-    public ConfigSourceConfigMap(ConfigSplitter configSplitter,
+    public ConfigSourceConfigMap(VersionAwareFieldFilter versionAwareFieldFilter,
+                                 ConfigSplitter configSplitter,
                                  ConfigMerger configMerger,
                                  List<String> secretNames,
                                  int maxSecretSize,
                                  K8ConfigService k8ConfigService,
                                  String configKey,
                                  ObjectMapper objectMapper) {
-        super(configSplitter, configMerger, secretNames, maxSecretSize);
+        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, maxSecretSize);
         this.k8ConfigService = k8ConfigService;
         this.configKey = configKey;
         this.objectMapper = objectMapper;
@@ -70,7 +73,7 @@ public class ConfigSourceConfigMap extends CompositeConfigSource {
     }
 
     @Override
-    protected String encode(Config body) {
+    protected String encode(JsonNode body) {
         try (var writer = new StringWriter()) {
             objectMapper.writeValue(writer, body);
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceFile.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceFile.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ import java.util.Map;
 @Slf4j
 public class ConfigSourceFile implements ConfigSource {
 
+    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final ObjectMapper objectMapper;
     private final String outputFilePath;
 
@@ -55,8 +58,9 @@ public class ConfigSourceFile implements ConfigSource {
     @Override
     public void writeConfig(Config configBody, boolean createResources) {
         try {
+            JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(configBody);
             createDirectoryIfNeed();
-            objectMapper.writeValue(new File(outputFilePath), configBody);
+            objectMapper.writeValue(new File(outputFilePath), versionedConfig);
         } catch (IOException e) {
             log.error("Can't serialize configuration", e);
         }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceKubeSecret.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSourceKubeSecret.java
@@ -1,7 +1,9 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.util.HttpStatus;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.SneakyThrows;
@@ -18,14 +20,15 @@ public class ConfigSourceKubeSecret extends CompositeConfigSource {
     private final String secretKey;
     private final ObjectMapper objectMapper;
 
-    public ConfigSourceKubeSecret(ConfigSplitter configSplitter,
+    public ConfigSourceKubeSecret(VersionAwareFieldFilter versionAwareFieldFilter,
+                                  ConfigSplitter configSplitter,
                                   ConfigMerger configMerger,
                                   List<String> secretNames,
                                   int maxSecretSize,
                                   K8ConfigService k8ConfigService,
                                   String secretKey,
                                   ObjectMapper objectMapper) {
-        super(configSplitter, configMerger, secretNames, maxSecretSize);
+        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, maxSecretSize);
         this.k8ConfigService = k8ConfigService;
         this.secretKey = secretKey;
         this.objectMapper = objectMapper;
@@ -70,7 +73,7 @@ public class ConfigSourceKubeSecret extends CompositeConfigSource {
     }
 
     @Override
-    protected String encode(Config body) {
+    protected String encode(JsonNode body) {
         try (var writer = new StringWriter()) {
             objectMapper.writeValue(writer, body);
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSource.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
@@ -25,12 +27,13 @@ public class GcpVaultConfigSource extends CompositeConfigSource {
     private final SecretManagerServiceClient secretManagerServiceClient;
     private final String projectId;
 
-    public GcpVaultConfigSource(SecretManagerServiceClient secretManagerServiceClient,
+    public GcpVaultConfigSource(VersionAwareFieldFilter versionAwareFieldFilter,
+                                SecretManagerServiceClient secretManagerServiceClient,
                                 ConfigSplitter configSplitter,
                                 ConfigMerger configMerger,
                                 List<String> secretNames,
                                 ObjectMapper objectMapper, String projectId) {
-        super(configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
+        super(versionAwareFieldFilter, configSplitter, configMerger, secretNames, MAX_SECRET_SIZE);
         this.objectMapper = objectMapper;
         this.secretManagerServiceClient = secretManagerServiceClient;
         this.projectId = projectId;
@@ -83,7 +86,7 @@ public class GcpVaultConfigSource extends CompositeConfigSource {
 
     @Override
     @SneakyThrows
-    protected String encode(Config body) {
+    protected String encode(JsonNode body) {
         return objectMapper.writeValueAsString(body);
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -15,6 +17,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class HashiVaultConfigSource implements ConfigSource {
 
+    private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final VaultTemplate vaultTemplate;
     private final String secretPath;
     private final ObjectMapper objectMapper;
@@ -50,7 +53,8 @@ public class HashiVaultConfigSource implements ConfigSource {
         Config persisted = persistedOptional.orElse(null);
         Config secretConfig = ConfigUtils.secretsConfig(configBody);
         if (!Objects.equals(persisted, secretConfig)) {
-            vaultTemplate.write(secretPath, Map.of("data", secretConfig));
+            JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(secretConfig);
+            vaultTemplate.write(secretPath, Map.of("data", versionedConfig));
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
@@ -31,12 +31,16 @@ public class HashiVaultConfigSource implements ConfigSource {
         return Map.of(secretPath, content);
     }
 
+    @SneakyThrows
     @Override
     public Config readConfig() {
-        return readConfigOptional().orElse(null);
+        Optional<JsonNode> config = readConfigOptional();
+        return config.isPresent()
+                ? objectMapper.treeToValue(config.get(), Config.class)
+                : null;
     }
 
-    private Optional<Config> readConfigOptional() {
+    private Optional<JsonNode> readConfigOptional() {
         VaultResponseSupport<SecretConfigVaultResponse> response = vaultTemplate.read(secretPath, SecretConfigVaultResponse.class);
         return Optional.ofNullable(response)
                 .map(VaultResponseSupport::getData)
@@ -45,19 +49,20 @@ public class HashiVaultConfigSource implements ConfigSource {
 
     @Override
     public void writeConfig(Config configBody, boolean createResources) {
-        Optional<Config> persistedOptional = readConfigOptional();
+        Optional<JsonNode> persistedOptional = readConfigOptional();
         if (persistedOptional.isEmpty() && !createResources) {
             throw new IllegalStateException("Secret is not found " + secretPath);
         }
 
-        Config persisted = persistedOptional.orElse(null);
+        JsonNode persisted = persistedOptional.orElse(null);
+
         Config secretConfig = ConfigUtils.secretsConfig(configBody);
-        if (!Objects.equals(persisted, secretConfig)) {
-            JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(secretConfig);
+        JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(secretConfig);
+        if (!Objects.equals(persisted, versionedConfig)) {
             vaultTemplate.write(secretPath, Map.of("data", versionedConfig));
         }
     }
 
-    public static class SecretConfigVaultResponse extends VaultResponseSupport<Config> {
+    public static class SecretConfigVaultResponse extends VaultResponseSupport<JsonNode> {
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/HashiVaultConfigSource.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.service.config.impl.storage;
 
 import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -31,13 +32,18 @@ public class HashiVaultConfigSource implements ConfigSource {
         return Map.of(secretPath, content);
     }
 
-    @SneakyThrows
     @Override
     public Config readConfig() {
         Optional<JsonNode> config = readConfigOptional();
-        return config.isPresent()
-                ? objectMapper.treeToValue(config.get(), Config.class)
-                : null;
+        if (config.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return objectMapper.treeToValue(config.get(), Config.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error reading config", e);
+        }
     }
 
     private Optional<JsonNode> readConfigOptional() {

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
@@ -93,7 +93,7 @@ public class ConfigTransfer {
     private StreamingResponseBody exportCoreConfig(ExportConfig config) {
         Config fullCoreConfig = configMapper.toCoreConfig(config);
         normalizers.forEach(n -> n.normalize(fullCoreConfig));
-        Config versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
+        JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
         return outputStream -> {
             try {
                 prettyJsonMapper.writeValue(outputStream, versionedConfig);

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilter.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -23,6 +23,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @LogExecution
+@RequiredArgsConstructor
 public class VersionAwareFieldFilter {
 
     private static final String APPLICATION_TYPE_SCHEMAS_KEY = "applicationTypeSchemas";
@@ -30,33 +31,20 @@ public class VersionAwareFieldFilter {
     private final CoreConfigVersionService coreConfigVersionService;
     private final VersionedSchemaLoader schemaLoader;
     private final ObjectMapper objectMapper;
-    private final ObjectMapper nullIncludedJsonMapper;
-
-    public VersionAwareFieldFilter(CoreConfigVersionService coreConfigVersionService,
-                                   VersionedSchemaLoader schemaLoader,
-                                   ObjectMapper objectMapper,
-                                   @Qualifier("nullIncludedJsonMapper") ObjectMapper nullIncludedJsonMapper) {
-        this.coreConfigVersionService = coreConfigVersionService;
-        this.schemaLoader = schemaLoader;
-        this.objectMapper = objectMapper;
-        this.nullIncludedJsonMapper = nullIncludedJsonMapper;
-    }
 
     /**
      * Filters a Config object to include only fields defined in the schema for the specified version.
      *
      * @param config The config to filter by target version
-     * @return Filtered config with only schema-defined fields
+     * @return Filtered config node with only schema-defined fields
      */
-    public Config filterForTargetVersion(Config config) {
+    public JsonNode filterForTargetVersion(Config config) {
         String version = coreConfigVersionService.getVersionForExport();
         try {
             JsonNode schema = schemaLoader.loadSchema(version);
-            String configJson = nullIncludedJsonMapper.writeValueAsString(config);
+            String configJson = objectMapper.writeValueAsString(config);
             JsonNode configNode = objectMapper.readTree(configJson);
-            JsonNode filteredNode = filterNodeBySchema(configNode, schema);
-            return objectMapper.treeToValue(filteredNode, Config.class);
-
+            return filterNodeBySchema(configNode, schema);
         } catch (Exception e) {
             log.error("Failed to filter config for version: {}", version, e);
             throw new SchemaValidationException("Failed to filter config for version: %s".formatted(version), e);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -76,12 +76,12 @@ import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreApplicationTypeSchema;
 import com.epam.aidial.core.config.CoreRoute;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
-import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -1902,7 +1902,7 @@ public abstract class ConfigTransferFunctionalTest {
     }
 
     @Test
-    void testExport_CoreFormatAll_FullRequest() throws IOException, JSONException {
+    void testExport_CoreFormatAll_FullRequest() throws IOException {
         // given
         String importConfig = ResourceUtils.readResource("/import_for_export.json");
         MockMultipartFile mockFile = new MockMultipartFile(
@@ -1912,8 +1912,8 @@ public abstract class ConfigTransferFunctionalTest {
                 importConfig.getBytes()
         );
 
-        Config expectedConfigObj = jsonMapper.readValue(ResourceUtils.readResource("/full_core_export.json"), Config.class);
-        String expectedConfig = prettyJsonMapper.writeValueAsString(expectedConfigObj);
+        JsonNode expectedConfigNode = jsonMapper.readTree(ResourceUtils.readResource("/full_core_export.json"));
+        String expectedConfig = prettyJsonMapper.writeValueAsString(expectedConfigNode);
 
         doReturn(123L).when(transactionTimestampContext).getTimestamp();
 

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
@@ -3,9 +3,11 @@ package com.epam.aidial.cfg.service.config.impl.storage;
 import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
@@ -41,10 +43,12 @@ class AzureKeyVaultConfigSourceTest {
     private ConfigSplitter configSplitter;
     @Mock
     private ConfigMerger configMerger;
+    @Mock
+    private VersionAwareFieldFilter versionAwareFieldFilter;
 
     @Test
     void writeConfig_shouldWriteSecret() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -52,6 +56,8 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         when(secretClient.getSecret(any(String.class))).thenReturn(new KeyVaultSecret("secret", "{}"));
         Config secretConfig = new Config();
@@ -70,7 +76,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldWriteWithoutSplit() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1", "secret2"),
+        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1", "secret2"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -78,6 +84,9 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        Config emptyConfig = new Config();
+        when(versionAwareFieldFilter.filterForTargetVersion(emptyConfig)).thenReturn(configAsJsonNode(emptyConfig));
 
         when(secretClient.getSecret(any(String.class))).thenReturn(new KeyVaultSecret("secret", "{}"));
         Config secretConfig = new Config();
@@ -99,7 +108,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionNotEnoughSpace() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1", "secret2"),
+        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1", "secret2"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -119,7 +128,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldCreateResourceWhenTrue() throws JsonProcessingException {
-        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -127,6 +136,8 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));
@@ -143,7 +154,7 @@ class AzureKeyVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionWhenResourceNotFoundAndCreateResourcesFalse() {
-        source = new AzureKeyVaultConfigSource(configSplitter, configMerger, List.of("secret1"),
+        source = new AzureKeyVaultConfigSource(versionAwareFieldFilter, configSplitter, configMerger, List.of("secret1"),
             secretClient, expirationTimeUnit, expirationPeriod, objectMapper);
 
         Config config = new Config();
@@ -151,6 +162,8 @@ class AzureKeyVaultConfigSourceTest {
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));
@@ -167,6 +180,10 @@ class AzureKeyVaultConfigSourceTest {
     private ConfigPart emptyConfigPart() {
         Config config = new Config();
         return new ConfigPart(config, objectMapper.writeValueAsString(config));
+    }
+
+    private JsonNode configAsJsonNode(Config config) {
+        return objectMapper.valueToTree(config);
     }
 
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
@@ -1,8 +1,10 @@
 package com.epam.aidial.cfg.service.config.impl.storage;
 
+import com.epam.aidial.cfg.service.config.transfer.VersionAwareFieldFilter;
 import com.epam.aidial.core.config.Config;
 import com.epam.aidial.core.config.CoreKey;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.httpjson.HttpJsonStatusCode;
 import com.google.api.gax.rpc.NotFoundException;
@@ -46,16 +48,20 @@ class GcpVaultConfigSourceTest {
     private ConfigSplitter configSplitter;
     @Mock
     private ConfigMerger configMerger;
+    @Mock
+    private VersionAwareFieldFilter versionAwareFieldFilter;
 
     @Test
     void writeConfig_shouldWriteSecret() throws JsonProcessingException, UnsupportedEncodingException {
-        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         ByteString body = ByteString.copyFrom("{}", "utf-8");
         SecretPayload payload = SecretPayload.newBuilder().setData(body).build();
@@ -76,13 +82,16 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldWriteWithoutSplit() throws JsonProcessingException, UnsupportedEncodingException {
-        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        Config emptyConfig = new Config();
+        when(versionAwareFieldFilter.filterForTargetVersion(emptyConfig)).thenReturn(configAsJsonNode(emptyConfig));
 
         ByteString body = ByteString.copyFrom("{}", "utf-8");
         SecretPayload payload = SecretPayload.newBuilder().setData(body).build();
@@ -106,7 +115,7 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionNotEnoughSpace() throws JsonProcessingException {
-        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1", "secret2"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
@@ -125,13 +134,15 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldCreateResourceWhenTrue() throws JsonProcessingException {
-        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));
@@ -147,13 +158,15 @@ class GcpVaultConfigSourceTest {
 
     @Test
     void writeConfig_shouldThrowExceptionWhenResourceNotFoundAndCreateResourcesFalse() {
-        source = new GcpVaultConfigSource(secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
+        source = new GcpVaultConfigSource(versionAwareFieldFilter, secretClient, configSplitter, configMerger, List.of("secret1"), objectMapper, "projectId");
 
         Config config = new Config();
         CoreKey key = new CoreKey();
         key.setProject("project");
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
+
+        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
 
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));
@@ -170,5 +183,10 @@ class GcpVaultConfigSourceTest {
     private ConfigPart emptyConfigPart() {
         Config config = new Config();
         return new ConfigPart(config, objectMapper.writeValueAsString(config));
+    }
+
+
+    private JsonNode configAsJsonNode(Config config) {
+        return objectMapper.valueToTree(config);
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
@@ -1,14 +1,27 @@
 package com.epam.aidial.cfg.service.config.transfer;
 
+import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.exception.SchemaValidationException;
 import com.epam.aidial.cfg.service.config.transfer.version.CoreConfigVersionService;
+import com.epam.aidial.cfg.utils.ResourceUtils;
+import com.epam.aidial.core.config.Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,7 +30,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class VersionAwareFieldFilterTest {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapperConfiguration.createJsonMapper();
     private static final String VERSION = "1.0.0";
 
     @Mock
@@ -267,5 +280,44 @@ class VersionAwareFieldFilterTest {
         // when / then
         assertThatThrownBy(() -> filter.filterEntityNodeForTargetVersion(entityNode, "applications"))
                 .isSameAs(original);
+    }
+
+    @ParameterizedTest
+    @MethodSource("realSchemaVersions")
+    void filterForTargetVersion_fullyPopulatedConfig_resultHasNoSchemaViolations(String version) throws IOException {
+        // given
+        JsonNode schema = loadRealSchema(version);
+        when(coreConfigVersionService.getVersionForExport()).thenReturn(version);
+        when(schemaLoader.loadSchema(version)).thenReturn(schema);
+
+        VersionAwareSchemaChecker schemaChecker = new VersionAwareSchemaChecker(schemaLoader);
+        Config config = MAPPER.readValue(ResourceUtils.readResource("/import_for_export.json"), Config.class);
+
+        // when
+        JsonNode result = filter.filterForTargetVersion(config);
+
+        // then
+        List<String> violations = schemaChecker.check(result, version);
+        assertThat(violations)
+                .as("Schema violations for version %s", version)
+                .isEmpty();
+    }
+
+    private JsonNode loadRealSchema(String version) throws IOException {
+        String path = "core-config-schemas/schema-v" + version + ".json";
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(path)) {
+            return MAPPER.readTree(is);
+        }
+    }
+
+    private static Stream<String> realSchemaVersions() throws IOException {
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        Resource[] resources = resolver.getResources("classpath:core-config-schemas/schema-v*.json");
+
+        return Arrays.stream(resources)
+                .map(Resource::getFilename)
+                .map(name -> name
+                        .replace("schema-v", "")
+                        .replace(".json", ""));
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
@@ -29,7 +29,7 @@ class VersionAwareFieldFilterTest {
 
     @BeforeEach
     void setUp() {
-        filter = new VersionAwareFieldFilter(coreConfigVersionService, schemaLoader, MAPPER, MAPPER);
+        filter = new VersionAwareFieldFilter(coreConfigVersionService, schemaLoader, MAPPER);
         when(coreConfigVersionService.getVersionForExport()).thenReturn(VERSION);
     }
 

--- a/src/test/resources/full_core_export.json
+++ b/src/test/resources/full_core_export.json
@@ -12,8 +12,8 @@
         "/service/"
       ],
       "methods": [
-        "POST",
-        "GET"
+        "GET",
+        "POST"
       ],
       "upstreams": [
         {
@@ -56,8 +56,8 @@
         "/service/"
       ],
       "methods": [
-        "POST",
-        "GET"
+        "GET",
+        "POST"
       ],
       "upstreams": [
         {
@@ -91,9 +91,6 @@
       "name": "testModel1",
       "endpoint": "https://endpoint1/embeddings",
       "responsesEndpoint": "https://endpoint1/responses",
-      "responsesDefaults": {
-        "field": "skipped-value"
-      },
       "displayName": "Test Model1",
       "displayVersion": "2.0.0",
       "forwardAuthToken": false,
@@ -111,6 +108,9 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responsesDefaults": {
+        "field": "skipped-value"
+      },
       "interceptors": [
         "testInterceptor1"
       ],
@@ -155,6 +155,7 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responsesDefaults": {},
       "interceptors": [],
       "descriptionKeywords": [],
       "maxRetryAttempts": 5,
@@ -190,6 +191,7 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responses_defaults": {},
       "interceptors": [
         "testInterceptor1"
       ],
@@ -202,8 +204,7 @@
         "dep1",
         "dep2"
       ],
-      "application_type_schema_id": "https://test-schema-id.example",
-      "routes": {}
+      "application_type_schema_id": "https://test-schema-id.example"
     },
     "testApplication2": {
       "name": "testApplication2",
@@ -211,6 +212,7 @@
         "testRole1"
       ],
       "endpoint": "endpoint",
+      "responses_endpoint": "https://application2/responses",
       "display_name": "Test Application2",
       "display_version": "1.0.0",
       "forward_auth_token": false,
@@ -228,21 +230,19 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responses_defaults": {
+        "field": "skipped-value"
+      },
       "interceptors": [],
       "description_keywords": [],
       "max_retry_attempts": 1,
       "created_at": 123,
       "updated_at": 123,
       "dependencies": [],
-      "routes": {},
-      "responsesEndpoint": "https://application2/responses",
-      "responsesDefaults": {
-        "field": "skipped-value"
-      },
       "mcp": {
         "endpoint": "http://localhost:9876/mcp",
         "transport": "http",
-        "allowed_tools": ["classify_text"],
+        "allowedTools": ["classify_text"],
         "configDelivery": "header",
         "forwardPerRequestKey": false
       }
@@ -256,19 +256,20 @@
       "display_name": "ToolSet1",
       "forward_auth_token": false,
       "defaults": {},
+      "responses_defaults": {},
       "interceptors": [],
       "description_keywords": [],
       "max_retry_attempts": 1,
       "created_at": 123,
       "updated_at": 123,
       "dependencies": [],
+      "forward_per_request_key": false,
       "auth_settings": {
         "authentication_type": "oauth",
         "client_id": "some-client-id",
-        "authorizationEndpoint": "some-auth-endpoint",
-        "tokenEndpoint": "some-token-endpoint"
+        "authorization_endpoint": "some-auth-endpoint",
+        "token_endpoint": "some-token-endpoint"
       },
-      "forward_per_request_key": false,
       "transport": "sse",
       "allowed_tools": [
         "branch",
@@ -337,6 +338,7 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responsesDefaults": {},
       "interceptors": [],
       "descriptionKeywords": [],
       "maxRetryAttempts": 1,
@@ -367,6 +369,7 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responsesDefaults": {},
       "interceptors": [],
       "descriptionKeywords": [],
       "maxRetryAttempts": 1,
@@ -397,6 +400,7 @@
         "assistant_attachments_in_request_supported": false
       },
       "defaults": {},
+      "responsesDefaults": {},
       "interceptors": [],
       "descriptionKeywords": [],
       "maxRetryAttempts": 1,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
The problem was that filtering didn't work for fields with default values. E.g. filtering against 0.42.0 core version still left `responsesDefaults` field in produced JSON even if that field is introduced in 0.43.0 core version.

**The cause**: After filtering, we obtained a JsonNode containing only the fields specified in the corresponding versioned core schema, which was correct. However, this JsonNode was then converted into a Config object, leading to two scenarios:

1. Fields missing from the JsonNode without a default value were set to `null`. These were excluded from the resulting JSON because our default ObjectMapper is configured to include only fields with non-null values during Config serialization.
2. Fields missing from the JsonNode that did have a default value were assigned that default. Consequently, they were included in the resulting JSON, which triggered an error in the Core.

**The solution:** We decided to stop converting the JsonNode back into a Config object after filtering to avoid restoring default values. As a result, the filtering logic was moved closer to the point where the config is actually written (file, ConfigMap, controller output stream, etc.).

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.