### PR TITLE
fix: improve config split error messages and remove single-destination bypass

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/CompositeConfigSource.java
@@ -61,11 +61,6 @@ public abstract class CompositeConfigSource implements ConfigSource {
         if (CollectionUtils.isEmpty(sourceNames)) {
             throw new IllegalStateException("Unable to store source, names is not configured.");
         }
-        if (sourceNames.size() == 1) {
-            String newValue = encodeConfig(configBody);
-            return List.of(new SourceValue(sourceNames.get(0), newValue));
-        }
-
         List<ConfigPart> configs = configSplitter.splitConfig(configBody, this::encodeConfig, maxSourceSize, sourceNames.size());
 
         if (configs.size() > sourceNames.size()) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitter.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,7 +52,8 @@ public class ConfigSplitter {
             }
             return configs;
         }
-        throw new IllegalStateException("Unable to split config to " + partitioningLimit + " parts with maxSize " + maxSize);
+        throw new IllegalStateException("Unable to split config to " + partitioningLimit + " part(s) with maxSize " + maxSize + ". "
+                + buildErrorDetail(encoder, maxSize, entries, partitioningLimit));
     }
 
     private List<ConfigPart> trySplit(Function<Config, String> encoder, int maxSize, List<ConfigEntry> entries, int partSize) {
@@ -73,10 +75,33 @@ public class ConfigSplitter {
         return configs;
     }
 
+    private String buildErrorDetail(Function<Config, String> encoder, int maxSize,
+                                    List<ConfigEntry> entries, int partitioningLimit) {
+        long totalSize = 0;
+        List<EntrySizeInfo> entrySizes = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            Config config = createConfig();
+            entries.get(i).put().accept(config);
+            ConfigUtils.removeEmptyCollections(config);
+            int size = encoder.apply(config).getBytes().length;
+            totalSize += size;
+            String label = entries.get(i).label() != null ? entries.get(i).label() : "entry[" + i + "]";
+            entrySizes.add(new EntrySizeInfo(label, size));
+        }
+        long capacity = (long) partitioningLimit * maxSize;
+        List<String> topEntries = entrySizes.stream()
+                .sorted(Comparator.comparingInt(EntrySizeInfo::size).reversed())
+                .limit(5)
+                .map(e -> e.label() + "=" + e.size() + "B")
+                .toList();
+        return ("Total encoded size %d bytes exceeds available capacity %d bytes "
+                + "(%d destinations x %d maxSize). Largest entries: %s")
+                .formatted(totalSize, capacity, partitioningLimit, maxSize, topEntries);
+    }
+
     private Stream<ConfigEntry> mapRetriableErrorCodes(Config configBody) {
         Consumer<Config> put = config -> config.setRetriableErrorCodes(configBody.getRetriableErrorCodes());
-        ConfigEntry configEntry = new ConfigEntry(put);
-        return Stream.of(configEntry);
+        return Stream.of(new ConfigEntry(put, "retriableErrorCodes"));
     }
 
     private Stream<ConfigEntry> mapAssistantEndpoint(Config configBody) {
@@ -87,8 +112,7 @@ public class ConfigSplitter {
                 }
                 config.getAssistant().setEndpoint(configBody.getAssistant().getEndpoint());
             };
-            ConfigEntry endpoint = new ConfigEntry(putEndpoint);
-            return Stream.of(endpoint);
+            return Stream.of(new ConfigEntry(putEndpoint, "assistant.endpoint"));
         }
         return Stream.empty();
     }
@@ -101,8 +125,7 @@ public class ConfigSplitter {
                 }
                 config.getAssistant().setFeatures(configBody.getAssistant().getFeatures());
             };
-            ConfigEntry features = new ConfigEntry(putFeatures);
-            return Stream.of(features);
+            return Stream.of(new ConfigEntry(putFeatures, "assistant.features"));
         }
         return Stream.empty();
     }
@@ -144,11 +167,12 @@ public class ConfigSplitter {
                                 setter.accept(config, map);
                             }
                             map.put(e.getKey(), e.getValue());
