### PR TITLE
fix: bump netty-handler and netty-codec-http2/transport-native-epoll to 4.2.15.Final, and netty-resolver-dns/netty-codec-dns to 4.1.135.Final. (#1044), upgrade runtime image to eclipse-temurin:21-jre-alpine (#1050), pin OpenSSL packages to 3.5.7-r0 (#1055)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ COPY query-language/build.gradle query-language/
 RUN gradle --no-daemon clean bootJar
 
 # Runtime stage
-FROM eclipse-temurin:17-jre-noble AS runtime
+FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
-RUN adduser -u 1001 --disabled-password --gecos "" appuser && \
+RUN apk add --no-cache bash && \
+    adduser -u 1001 -D appuser && \
     mkdir -p /app/data && \
     chown -R appuser:appuser /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN gradle --no-daemon clean bootJar
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
-RUN apk add --no-cache bash && \
+# TODO: remove explicit openssl pinning once eclipse-temurin:21-jre-alpine ships with libcrypto3>=3.5.7-r0 (CVE-2026-45447)
+RUN apk add --no-cache 'libcrypto3=3.5.7-r0' 'libssl3=3.5.7-r0' 'openssl=3.5.7-r0' && \
+    apk add --no-cache bash && \
     adduser -u 1001 -D appuser && \
     mkdir -p /app/data && \
     chown -R appuser:appuser /app

--- a/build.gradle
+++ b/build.gradle
@@ -172,16 +172,22 @@ dependencies {
         implementation ('commons-fileupload:commons-fileupload:1.6.0') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.13.Final') {
+        implementation ('io.netty:netty-codec-http2:4.2.15.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('io.netty:netty-handler:4.2.15.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation("io.grpc:grpc-netty-shaded:1.75.0") {
             because("previous versions have vulnerabilities")
         }
-        implementation("io.netty:netty-codec-dns:4.1.133.Final") {
+        implementation("io.netty:netty-codec-dns:4.1.135.Final") {
             because("previous versions have vulnerabilities")
         }
-        implementation("io.netty:netty-transport-native-epoll:4.2.13.Final") {
+        implementation("io.netty:netty-resolver-dns:4.1.135.Final") {
+            because("previous versions have vulnerabilities")
+        }
+        implementation("io.netty:netty-transport-native-epoll:4.2.15.Final") {
             because("previous versions have vulnerabilities")
         }
         implementation("org.bouncycastle:bcprov-jdk18on:1.84") {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.