### PR TITLE
fix: add new `HEAD /api/v1/interceptors/{interceptorName}` endpoint

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/service/InterceptorService.java
@@ -72,6 +72,13 @@ public class InterceptorService {
     private final HashCalculator calculator;
 
     @Transactional(readOnly = true)
+    public void ensureExists(String interceptorName) {
+        if (!interceptorJpaRepository.existsById(interceptorName)) {
+            throw new EntityNotFoundException(NOT_FOUND_MESSAGE_TEMPLATE.formatted(interceptorName));
+        }
+    }
+
+    @Transactional(readOnly = true)
     public Collection<Interceptor> getAll() {
         return interceptorJpaRepository.findAll().stream()
                 .map(mapper::toDomain)

--- a/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
+++ b/src/main/java/com/epam/aidial/cfg/web/controller/InterceptorController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
 
+import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
+
 @RestController
 @RequestMapping("/api/v1/interceptors")
 @Validated
@@ -36,6 +38,11 @@ public class InterceptorController extends AbstractController {
 
     public InterceptorController(InterceptorFacade interceptorFacade) {
         this.interceptorFacade = interceptorFacade;
+    }
+
+    @RequestMapping(method = HEAD, path = "/{interceptorName}")
+    public void ensureExists(@PathVariable String interceptorName) {
+        interceptorFacade.ensureExists(interceptorName);
     }
 
     @GetMapping(produces = MimeTypeUtils.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/epam/aidial/cfg/web/facade/InterceptorFacade.java
+++ b/src/main/java/com/epam/aidial/cfg/web/facade/InterceptorFacade.java
@@ -28,6 +28,10 @@ public class InterceptorFacade {
     private final CoreInterceptorService coreInterceptorService;
     private final EntitySyncStateDtoMapper entitySyncStateDtoMapper;
 
+    public void ensureExists(String interceptorName) {
+        interceptorService.ensureExists(interceptorName);
+    }
+
     public Collection<InterceptorDto> getAllInterceptors() {
         return interceptorService.getAll()
                 .stream()

--- a/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
+++ b/src/test/java/com/epam/aidial/cfg/web/controller/none/InterceptorControllerTest.java
@@ -3,6 +3,7 @@ package com.epam.aidial.cfg.web.controller.none;
 import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.dto.DtoWithDomainHash;
 import com.epam.aidial.cfg.dto.InterceptorDto;
+import com.epam.aidial.cfg.exception.EntityNotFoundException;
 import com.epam.aidial.cfg.exception.OptimisticLockConflictException;
 import com.epam.aidial.cfg.utils.ResourceUtils;
 import com.epam.aidial.cfg.web.controller.InterceptorController;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -50,6 +52,30 @@ public class InterceptorControllerTest extends AbstractControllerNoneSecureTest 
 
     @MockitoBean
     private InterceptorFacade interceptorFacade;
+
+    @Test
+    void testEnsureExistsShouldReturnEmptyBodyWhenInterceptorExists() throws Exception {
+        String interceptorName = "test";
+
+        doNothing().when(interceptorFacade).ensureExists(interceptorName);
+
+        mockMvc.perform(head("/api/v1/interceptors/{interceptorName}", interceptorName))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void testEnsureExistsShouldReturnNotFoundWhenInterceptorDoesNotExist() throws Exception {
+        String interceptorName = "test";
+        String notFoundMessage = "Interceptor with name " + interceptorName + " doesn't exist";
+
+        doThrow(new EntityNotFoundException(notFoundMessage))
+                .when(interceptorFacade).ensureExists(interceptorName);
+
+        mockMvc.perform(head("/api/v1/interceptors/{interceptorName}", interceptorName))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(notFoundMessage));
+    }
 
     @Test
     void testGetAllInterceptors() throws Exception {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1019 

### Description of changes

Adds a `HEAD /api/v1/interceptors/{interceptorName}` endpoint to check interceptor existence without returning a response body:
- Returns `200 OK` if the interceptor exists
- Returns `404 Not Found` if the interceptor does not exist

This endpoint is used by the frontend to detect duplicate IDs across entity types before saving a new interceptor, preventing configuration reload failures caused by ID conflicts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.