### PR TITLE
fix:  [Assets][Prompts] Prompt versions are not displayed after creating a Prompt with consecutive underscores in Display Name

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/utils/PathUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/utils/PathUtils.java
@@ -100,13 +100,11 @@ public class PathUtils {
     }
 
     private static Pair<String, String> extractNameAndVersion(String rawName) {
-        var nameParts = rawName.split("__");
+        int lastSeparatorIndex = rawName.lastIndexOf("__");
 
-        if (nameParts.length < 2) {
+        if (lastSeparatorIndex == -1) {
             return Pair.of(rawName, null);
         }
-
-        int lastSeparatorIndex = rawName.lastIndexOf("__");
 
         String name = rawName.substring(0, lastSeparatorIndex);
         String version = rawName.substring(lastSeparatorIndex + 2);

--- a/src/main/java/com/epam/aidial/cfg/utils/PathUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/utils/PathUtils.java
@@ -101,15 +101,16 @@ public class PathUtils {
 
     private static Pair<String, String> extractNameAndVersion(String rawName) {
         var nameParts = rawName.split("__");
-        String name;
-        String version;
-        if (nameParts.length != 2) {
-            name = rawName;
-            version = null;
-        } else {
-            name = nameParts[0];
-            version = nameParts[1];
+
+        if (nameParts.length < 2) {
+            return Pair.of(rawName, null);
         }
+
+        int lastSeparatorIndex = rawName.lastIndexOf("__");
+
+        String name = rawName.substring(0, lastSeparatorIndex);
+        String version = rawName.substring(lastSeparatorIndex + 2);
+
         return Pair.of(name, version);
     }
 

--- a/src/test/java/com/epam/aidial/cfg/utils/PathUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/utils/PathUtilsTest.java
@@ -1,5 +1,6 @@
 package com.epam.aidial.cfg.utils;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -8,6 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static com.epam.aidial.cfg.utils.PathUtils.parseVersionedPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -83,6 +85,15 @@ class PathUtilsTest {
     @CsvSource(value = {"public/file.txt", "public", "''", "null"}, nullValues = "null")
     void testIsFolderPath_WithoutTrailingSlash_ReturnsFalse(String path) {
         assertThat(PathUtils.isFolderPath(path)).isFalse();
+    }
+
+    @Test
+    void shouldUseLastSeparatorWhenMultipleSeparatorsPresent() {
+        var result = parseVersionedPath("public/my__super__model__2.0");
+
+        Assertions.assertEquals("my__super__model", result.getName());
+        Assertions.assertEquals("2.0", result.getVersion());
+        Assertions.assertEquals("my__super__model__2.0", result.getVersionedName());
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/utils/PathUtilsTest.java
+++ b/src/test/java/com/epam/aidial/cfg/utils/PathUtilsTest.java
@@ -1,6 +1,5 @@
 package com.epam.aidial.cfg.utils;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -87,13 +86,23 @@ class PathUtilsTest {
         assertThat(PathUtils.isFolderPath(path)).isFalse();
     }
 
-    @Test
-    void shouldUseLastSeparatorWhenMultipleSeparatorsPresent() {
-        var result = parseVersionedPath("public/my__super__model__2.0");
+    @ParameterizedTest
+    @CsvSource(value = {
+            "public/promptname, promptname, null, promptname",
+            "public/prompt__1.0, prompt, 1.0, prompt__1.0",
+            "public/name__, name, '', name__",
+            "public/my__super__model__2.0, my__super__model, 2.0, my__super__model__2.0"}, nullValues = "null")
+    void shouldParseVersionedPath(
+            String path,
+            String expectedName,
+            String expectedVersion,
+            String expectedVersionedName
+    ) {
+        var result = parseVersionedPath(path);
 
-        Assertions.assertEquals("my__super__model", result.getName());
-        Assertions.assertEquals("2.0", result.getVersion());
-        Assertions.assertEquals("my__super__model__2.0", result.getVersionedName());
+        assertThat(result.getName()).isEqualTo(expectedName);
+        assertThat(result.getVersion()).isEqualTo(expectedVersion);
+        assertThat(result.getVersionedName()).isEqualTo(expectedVersionedName);
     }
 
     @Test


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1036 

### Description of changes
Fixed prompt version parsing for names containing consecutive underscores (__), restoring correct version listing and creation.

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.