### PR TITLE
fix: prevent duplicate IDs between interceptors and deployments

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.AddonJpaRepository;
+import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AddonEntityMapper;
 import com.epam.aidial.cfg.dao.model.AddonEntity;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -10,6 +11,7 @@ import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.validator.AddonValidator;
+import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
@@ -37,6 +39,7 @@ public class AddonService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Addon with name %s does not exist";
 
     private final AddonJpaRepository addonJpaRepository;
+    private final InterceptorJpaRepository interceptorJpaRepository;
     private final AddonEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final AddonValidator addonValidator;
@@ -81,6 +84,7 @@ public class AddonService {
     public void createAddon(Addon addon) {
         addonValidator.validateAddonCreation(addon);
         deploymentService.assertDeploymentNotExists(addon.getDeployment().getName());
+        assertInterceptorNotExists(addon.getDeployment().getName());
         Optional.of(addon)
                 .map(domainAddon -> toEntity(domainAddon, new AddonEntity()))
                 .map(this::save)
@@ -184,5 +188,11 @@ public class AddonService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
+        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AddonService.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.AddonJpaRepository;
-import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AddonEntityMapper;
 import com.epam.aidial.cfg.dao.model.AddonEntity;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -11,7 +10,6 @@ import com.epam.aidial.cfg.domain.model.DomainObjectWithHash;
 import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.validator.AddonValidator;
-import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
@@ -39,7 +37,6 @@ public class AddonService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Addon with name %s does not exist";
 
     private final AddonJpaRepository addonJpaRepository;
-    private final InterceptorJpaRepository interceptorJpaRepository;
     private final AddonEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final AddonValidator addonValidator;
@@ -84,7 +81,7 @@ public class AddonService {
     public void createAddon(Addon addon) {
         addonValidator.validateAddonCreation(addon);
         deploymentService.assertDeploymentNotExists(addon.getDeployment().getName());
-        assertInterceptorNotExists(addon.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(addon.getDeployment().getName());
         Optional.of(addon)
                 .map(domainAddon -> toEntity(domainAddon, new AddonEntity()))
                 .map(this::save)
@@ -188,11 +185,5 @@ public class AddonService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
-        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
@@ -142,6 +142,7 @@ public class ApplicationService {
         applicationValidator.validateCreation(application);
         deploymentService.assertDeploymentNotExists(application.getDeployment().getName());
         assertNotExists(application.getDisplayName(), application.getDisplayVersion());
+        assertInterceptorNotExists(application.getDeployment().getName());
         resolveEndpointsIfContainerSource(application);
         Optional.of(application)
                 .map(domainModel -> toEntity(domainModel, new ApplicationEntity()))
@@ -347,6 +348,12 @@ public class ApplicationService {
     private void assertNotExists(String displayName, String displayVersion) {
         if ((displayName != null || displayVersion != null) && applicationJpaRepository.existsByDisplayNameAndDisplayVersion(displayName, displayVersion)) {
             throw new EntityAlreadyExistsException("Application with display name: '" + displayName + "' and display version: '" + displayVersion + "' already exists");
+        }
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
@@ -141,8 +141,8 @@ public class ApplicationService {
         applicationNormalizer.normalize(application);
         applicationValidator.validateCreation(application);
         deploymentService.assertDeploymentNotExists(application.getDeployment().getName());
-        assertNotExists(application.getDisplayName(), application.getDisplayVersion());
         deploymentService.assertInterceptorNotExists(application.getDeployment().getName());
+        assertNotExists(application.getDisplayName(), application.getDisplayVersion());
         resolveEndpointsIfContainerSource(application);
         Optional.of(application)
                 .map(domainModel -> toEntity(domainModel, new ApplicationEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ApplicationService.java
@@ -142,7 +142,7 @@ public class ApplicationService {
         applicationValidator.validateCreation(application);
         deploymentService.assertDeploymentNotExists(application.getDeployment().getName());
         assertNotExists(application.getDisplayName(), application.getDisplayVersion());
-        assertInterceptorNotExists(application.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(application.getDeployment().getName());
         resolveEndpointsIfContainerSource(application);
         Optional.of(application)
                 .map(domainModel -> toEntity(domainModel, new ApplicationEntity()))
@@ -348,12 +348,6 @@ public class ApplicationService {
     private void assertNotExists(String displayName, String displayVersion) {
         if ((displayName != null || displayVersion != null) && applicationJpaRepository.existsByDisplayNameAndDisplayVersion(displayName, displayVersion)) {
             throw new EntityAlreadyExistsException("Application with display name: '" + displayName + "' and display version: '" + displayVersion + "' already exists");
-        }
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.AssistantJpaRepository;
-import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AssistantEntityMapper;
 import com.epam.aidial.cfg.dao.model.AssistantEntity;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -10,7 +9,6 @@ import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.validator.AssistantValidator;
-import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +30,6 @@ public class AssistantService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Assistant with name %s does not exist";
 
     private final AssistantJpaRepository assistantJpaRepository;
-    private final InterceptorJpaRepository interceptorJpaRepository;
     private final AssistantEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final AssistantValidator assistantValidator;
@@ -70,7 +67,7 @@ public class AssistantService {
     public void createAssistant(Assistant assistant) {
         assistantValidator.validateAssistantCreation(assistant);
         deploymentService.assertDeploymentNotExists(assistant.getDeployment().getName());
-        assertInterceptorNotExists(assistant.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(assistant.getDeployment().getName());
         Optional.of(assistant)
                 .map(domainModel -> toEntity(domainModel, new AssistantEntity()))
                 .map(this::save)
@@ -151,11 +148,5 @@ public class AssistantService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
-        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/AssistantService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.AssistantJpaRepository;
+import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.AssistantEntityMapper;
 import com.epam.aidial.cfg.dao.model.AssistantEntity;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -9,6 +10,7 @@ import com.epam.aidial.cfg.domain.model.Deployment;
 import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.validator.AssistantValidator;
+import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.features.flag.annotation.FeatureFlagGate;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,7 @@ public class AssistantService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Assistant with name %s does not exist";
 
     private final AssistantJpaRepository assistantJpaRepository;
+    private final InterceptorJpaRepository interceptorJpaRepository;
     private final AssistantEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final AssistantValidator assistantValidator;
@@ -67,6 +70,7 @@ public class AssistantService {
     public void createAssistant(Assistant assistant) {
         assistantValidator.validateAssistantCreation(assistant);
         deploymentService.assertDeploymentNotExists(assistant.getDeployment().getName());
+        assertInterceptorNotExists(assistant.getDeployment().getName());
         Optional.of(assistant)
                 .map(domainModel -> toEntity(domainModel, new AssistantEntity()))
                 .map(this::save)
@@ -147,5 +151,11 @@ public class AssistantService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
+        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/DeploymentService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.dao.jpa.DeploymentJpaRepository;
+import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.jpa.RoleJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.DeploymentEntityMapper;
 import com.epam.aidial.cfg.dao.model.DeploymentEntity;
@@ -29,6 +30,7 @@ public class DeploymentService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Deployment with name %s does not exist";
 
     private final DeploymentJpaRepository deploymentJpaRepository;
+    private final InterceptorJpaRepository interceptorJpaRepository;
     private final RoleJpaRepository roleJpaRepository;
     private final DeploymentEntityMapper mapper;
 
@@ -51,6 +53,13 @@ public class DeploymentService {
         boolean exists = deploymentJpaRepository.existsById(name);
         if (exists) {
             throw new EntityAlreadyExistsException("Deployment with name " + name + " already exists");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
@@ -68,6 +68,7 @@ public class InterceptorService {
     private final InterceptorContainerEntityMapper interceptorContainerEntityMapper;
     private final HistoryService historyService;
     private final GlobalSettingsService globalSettingsService;
+    private final DeploymentService deploymentService;
     private final HashCalculator calculator;
 
     @Transactional(readOnly = true)
@@ -124,6 +125,7 @@ public class InterceptorService {
     public void create(Interceptor interceptor) {
         interceptorValidator.validateCreation(interceptor);
         assertNotExists(interceptor.getName());
+        deploymentService.assertDeploymentNotExists(interceptor.getName());
         resolveEndpointsIfContainerSource(interceptor);
         Optional.of(interceptor)
                 .map(domainModel -> toEntity(domainModel, new InterceptorEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
@@ -130,6 +130,7 @@ public class ModelService {
         modelValidator.validateCreation(model);
         deploymentService.assertDeploymentNotExists(model.getDeployment().getName());
         assertNotExists(model.getDisplayName(), model.getDisplayVersion());
+        assertInterceptorNotExists(model.getDeployment().getName());
         resolveEndpointsIfContainerSource(model);
         Optional.of(model)
                 .map(domainModel -> toEntity(domainModel, new ModelEntity()))
@@ -261,6 +262,12 @@ public class ModelService {
     private void assertNotExists(String displayName, String displayVersion) {
         if ((displayName != null || displayVersion != null) && modelJpaRepository.existsByDisplayNameAndDisplayVersion(displayName, displayVersion)) {
             throw new EntityAlreadyExistsException("Model with display name: '" + displayName + "' and display version: '" + displayVersion + "' already exists");
+        }
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
@@ -129,8 +129,8 @@ public class ModelService {
         modelNormalizer.normalize(model);
         modelValidator.validateCreation(model);
         deploymentService.assertDeploymentNotExists(model.getDeployment().getName());
-        assertNotExists(model.getDisplayName(), model.getDisplayVersion());
         deploymentService.assertInterceptorNotExists(model.getDeployment().getName());
+        assertNotExists(model.getDisplayName(), model.getDisplayVersion());
         resolveEndpointsIfContainerSource(model);
         Optional.of(model)
                 .map(domainModel -> toEntity(domainModel, new ModelEntity()))

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ModelService.java
@@ -130,7 +130,7 @@ public class ModelService {
         modelValidator.validateCreation(model);
         deploymentService.assertDeploymentNotExists(model.getDeployment().getName());
         assertNotExists(model.getDisplayName(), model.getDisplayVersion());
-        assertInterceptorNotExists(model.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(model.getDeployment().getName());
         resolveEndpointsIfContainerSource(model);
         Optional.of(model)
                 .map(domainModel -> toEntity(domainModel, new ModelEntity()))
@@ -262,12 +262,6 @@ public class ModelService {
     private void assertNotExists(String displayName, String displayVersion) {
         if ((displayName != null || displayVersion != null) && modelJpaRepository.existsByDisplayNameAndDisplayVersion(displayName, displayVersion)) {
             throw new EntityAlreadyExistsException("Model with display name: '" + displayName + "' and display version: '" + displayVersion + "' already exists");
-        }
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
         }
     }
 

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
@@ -1,7 +1,6 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
-import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.jpa.RouteJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.RouteEntityMapper;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -12,7 +11,6 @@ import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.model.route.Route;
 import com.epam.aidial.cfg.domain.validator.RouteValidator;
-import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.service.hashing.HashCalculator;
@@ -41,7 +39,6 @@ public class RouteService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Route with name %s does not exist";
 
     private final RouteJpaRepository routeJpaRepository;
-    private final InterceptorJpaRepository interceptorJpaRepository;
     private final RouteEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final RouteValidator routeValidator;
@@ -102,7 +99,7 @@ public class RouteService {
     public void create(Route route) {
         routeValidator.validateRouteCreation(route);
         deploymentService.assertDeploymentNotExists(route.getDeployment().getName());
-        assertInterceptorNotExists(route.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(route.getDeployment().getName());
         Optional.of(route)
                 .map(domainModel -> toEntity(domainModel, new RouteEntity()))
                 .map(this::save)
@@ -203,12 +200,6 @@ public class RouteService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
-        }
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/RouteService.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.jpa.RouteJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.RouteEntityMapper;
 import com.epam.aidial.cfg.dao.model.RoleEntity;
@@ -11,6 +12,7 @@ import com.epam.aidial.cfg.domain.model.RoleBased;
 import com.epam.aidial.cfg.domain.model.RoleLimit;
 import com.epam.aidial.cfg.domain.model.route.Route;
 import com.epam.aidial.cfg.domain.validator.RouteValidator;
+import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.service.hashing.HashCalculator;
@@ -39,6 +41,7 @@ public class RouteService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "Route with name %s does not exist";
 
     private final RouteJpaRepository routeJpaRepository;
+    private final InterceptorJpaRepository interceptorJpaRepository;
     private final RouteEntityMapper mapper;
     private final DeploymentService deploymentService;
     private final RouteValidator routeValidator;
@@ -99,6 +102,7 @@ public class RouteService {
     public void create(Route route) {
         routeValidator.validateRouteCreation(route);
         deploymentService.assertDeploymentNotExists(route.getDeployment().getName());
+        assertInterceptorNotExists(route.getDeployment().getName());
         Optional.of(route)
                 .map(domainModel -> toEntity(domainModel, new RouteEntity()))
                 .map(this::save)
@@ -199,6 +203,12 @@ public class RouteService {
         List<RoleEntity> rolesForLimits = deploymentService.findRolesByNames(roleLimits.stream().map(RoleLimit::getRole).toList());
 
         return mapper.toEntity(domain, entity, roleLimits, rolesForLimits);
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
+        }
     }
 
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ToolSetService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ToolSetService.java
@@ -2,7 +2,6 @@ package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.client.ToolsClient;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
-import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.jpa.ToolSetJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.ToolSetContainerEntityMapper;
 import com.epam.aidial.cfg.dao.mapper.ToolSetEntityMapper;
@@ -24,7 +23,6 @@ import com.epam.aidial.cfg.domain.util.ContainerEndpointResolver;
 import com.epam.aidial.cfg.domain.util.ContainerSourceChangeDetector;
 import com.epam.aidial.cfg.domain.utils.CoreClientUrlUtils;
 import com.epam.aidial.cfg.domain.validator.ToolSetValidator;
-import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.service.hashing.HashCalculator;
@@ -55,7 +53,6 @@ public class ToolSetService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "ToolSet with name %s does not exist";
 
     private final ToolSetJpaRepository toolSetJpaRepository;
-    private final InterceptorJpaRepository interceptorJpaRepository;
     private final ToolSetNormalizer toolSetNormalizer;
     private final ToolSetValidator toolSetValidator;
     private final ToolSetEntityMapper mapper;
@@ -125,7 +122,7 @@ public class ToolSetService {
         toolSetNormalizer.normalize(toolSet);
         toolSetValidator.validateCreation(toolSet);
         deploymentService.assertDeploymentNotExists(toolSet.getDeployment().getName());
-        assertInterceptorNotExists(toolSet.getDeployment().getName());
+        deploymentService.assertInterceptorNotExists(toolSet.getDeployment().getName());
         resolveEndpointsIfContainerSource(toolSet);
         Optional.of(toolSet)
                 .map(domainModel -> toEntity(domainModel, new ToolSetEntity()))
@@ -316,11 +313,5 @@ public class ToolSetService {
         }
 
         return mapper.toEntity(domain, entity, toolSetContainer, toolSetMcpRegistry, roleLimits, rolesForLimits);
-    }
-
-    private void assertInterceptorNotExists(String name) {
-        if (interceptorJpaRepository.existsById(name)) {
-            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
-        }
     }
 }

--- a/src/main/java/com/epam/aidial/cfg/domain/service/ToolSetService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/ToolSetService.java
@@ -2,6 +2,7 @@ package com.epam.aidial.cfg.domain.service;
 
 import com.epam.aidial.cfg.client.ToolsClient;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
+import com.epam.aidial.cfg.dao.jpa.InterceptorJpaRepository;
 import com.epam.aidial.cfg.dao.jpa.ToolSetJpaRepository;
 import com.epam.aidial.cfg.dao.mapper.ToolSetContainerEntityMapper;
 import com.epam.aidial.cfg.dao.mapper.ToolSetEntityMapper;
@@ -23,6 +24,7 @@ import com.epam.aidial.cfg.domain.util.ContainerEndpointResolver;
 import com.epam.aidial.cfg.domain.util.ContainerSourceChangeDetector;
 import com.epam.aidial.cfg.domain.utils.CoreClientUrlUtils;
 import com.epam.aidial.cfg.domain.validator.ToolSetValidator;
+import com.epam.aidial.cfg.exception.EntityAlreadyExistsException;
 import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.service.hashing.HashCalculator;
@@ -53,6 +55,7 @@ public class ToolSetService {
     private static final String NOT_FOUND_MESSAGE_TEMPLATE = "ToolSet with name %s does not exist";
 
     private final ToolSetJpaRepository toolSetJpaRepository;
+    private final InterceptorJpaRepository interceptorJpaRepository;
     private final ToolSetNormalizer toolSetNormalizer;
     private final ToolSetValidator toolSetValidator;
     private final ToolSetEntityMapper mapper;
@@ -122,6 +125,7 @@ public class ToolSetService {
         toolSetNormalizer.normalize(toolSet);
         toolSetValidator.validateCreation(toolSet);
         deploymentService.assertDeploymentNotExists(toolSet.getDeployment().getName());
+        assertInterceptorNotExists(toolSet.getDeployment().getName());
         resolveEndpointsIfContainerSource(toolSet);
         Optional.of(toolSet)
                 .map(domainModel -> toEntity(domainModel, new ToolSetEntity()))
@@ -312,5 +316,11 @@ public class ToolSetService {
         }
 
         return mapper.toEntity(domain, entity, toolSetContainer, toolSetMcpRegistry, roleLimits, rolesForLimits);
+    }
+
+    private void assertInterceptorNotExists(String name) {
+        if (interceptorJpaRepository.existsById(name)) {
+            throw new EntityAlreadyExistsException("Interceptor with name " + name + " already exists");
+        }
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -279,6 +279,25 @@ public abstract class InterceptorFunctionalTest {
     }
 
     @Test
+    public void shouldThrowExceptionWhenCreateInterceptorWithExistingApplicationName() {
+        String name = "test";
+
+        ApplicationDto applicationDto = createApplicationDtoWithEndpoint("1");
+        applicationDto.setName(name);
+        applicationFacade.createApplication(applicationDto);
+
+        InterceptorDto interceptorDto = createInterceptorDto("1");
+        interceptorDto.setName(name);
+
+        EntityAlreadyExistsException exception = Assertions.assertThrows(
+                EntityAlreadyExistsException.class,
+                () -> interceptorFacade.createInterceptor(interceptorDto)
+        );
+
+        Assertions.assertEquals("Deployment with name test already exists", exception.getMessage());
+    }
+
+    @Test
     public void shouldThrowExceptionWhenInterceptorConcurrencyOverwrite() {
         ApplicationDto applicationDto1 = createApplicationDtoWithEndpoint("1");
         applicationFacade.createApplication(applicationDto1);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ModelFunctionalTest.java
@@ -396,6 +396,25 @@ public abstract class ModelFunctionalTest {
     }
 
     @Test
+    public void shouldThrowExceptionWhenCreateModelWithExistingInterceptorName() {
+        String name = "test";
+
+        InterceptorDto interceptorDto = createInterceptorDto("1");
+        interceptorDto.setName(name);
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        ModelDto modelDto = createModelDto("1");
+        modelDto.setName(name);
+
+        EntityAlreadyExistsException exception = Assertions.assertThrows(
+                EntityAlreadyExistsException.class,
+                () -> modelFacade.createModel(modelDto)
+        );
+
+        Assertions.assertEquals("Interceptor with name test already exists", exception.getMessage());
+    }
+
+    @Test
     public void shouldSaveAndReturnModelWithUniqueTopics() {
         ModelDto modelDto = createModelDto("1");
         modelDto.setTopics(new TreeSet<>(Set.of("topic3", "topic2", "topic1")));


### PR DESCRIPTION
### Applicable issues

- fixes #1019

### Description of changes

Interceptors and deployments (Models, Applications, Assistants, Addons, Routes, ToolSets) share the same ID namespace in DIAL Core, but previously there was no cross-entity uniqueness validation. This allowed creating an Interceptor with the same ID as an existing deployment (or vice versa), which caused DIAL Core configuration reload to fail silently.

The fix adds bidirectional ID conflict checks on creation:
- Each deployment service now calls `assertInterceptorNotExists` before saving, to reject names already used by an interceptor.
- `InterceptorService` now calls `assertDeploymentNotExists` before saving, to reject names already used by any deployment.

The `assertInterceptorNotExists` method was extracted into `DeploymentService` (backed by `InterceptorJpaRepository`) to avoid a circular service dependency.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.