### PR TITLE
fix: do not serialize `null` fields in CoreRoute

### DIFF
--- a/src/main/java/com/epam/aidial/core/config/CoreRoute.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreRoute.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
 import lombok.Data;
@@ -12,6 +13,7 @@ import java.util.regex.Pattern;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CoreRoute extends RoleBasedEntity {
 
     public static final AttachmentPath EMPTY_ATTACHMENT_PATHS = new AttachmentPath();

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/RouteFunctionalTest.java
@@ -254,7 +254,6 @@ public abstract class RouteFunctionalTest {
                     "route1": {
                       "name": "route1",
                       "userRoles": [],
-                      "response": null,
                       "rewritePath": false,
                       "paths": ["path1"],
                       "methods": [],


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1014 

### Description of changes
Syncronized serialization with Core. Serialization was changed in scope of https://github.com/epam/ai-dial-core/pull/1566/changes#diff-50eb64727b2bcd0e65350cb5b9ed6deee2cac6adbc9640a4ebef08996cea5553

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.