### PR TITLE
chore: remove unused aws-java-sdk-sts v1.x dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ dependencies {
 
     implementation 'org.apache.jclouds:jclouds-allblobstore:2.7.0'
     implementation 'org.apache.jclouds.api:filesystem:2.6.0'
-    implementation 'com.amazonaws:aws-java-sdk-sts:1.12.663'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
     implementation 'com.azure:azure-identity:1.15.3'
     implementation 'com.azure:azure-identity-extensions:1.2.7'


### PR DESCRIPTION
The application code already uses AWS SDK v2 (software.amazon.awssdk) for all Secrets Manager operations. The v1 artifact had no direct imports in the source tree and does not appear as a transitive dependency.

### Applicable issues

- fixes #1041

### Description of changes

Removed the explicit `com.amazonaws:aws-java-sdk-sts:1.12.663` (AWS SDK v1) declaration from `build.gradle`. All AWS functionality in this project uses AWS SDK v2 (`software.amazon.awssdk:secretsmanager`). The v1 artifact was a leftover with no usages — no `com.amazonaws.*` imports exist in the source tree, and it does not appear transitively via jclouds or any other dependency.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.