-                        })
+                        },
+                        e.getKey())
                 );
     }
 
-    record ConfigEntry(Consumer<Config> put) {
+    record ConfigEntry(Consumer<Config> put, String label) {
     }
 
     private static Config createConfig() {
@@ -178,4 +202,6 @@ public class ConfigSplitter {
     private Map<String, CoreRoute> getRoutes(Config config) {
         return config.getRoutes();
     }
+
+    private record EntrySizeInfo(String label, int size) {}
 }

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/AzureKeyVaultConfigSourceTest.java
@@ -57,15 +57,13 @@ class AzureKeyVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
-
+        ConfigPart configPart = new ConfigPart(config, objectMapper.writeValueAsString(config));
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
         when(secretClient.getSecret(any(String.class))).thenReturn(new KeyVaultSecret("secret", "{}"));
-        Config secretConfig = new Config();
-        secretConfig.setKeys(Map.of("key1", key));
 
         source.writeConfig(config, false);
 
-        verify(configSplitter, times(0)).splitConfig(any(), any(), anyInt(), eq(1));
+        verify(configSplitter, times(1)).splitConfig(any(), any(), anyInt(), eq(1));
         verify(secretClient, times(1)).setSecret(keyVaultSecretArgumentCaptor.capture());
 
         List<KeyVaultSecret> allValues = keyVaultSecretArgumentCaptor.getAllValues();
@@ -137,8 +135,8 @@ class AzureKeyVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
-
+        ConfigPart configPart = new ConfigPart(config, objectMapper.writeValueAsString(config));
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));
 
@@ -163,8 +161,8 @@ class AzureKeyVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
-
+        ConfigPart configPart = new ConfigPart(config, "{}");
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
         when(secretClient.getSecret(any(String.class)))
                 .thenThrow(new ResourceNotFoundException("Secret not found", null));
 

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitterTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigSplitterTest.java
@@ -31,6 +31,48 @@ class ConfigSplitterTest {
     private ObjectMapper objectMapper = JsonMapperConfiguration.createJsonMapper();
 
     @Test
+    void splitConfigErrorDetailShowsLargestEntries() {
+        ConfigSplitter splitter = new ConfigSplitter();
+        Config configBody = new Config();
+        configBody.setKeys(new HashMap<>());
+        for (int i = 0; i < 3; i++) {
+            configBody.getKeys().put("key" + i, generateKey(i));
+        }
+
+        int partitioningLimit = 1;
+        int maxSize = 10;
+
+        // compute expected per-entry sizes using the same encoder and removeEmptyCollections logic
+        int[] keySizes = new int[3];
+        for (int i = 0; i < 3; i++) {
+            Config single = createConfig();
+            single.setKeys(Map.of("key" + i, generateKey(i)));
+            ConfigUtils.removeEmptyCollections(single);
+            keySizes[i] = encode(single).getBytes().length;
+        }
+        // retriableErrorCodes entry is always produced by the splitter
+        Config retriableConfig = createConfig();
+        retriableConfig.setRetriableErrorCodes(configBody.getRetriableErrorCodes());
+        ConfigUtils.removeEmptyCollections(retriableConfig);
+        int retriableSize = encode(retriableConfig).getBytes().length;
+
+        long expectedTotal = (long) keySizes[0] + keySizes[1] + keySizes[2] + retriableSize;
+        long expectedCapacity = (long) partitioningLimit * maxSize;
+
+        IllegalStateException ex = Assertions.assertThrows(IllegalStateException.class,
+                () -> splitter.splitConfig(configBody, this::encode, maxSize, partitioningLimit));
+
+        String message = ex.getMessage();
+        Assertions.assertTrue(message.contains("Unable to split config to 1 part(s) with maxSize 10"), message);
+        Assertions.assertTrue(message.contains("Total encoded size " + expectedTotal + " bytes"), message);
+        Assertions.assertTrue(message.contains("available capacity " + expectedCapacity + " bytes"), message);
+        // all 3 keys should appear in the top-5 largest entries with their exact sizes
+        for (int i = 0; i < 3; i++) {
+            Assertions.assertTrue(message.contains("key" + i + "=" + keySizes[i] + "B"), message);
+        }
+    }
+
+    @Test
     void splitSecretConfig() {
         ConfigSplitter splitter = new ConfigSplitter();
         Config configBody = new Config();

--- a/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/impl/storage/GcpVaultConfigSourceTest.java
@@ -61,18 +61,17 @@ class GcpVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
+        ConfigPart configPart = new ConfigPart(config, objectMapper.writeValueAsString(config));
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
 
         ByteString body = ByteString.copyFrom("{}", "utf-8");
         SecretPayload payload = SecretPayload.newBuilder().setData(body).build();
         AccessSecretVersionResponse response = AccessSecretVersionResponse.newBuilder().setPayload(payload).build();
         when(secretClient.accessSecretVersion(any(SecretVersionName.class))).thenReturn(response);
-        Config secretConfig = new Config();
-        secretConfig.setKeys(Map.of("key1", key));
 
         source.writeConfig(config, false);
 
-        verify(configSplitter, times(0)).splitConfig(any(), any(), anyInt(), eq(1));
+        verify(configSplitter, times(1)).splitConfig(any(), any(), anyInt(), eq(1));
         verify(secretClient, times(1)).addSecretVersion(Mockito.eq("secret1"), keyVaultSecretArgumentCaptor.capture());
 
         List<SecretPayload> allValues = keyVaultSecretArgumentCaptor.getAllValues();
@@ -142,8 +141,8 @@ class GcpVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
-
+        ConfigPart configPart = new ConfigPart(config, objectMapper.writeValueAsString(config));
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));
 
