### PR TITLE
fix: bump netty-handler and netty-codec-http2/transport-native-epoll to 4.2.15.Final, and netty-resolver-dns/netty-codec-dns to 4.1.135.Final.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,16 +172,22 @@ dependencies {
         implementation ('commons-fileupload:commons-fileupload:1.6.0') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.13.Final') {
+        implementation ('io.netty:netty-codec-http2:4.2.15.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('io.netty:netty-handler:4.2.15.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
             because("previous versions have vulnerabilities")
         }
-        implementation("io.netty:netty-codec-dns:4.1.133.Final") {
+        implementation("io.netty:netty-codec-dns:4.1.135.Final") {
             because("previous versions have vulnerabilities")
         }
-        implementation("io.netty:netty-transport-native-epoll:4.2.13.Final") {
+        implementation("io.netty:netty-resolver-dns:4.1.135.Final") {
+            because("previous versions have vulnerabilities")
+        }
+        implementation("io.netty:netty-transport-native-epoll:4.2.15.Final") {
             because("previous versions have vulnerabilities")
         }
         implementation("org.bouncycastle:bcprov-jdk18on:1.84") {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Upgrades Netty dependency constraints to address 4 HIGH-severity CVEs detected in CI:

| CVE | Module | Installed | Fixed |
|-----|--------|-----------|-------|
| CVE-2026-44249 | `netty-handler` | 4.2.13.Final | 4.2.15.Final |
| CVE-2026-45416 | `netty-handler` | 4.2.13.Final | 4.2.15.Final |
| CVE-2026-45674 | `netty-resolver-dns` | 4.1.132.Final | 4.1.135.Final |
| CVE-2026-47691 | `netty-resolver-dns` | 4.1.132.Final | 4.1.135.Final |

Changes in `build.gradle` constraints block:
- `netty-handler`: added constraint at **4.2.15.Final** (was unforced)
- `netty-codec-http2`: **4.2.13.Final → 4.2.15.Final**
- `netty-transport-native-epoll`: **4.2.13.Final → 4.2.15.Final**
- `netty-resolver-dns`: added constraint at **4.1.135.Final** (was unforced)
- `netty-codec-dns`: **4.1.133.Final → 4.1.135.Final**

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.