@@ -166,8 +165,8 @@ class GcpVaultConfigSourceTest {
         key.setRole("role");
         config.setKeys(Map.of("key1", key));
 
-        when(versionAwareFieldFilter.filterForTargetVersion(config)).thenReturn(configAsJsonNode(config));
-
+        ConfigPart configPart = new ConfigPart(config, "{}");
+        when(configSplitter.splitConfig(any(), any(), anyInt(), eq(1))).thenReturn(List.of(configPart));
         when(secretClient.accessSecretVersion(any(SecretVersionName.class)))
                 .thenThrow(new NotFoundException(new RuntimeException(), HttpJsonStatusCode.of(StatusCode.Code.NOT_FOUND), false));
 


### PR DESCRIPTION
### Applicable issues

- fixes #1060

### Description of changes

**Problem:** Two failure paths produced unhelpful errors when the config was too large to export:

1. `CompositeConfigSource` had a shortcut that bypassed `ConfigSplitter` entirely when only one destination was configured (`sourceNames.size() == 1`). This caused Kubernetes to reject the Secret with a cryptic API error: `Secret "dial-core-admin" is invalid: data: Too long: may not be more than 1048576 bytes`.

2. When `ConfigSplitter` exhausted all partition attempts, it threw a generic `IllegalStateException: Unable to split config to N parts with maxSize M` with no information about what was contributing to the overflow.

**Changes:**

- **`CompositeConfigSource`** — removed the single-destination bypass so `ConfigSplitter` always runs, including the size check, regardless of how many destinations are configured.

- **`ConfigSplitter`** — added a `label` field to `ConfigEntry` (populated from the map key for entity entries, and descriptive strings like `"retriableErrorCodes"`, `"assistant.endpoint"` for fixed entries). When splitting fails, the error now reports total encoded size vs. available capacity and the top 5 largest entries by name and size:
  ```
  Unable to split config to 2 part(s) with maxSize 1048576.
  Total encoded size 2250000 bytes exceeds available capacity 2097152 bytes
  (2 destinations x 1048576 maxSize). Largest entries: [gpt-4-finetuned=950000B, my-heavy-app=870000B, ...]
  ```

- **Tests** — updated `AzureKeyVaultConfigSourceTest` and `GcpVaultConfigSourceTest` single-destination tests to reflect the new behaviour (splitter is now always called); added a new `ConfigSplitterTest` case verifying the error message contains exact total size, capacity, and per-entry sizes.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.