### PR TITLE
fix:  Secret Extra Data exposed in export when "Include secrets" is unchecked

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
@@ -83,13 +83,6 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .stream()
                 .flatMap(Collection::stream)
                 .filter(upstream -> upstream.getKey() != null || upstream.getSecretExtraData() != null)
-                .map(upstream -> {
-                    CoreUpstream secretUpstream = new CoreUpstream();
-                    secretUpstream.setEndpoint(upstream.getEndpoint());
-                    secretUpstream.setKey(upstream.getKey());
-                    secretUpstream.setSecretExtraData(upstream.getSecretExtraData());
-                    return secretUpstream;
-                })
                 .collect(Collectors.toList());
 
         CoreModel model = CoreModel.empty();
@@ -103,13 +96,6 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .stream()
                 .flatMap(Collection::stream)
                 .filter(upstream -> upstream.getKey() != null || upstream.getSecretExtraData() != null)
-                .map(upstream -> {
-                    CoreUpstream secretUpstream = new CoreUpstream();
-                    secretUpstream.setEndpoint(upstream.getEndpoint());
-                    secretUpstream.setKey(upstream.getKey());
-                    secretUpstream.setSecretExtraData(upstream.getSecretExtraData());
-                    return secretUpstream;
-                })
                 .collect(Collectors.toList());
 
         CoreRoute route = new CoreRoute();

--- a/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
@@ -4,16 +4,20 @@ import com.epam.aidial.cfg.service.config.impl.storage.ConfigSource;
 import com.epam.aidial.cfg.service.config.impl.storage.ConfigUtils;
 import com.epam.aidial.cfg.service.config.transfer.ConfigTransferLock;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
 import com.epam.aidial.core.config.CoreModel;
 import com.epam.aidial.core.config.CoreResourceAuthSettings;
+import com.epam.aidial.core.config.CoreRoute;
 import com.epam.aidial.core.config.CoreToolSet;
 import com.epam.aidial.core.config.CoreUpstream;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +53,20 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
         secretConfig.setModels(models);
 
+        LinkedHashMap<String, CoreRoute> routes = config.getRoutes().entrySet()
+                .stream()
+                .map(e -> Pair.of(e.getKey(), mapRoute(e.getValue())))
+                .filter(p -> CollectionUtils.isNotEmpty(p.getValue().getUpstreams()))
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (a, b) -> a, LinkedHashMap::new));
+        secretConfig.setRoutes(routes);
+
+        Map<String, CoreApplication> applications = config.getApplications().entrySet()
+                .stream()
+                .map(e -> Pair.of(e.getKey(), mapApplication(e.getValue())))
+                .filter(p -> MapUtils.isNotEmpty(p.getValue().getRoutes()))
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+        secretConfig.setApplications(applications);
+
         Map<String, CoreToolSet> toolsets = config.getToolsets().entrySet()
                 .stream()
                 .map(e -> Pair.of(e.getKey(), mapToolSet(e.getValue())))
@@ -64,12 +82,53 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .map(CoreModel::getUpstreams)
                 .stream()
                 .flatMap(Collection::stream)
-                .filter(upstream -> upstream.getKey() != null)
+                .filter(upstream -> upstream.getKey() != null || upstream.getSecretExtraData() != null)
+                .map(upstream -> {
+                    CoreUpstream secretUpstream = new CoreUpstream();
+                    secretUpstream.setEndpoint(upstream.getEndpoint());
+                    secretUpstream.setKey(upstream.getKey());
+                    secretUpstream.setSecretExtraData(upstream.getSecretExtraData());
+                    return secretUpstream;
+                })
                 .collect(Collectors.toList());
 
         CoreModel model = CoreModel.empty();
         model.setUpstreams(upstreams);
         return model;
+    }
+
+    private CoreRoute mapRoute(CoreRoute value) {
+        List<CoreUpstream> upstreams = Optional.ofNullable(value)
+                .map(CoreRoute::getUpstreams)
+                .stream()
+                .flatMap(Collection::stream)
+                .filter(upstream -> upstream.getKey() != null || upstream.getSecretExtraData() != null)
+                .map(upstream -> {
+                    CoreUpstream secretUpstream = new CoreUpstream();
+                    secretUpstream.setEndpoint(upstream.getEndpoint());
+                    secretUpstream.setKey(upstream.getKey());
+                    secretUpstream.setSecretExtraData(upstream.getSecretExtraData());
+                    return secretUpstream;
+                })
+                .collect(Collectors.toList());
+
+        CoreRoute route = new CoreRoute();
+        route.setUpstreams(upstreams);
+        return route;
+    }
+
+    private CoreApplication mapApplication(CoreApplication value) {
+        LinkedHashMap<String, CoreRoute> routes = Optional.ofNullable(value)
+                .map(CoreApplication::getRoutes)
+                .stream()
+                .flatMap(map -> map.entrySet().stream())
+                .map(e -> Pair.of(e.getKey(), mapRoute(e.getValue())))
+                .filter(p -> CollectionUtils.isNotEmpty(p.getValue().getUpstreams()))
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (a, b) -> a, LinkedHashMap::new));
+
+        CoreApplication app = new CoreApplication();
+        app.setRoutes(routes);
+        return app;
     }
 
     private CoreToolSet mapToolSet(CoreToolSet value) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImpl.java
@@ -98,7 +98,7 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .filter(upstream -> upstream.getKey() != null || upstream.getSecretExtraData() != null)
                 .collect(Collectors.toList());
 
-        CoreRoute route = new CoreRoute();
+        CoreRoute route = CoreRoute.empty();
         route.setUpstreams(upstreams);
         return route;
     }
@@ -112,7 +112,7 @@ public class ConfigExportServiceSecuredImpl implements ConfigExportService {
                 .filter(p -> CollectionUtils.isNotEmpty(p.getValue().getUpstreams()))
                 .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (a, b) -> a, LinkedHashMap::new));
 
-        CoreApplication app = new CoreApplication();
+        CoreApplication app = CoreApplication.empty();
         app.setRoutes(routes);
         return app;
     }

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
@@ -21,7 +21,6 @@ public class ConfigUtils {
         return secretConfig;
     }
 
-
     public static void removeSecrets(Config config) {
         config.setKeys(Map.of());
 

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
@@ -7,7 +7,6 @@ import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class ConfigUtils {
 
@@ -15,22 +14,36 @@ public class ConfigUtils {
         Config secretConfig = new Config();
         secretConfig.setKeys(config.getKeys());
         secretConfig.setModels(config.getModels());
+        secretConfig.setRoutes(config.getRoutes());
+        secretConfig.setApplications(config.getApplications());
         secretConfig.setToolsets(config.getToolsets());
         return secretConfig;
     }
 
+
     public static void removeSecrets(Config config) {
         config.setKeys(Map.of());
+
         config.getModels().forEach((key, model) -> {
-            if (model.getUpstreams() == null) {
-                return;
-            }
-            List<CoreUpstream> upstreams = model.getUpstreams()
-                    .stream()
-                    .filter(upstream -> upstream.getKey() == null)
-                    .collect(Collectors.toList());
-            model.setUpstreams(upstreams);
+            removeSecretsFromUpstreams(model.getUpstreams());
         });
+
+        if (MapUtils.isNotEmpty(config.getRoutes())) {
+            config.getRoutes().forEach((key, route) -> {
+                removeSecretsFromUpstreams(route.getUpstreams());
+            });
+        }
+
+        if (MapUtils.isNotEmpty(config.getApplications())) {
+            config.getApplications().forEach((key, application) -> {
+                if (MapUtils.isNotEmpty(application.getRoutes())) {
+                    application.getRoutes().forEach((routeKey, route) -> {
+                        removeSecretsFromUpstreams(route.getUpstreams());
+                    });
+                }
+            });
+        }
+
         config.getToolsets().forEach((key, toolset) -> {
             var authSettings = toolset.getAuthSettings();
             if (authSettings == null) {
@@ -38,6 +51,15 @@ public class ConfigUtils {
             }
             toolset.getAuthSettings().setClientSecret(null);
         });
+    }
+
+    private static void removeSecretsFromUpstreams(List<CoreUpstream> coreUpstreamList) {
+        if (CollectionUtils.isNotEmpty(coreUpstreamList)) {
+            for (CoreUpstream upstream : coreUpstreamList) {
+                upstream.setKey(null);
+                upstream.setSecretExtraData(null);
+            }
+        }
     }
 
     public static void removeEmptyCollections(Config config) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/impl/storage/ConfigUtils.java
@@ -7,6 +7,7 @@ import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ConfigUtils {
 
@@ -25,12 +26,12 @@ public class ConfigUtils {
         config.setKeys(Map.of());
 
         config.getModels().forEach((key, model) -> {
-            removeSecretsFromUpstreams(model.getUpstreams());
+            model.setUpstreams(removeUpstreamsWithSecrets(model.getUpstreams()));
         });
 
         if (MapUtils.isNotEmpty(config.getRoutes())) {
             config.getRoutes().forEach((key, route) -> {
-                removeSecretsFromUpstreams(route.getUpstreams());
+                route.setUpstreams(removeUpstreamsWithSecrets(route.getUpstreams()));
             });
         }
 
@@ -38,7 +39,7 @@ public class ConfigUtils {
             config.getApplications().forEach((key, application) -> {
                 if (MapUtils.isNotEmpty(application.getRoutes())) {
                     application.getRoutes().forEach((routeKey, route) -> {
-                        removeSecretsFromUpstreams(route.getUpstreams());
+                        route.setUpstreams(removeUpstreamsWithSecrets(route.getUpstreams()));
                     });
                 }
             });
@@ -53,13 +54,13 @@ public class ConfigUtils {
         });
     }
 
-    private static void removeSecretsFromUpstreams(List<CoreUpstream> coreUpstreamList) {
+    private static List<CoreUpstream> removeUpstreamsWithSecrets(List<CoreUpstream> coreUpstreamList) {
         if (CollectionUtils.isNotEmpty(coreUpstreamList)) {
-            for (CoreUpstream upstream : coreUpstreamList) {
-                upstream.setKey(null);
-                upstream.setSecretExtraData(null);
-            }
+            return coreUpstreamList.stream()
+                    .filter(upstream -> (upstream.getKey() == null && upstream.getSecretExtraData() == null))
+                    .collect(Collectors.toList());
         }
+        return coreUpstreamList;
     }
 
     public static void removeEmptyCollections(Config config) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
@@ -96,7 +96,7 @@ public class ConfigTransfer {
         JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
         return outputStream -> {
             try {
-                prettyJsonMapper.writer().withDefaultPrettyPrinter().writeValue(outputStream, versionedConfig);
+                prettyJsonMapper.writeValue(outputStream, versionedConfig);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to export core config.", e);
             }

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
@@ -54,7 +54,6 @@ public class ConfigTransfer {
     private final ConfigMapper configMapper;
     private final ObjectMapper jsonMapper = JsonMapperConfiguration.createJsonMapper();
     private final ObjectMapper prettyJsonMapper = JsonMapperConfiguration.createPrettyJsonMapper();
-    private final ObjectMapper coreJsonMapper = JsonMapperConfiguration.createCoreJsonMapper();
     private final ConfigExportProperties properties;
     private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final List<CoreConfigNormalizer> normalizers;
@@ -97,7 +96,7 @@ public class ConfigTransfer {
         JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
         return outputStream -> {
             try {
-                coreJsonMapper.writer().withDefaultPrettyPrinter().writeValue(outputStream, versionedConfig);
+                prettyJsonMapper.writer().withDefaultPrettyPrinter().writeValue(outputStream, versionedConfig);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to export core config.", e);
             }

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/ConfigTransfer.java
@@ -54,6 +54,7 @@ public class ConfigTransfer {
     private final ConfigMapper configMapper;
     private final ObjectMapper jsonMapper = JsonMapperConfiguration.createJsonMapper();
     private final ObjectMapper prettyJsonMapper = JsonMapperConfiguration.createPrettyJsonMapper();
+    private final ObjectMapper coreJsonMapper = JsonMapperConfiguration.createCoreJsonMapper();
     private final ConfigExportProperties properties;
     private final VersionAwareFieldFilter versionAwareFieldFilter;
     private final List<CoreConfigNormalizer> normalizers;
@@ -96,7 +97,7 @@ public class ConfigTransfer {
         JsonNode versionedConfig = versionAwareFieldFilter.filterForTargetVersion(fullCoreConfig);
         return outputStream -> {
             try {
-                prettyJsonMapper.writeValue(outputStream, versionedConfig);
+                coreJsonMapper.writer().withDefaultPrettyPrinter().writeValue(outputStream, versionedConfig);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to export core config.", e);
             }

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ApplicationExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ApplicationExporter.java
@@ -5,6 +5,7 @@ import com.epam.aidial.cfg.domain.model.Application;
 import com.epam.aidial.cfg.domain.model.ExportComponentInfo;
 import com.epam.aidial.cfg.domain.model.ExportConfigComponentType;
 import com.epam.aidial.cfg.domain.model.ExportFormat;
+import com.epam.aidial.cfg.domain.model.Upstream;
 import com.epam.aidial.cfg.domain.model.source.ApplicationEndpointsSource;
 import com.epam.aidial.cfg.domain.model.source.ApplicationSchemaSource;
 import com.epam.aidial.cfg.domain.service.ApplicationService;
@@ -12,6 +13,7 @@ import com.epam.aidial.cfg.model.ExportRequest;
 import com.epam.aidial.cfg.model.FullExportRequest;
 import com.epam.aidial.cfg.model.SelectedItemsExportRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -70,6 +72,7 @@ public class ApplicationExporter {
     private Collection<Application> getApplicationsWithRemovedDependencies(FullExportRequest fullExportRequest) {
         return getValidApplications(fullExportRequest).stream()
                 .map(app -> removeDependency(app, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
+                .map(app -> removeSecretData(app, fullExportRequest.isAddSecrets()))
                 .toList();
     }
 
@@ -84,6 +87,7 @@ public class ApplicationExporter {
                         componentsByName.get(application.getDeployment().getName()).getDependencies(),
                         selectedItemsExportRequest.getExportFormat())
                 )
+                .map(application -> removeSecretData(application, selectedItemsExportRequest.isAddSecrets()))
                 .filter(app -> isValidApplication(app, selectedItemsExportRequest))
                 .toList();
     }
@@ -108,4 +112,17 @@ public class ApplicationExporter {
         return selectedItemsExportRequest.getExportFormat() != CORE || application.getValidityState().isValid();
     }
 
+    private Application removeSecretData(Application application, boolean addSecrets) {
+        if (!addSecrets && CollectionUtils.isNotEmpty(application.getRoutes())) {
+            application.getRoutes().forEach(route -> {
+                if (CollectionUtils.isNotEmpty(route.getUpstreams())) {
+                    for (Upstream upstream : route.getUpstreams()) {
+                        upstream.setKey(null);
+                        upstream.setSecretExtraData(null);
+                    }
+                }
+            });
+        }
+        return application;
+    }
 }

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
@@ -86,7 +86,7 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
         return publicModels;
     }
 
-    private Map<String, CoreRoute> getRoutes(Map<String, CoreRoute> publicRoutes, Map<String, CoreRoute> secretRoutes) {
+    private void mergeRoutes(Map<String, CoreRoute> publicRoutes, Map<String, CoreRoute> secretRoutes) {
         for (Map.Entry<String, CoreRoute> entry : secretRoutes.entrySet()) {
             String routeName = entry.getKey();
             CoreRoute secretRoute = entry.getValue();
@@ -101,6 +101,10 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
             }
             publicRoute.setUpstreams(mergedUpstreams);
         }
+    }
+
+    private Map<String, CoreRoute> getRoutes(Map<String, CoreRoute> publicRoutes, Map<String, CoreRoute> secretRoutes) {
+        mergeRoutes(publicRoutes, secretRoutes);
         return publicRoutes;
     }
 
@@ -117,21 +121,7 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
                     publicRoutes = new LinkedHashMap<>();
                     publicApp.setRoutes(publicRoutes);
                 }
-
-                for (Map.Entry<String, CoreRoute> routeEntry : secretAppRoutes.entrySet()) {
-                    String routeName = routeEntry.getKey();
-                    CoreRoute secretRoute = routeEntry.getValue();
-                    CoreRoute publicRoute = publicRoutes.computeIfAbsent(routeName, k -> new CoreRoute());
-
-                    List<CoreUpstream> mergedUpstreams = new ArrayList<>();
-                    if (publicRoute.getUpstreams() != null) {
-                        mergedUpstreams.addAll(publicRoute.getUpstreams());
-                    }
-                    if (secretRoute.getUpstreams() != null) {
-                        mergedUpstreams.addAll(secretRoute.getUpstreams());
-                    }
-                    publicRoute.setUpstreams(mergedUpstreams);
-                }
+                mergeRoutes(publicRoutes, secretAppRoutes);
             }
         }
         return publicApps;

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
@@ -3,14 +3,18 @@ package com.epam.aidial.cfg.service.config.transfer.exporter;
 import com.epam.aidial.cfg.configuration.logging.LogExecution;
 import com.epam.aidial.cfg.service.config.impl.storage.ConfigSource;
 import com.epam.aidial.core.config.Config;
+import com.epam.aidial.core.config.CoreApplication;
 import com.epam.aidial.core.config.CoreModel;
 import com.epam.aidial.core.config.CoreResourceAuthSettings;
+import com.epam.aidial.core.config.CoreRoute;
 import com.epam.aidial.core.config.CoreToolSet;
 import com.epam.aidial.core.config.CoreUpstream;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -52,6 +56,12 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
         Map<String, CoreModel> models = getModels(optionalMap(publicConfig.getModels()), optionalMap(secretConfig.getModels()));
         publicConfig.setModels(models);
 
+        LinkedHashMap<String, CoreRoute> routes = new LinkedHashMap<>(getRoutes(optionalMap(publicConfig.getRoutes()), optionalMap(secretConfig.getRoutes())));
+        publicConfig.setRoutes(routes);
+
+        Map<String, CoreApplication> applications = getApplications(optionalMap(publicConfig.getApplications()), optionalMap(secretConfig.getApplications()));
+        publicConfig.setApplications(applications);
+
         Map<String, CoreToolSet> toolSets = getToolSets(optionalMap(publicConfig.getToolsets()), optionalMap(secretConfig.getToolsets()));
         publicConfig.setToolsets(toolSets);
 
@@ -74,6 +84,56 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
             publicModel.setUpstreams(mergedUpstreams);
         }
         return publicModels;
+    }
+
+    private Map<String, CoreRoute> getRoutes(Map<String, CoreRoute> publicRoutes, Map<String, CoreRoute> secretRoutes) {
+        for (Map.Entry<String, CoreRoute> entry : secretRoutes.entrySet()) {
+            String routeName = entry.getKey();
+            CoreRoute secretRoute = entry.getValue();
+            CoreRoute publicRoute = publicRoutes.computeIfAbsent(routeName, k -> new CoreRoute());
+
+            List<CoreUpstream> mergedUpstreams = new ArrayList<>();
+            if (publicRoute.getUpstreams() != null) {
+                mergedUpstreams.addAll(publicRoute.getUpstreams());
+            }
+            if (secretRoute.getUpstreams() != null) {
+                mergedUpstreams.addAll(secretRoute.getUpstreams());
+            }
+            publicRoute.setUpstreams(mergedUpstreams);
+        }
+        return publicRoutes;
+    }
+
+    private Map<String, CoreApplication> getApplications(Map<String, CoreApplication> publicApps, Map<String, CoreApplication> secretApps) {
+        for (Map.Entry<String, CoreApplication> entry : secretApps.entrySet()) {
+            String appName = entry.getKey();
+            CoreApplication secretApp = entry.getValue();
+            CoreApplication publicApp = publicApps.computeIfAbsent(appName, k -> new CoreApplication());
+
+            if (MapUtils.isNotEmpty(secretApp.getRoutes())) {
+                LinkedHashMap<String, CoreRoute> publicRoutes = publicApp.getRoutes();
+                if (publicRoutes == null) {
+                    publicRoutes = new LinkedHashMap<>();
+                    publicApp.setRoutes(publicRoutes);
+                }
+
+                for (Map.Entry<String, CoreRoute> routeEntry : secretApp.getRoutes().entrySet()) {
+                    String routeName = routeEntry.getKey();
+                    CoreRoute secretRoute = routeEntry.getValue();
+                    CoreRoute publicRoute = publicRoutes.computeIfAbsent(routeName, k -> new CoreRoute());
+
+                    List<CoreUpstream> mergedUpstreams = new ArrayList<>();
+                    if (publicRoute.getUpstreams() != null) {
+                        mergedUpstreams.addAll(publicRoute.getUpstreams());
+                    }
+                    if (secretRoute.getUpstreams() != null) {
+                        mergedUpstreams.addAll(secretRoute.getUpstreams());
+                    }
+                    publicRoute.setUpstreams(mergedUpstreams);
+                }
+            }
+        }
+        return publicApps;
     }
 
     private Map<String, CoreToolSet> getToolSets(Map<String, CoreToolSet> publicToolSets, Map<String, CoreToolSet> secretToolSets) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/CoreConfigRetrieverSecuredImpl.java
@@ -110,14 +110,15 @@ public class CoreConfigRetrieverSecuredImpl implements CoreConfigRetriever {
             CoreApplication secretApp = entry.getValue();
             CoreApplication publicApp = publicApps.computeIfAbsent(appName, k -> new CoreApplication());
 
-            if (MapUtils.isNotEmpty(secretApp.getRoutes())) {
+            var secretAppRoutes = secretApp.getRoutes();
+            if (MapUtils.isNotEmpty(secretAppRoutes)) {
                 LinkedHashMap<String, CoreRoute> publicRoutes = publicApp.getRoutes();
                 if (publicRoutes == null) {
                     publicRoutes = new LinkedHashMap<>();
                     publicApp.setRoutes(publicRoutes);
                 }
 
-                for (Map.Entry<String, CoreRoute> routeEntry : secretApp.getRoutes().entrySet()) {
+                for (Map.Entry<String, CoreRoute> routeEntry : secretAppRoutes.entrySet()) {
                     String routeName = routeEntry.getKey();
                     CoreRoute secretRoute = routeEntry.getValue();
                     CoreRoute publicRoute = publicRoutes.computeIfAbsent(routeName, k -> new CoreRoute());

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ModelExporter.java
@@ -63,13 +63,13 @@ public class ModelExporter {
                     ExportConfigComponent component = componentsByName.get(model.getDeployment().getName());
                     return removeDependency(model, component.getDependencies(), selectedItemsExportRequest.getExportFormat());
                 })
-                .map(model -> removeUpstreamKey(model, addSecrets))
+                .map(model -> removeSecretData(model, addSecrets))
                 .toList();
     }
 
     private Collection<Model> getModels(FullExportRequest fullExportRequest) {
         return modelService.getAllOrderedByDisplayNameAscDisplayVersionAscNameAsc().stream()
-                .map(model -> removeUpstreamKey(model, fullExportRequest.isAddSecrets()))
+                .map(model -> removeSecretData(model, fullExportRequest.isAddSecrets()))
                 .map(model -> removeDependency(model, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
                 .toList();
     }
@@ -112,7 +112,7 @@ public class ModelExporter {
         return model;
     }
 
-    private Model removeUpstreamKey(Model model, boolean addSecrets) {
+    private Model removeSecretData(Model model, boolean addSecrets) {
         List<Upstream> upstreams = model.getUpstreams();
         if (CollectionUtils.isNotEmpty(upstreams) && !addSecrets) {
             for (Upstream upstream : upstreams) {

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ModelExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/ModelExporter.java
@@ -117,6 +117,7 @@ public class ModelExporter {
         if (CollectionUtils.isNotEmpty(upstreams) && !addSecrets) {
             for (Upstream upstream : upstreams) {
                 upstream.setKey(null);
+                upstream.setSecretExtraData(null);
             }
         }
         return model;

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/RouteExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/RouteExporter.java
@@ -91,6 +91,7 @@ public class RouteExporter {
         if (CollectionUtils.isNotEmpty(upstreams) && !addSecrets) {
             for (Upstream upstream : upstreams) {
                 upstream.setKey(null);
+                upstream.setSecretExtraData(null);
             }
         }
         return route;

--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/RouteExporter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/exporter/RouteExporter.java
@@ -55,13 +55,13 @@ public class RouteExporter {
         return routeService.getAllByDeploymentNamesOrderByDisplayNameAscNameAsc(componentsByName.keySet()).stream()
                 .map(route -> removeDependency(route, componentsByName.get(route.getDeployment().getName()).getDependencies(),
                         selectedItemsExportRequest.getExportFormat()))
-                .map(route -> removeUpstreamKey(route, addSecrets))
+                .map(route -> removeSecretData(route, addSecrets))
                 .toList();
     }
 
     private Collection<Route> getRoutes(FullExportRequest fullExportRequest) {
         return routeService.getAllOrderedByDisplayNameAscNameAsc().stream()
-                .map(route -> removeUpstreamKey(route, fullExportRequest.isAddSecrets()))
+                .map(route -> removeSecretData(route, fullExportRequest.isAddSecrets()))
                 .map(route -> removeDependency(route, fullExportRequest.getComponentTypes(), fullExportRequest.getExportFormat()))
                 .toList();
     }
@@ -86,7 +86,7 @@ public class RouteExporter {
         return route;
     }
 
-    private Route removeUpstreamKey(Route route, boolean addSecrets) {
+    private Route removeSecretData(Route route, boolean addSecrets) {
         List<Upstream> upstreams = route.getUpstreams();
         if (CollectionUtils.isNotEmpty(upstreams) && !addSecrets) {
             for (Upstream upstream : upstreams) {

--- a/src/main/java/com/epam/aidial/core/config/CoreApplication.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreApplication.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -129,11 +130,47 @@ public class CoreApplication extends Deployment {
         }
 
         public enum McpConfigDelivery {
-            HEADER, META;
+            HEADER, META
         }
     }
 
     public CoreApplication() {
         super();
+    }
+
+    @JsonIgnore
+    public static CoreApplication empty() {
+        CoreApplication coreApplication = new CoreApplication();
+
+        coreApplication.setApplicationProperties(null);
+        coreApplication.setApplicationTypeSchemaId(null);
+        coreApplication.setAuthor(null);
+        coreApplication.setCreatedAt(null);
+        coreApplication.setDefaults(null);
+        coreApplication.setDependencies(null);
+        coreApplication.setDescription(null);
+        coreApplication.setDescriptionKeywords(null);
+        coreApplication.setDisplayName(null);
+        coreApplication.setDisplayVersion(null);
+        coreApplication.setEditorUrl(null);
+        coreApplication.setEndpoint(null);
+        coreApplication.setFeatures(null);
+        coreApplication.setForwardAuthToken(null);
+        coreApplication.setFunction(null);
+        coreApplication.setIconUrl(null);
+        coreApplication.setInputAttachmentTypes(null);
+        coreApplication.setInterceptors(null);
+        coreApplication.setMaxInputAttachments(null);
+        coreApplication.setMaxRetryAttempts(null);
+        coreApplication.setMcp(null);
+        coreApplication.setName(null);
+        coreApplication.setUserRoles(null);
+        coreApplication.setReference(null);
+        coreApplication.setResponsesDefaults(null);
+        coreApplication.setResponsesEndpoint(null);
+        coreApplication.setRoutes(null);
+        coreApplication.setUpdatedAt(null);
+        coreApplication.setViewerUrl(null);
+        return coreApplication;
     }
 }

--- a/src/main/java/com/epam/aidial/core/config/CoreRoute.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreRoute.java
@@ -1,6 +1,7 @@
 package com.epam.aidial.core.config;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
@@ -73,5 +74,23 @@ public class CoreRoute extends RoleBasedEntity {
          * List of JSON paths in the HTTP response body.
          */
         private List<String> responseBody = List.of();
+    }
+
+    @JsonIgnore
+    public static CoreRoute empty() {
+        CoreRoute coreRoute = new CoreRoute();
+
+        coreRoute.setResponse(null);
+        coreRoute.setPaths(null);
+        coreRoute.setMethods(null);
+        coreRoute.setUpstreams(null);
+        coreRoute.setMaxRetryAttempts(0);
+        coreRoute.setOrder(0);
+        coreRoute.setPermissions(null);
+        coreRoute.setAttachmentPaths(null);
+        coreRoute.setName(null);
+        coreRoute.setUserRoles(null);
+        coreRoute.setRewritePath(false);
+        return coreRoute;
     }
 }

--- a/src/main/java/com/epam/aidial/core/config/CoreRoute.java
+++ b/src/main/java/com/epam/aidial/core/config/CoreRoute.java
@@ -22,7 +22,7 @@ public class CoreRoute extends RoleBasedEntity {
     @JsonAlias({"response", "dial:response"})
     private Response response;
     @JsonAlias({"rewritePath", "dial:rewritePath"})
-    private boolean rewritePath;
+    private Boolean rewritePath = false;
     @JsonAlias({"paths", "dial:paths"})
     private List<Pattern> paths = List.of();
     @JsonAlias({"methods", "dial:methods"})
@@ -33,13 +33,13 @@ public class CoreRoute extends RoleBasedEntity {
      * Indicated max retry attempts to route a single user request.
      */
     @JsonAlias({"maxRetryAttempts", "dial:maxRetryAttempts"})
-    private int maxRetryAttempts = 1;
+    private Integer maxRetryAttempts = 1;
     /**
      * Determines the order the route is resolved. The lower value means the higher priority.
      */
     @Min(value = 0, message = "Order can't be negative")
     @JsonAlias({"order", "dial:order"})
-    private int order = Integer.MAX_VALUE; // 0.32.0
+    private Integer order = Integer.MAX_VALUE; // 0.32.0
     @JsonAlias({"permissions", "dial:permissions"})
     private Set<ResourceAccessType> permissions = Set.of(); // 0.32.0
     @JsonAlias({"attachmentPaths", "dial:attachmentPaths"})
@@ -84,13 +84,13 @@ public class CoreRoute extends RoleBasedEntity {
         coreRoute.setPaths(null);
         coreRoute.setMethods(null);
         coreRoute.setUpstreams(null);
-        coreRoute.setMaxRetryAttempts(0);
-        coreRoute.setOrder(0);
+        coreRoute.setMaxRetryAttempts(null);
+        coreRoute.setOrder(null);
         coreRoute.setPermissions(null);
         coreRoute.setAttachmentPaths(null);
         coreRoute.setName(null);
         coreRoute.setUserRoles(null);
-        coreRoute.setRewritePath(false);
+        coreRoute.setRewritePath(null);
         return coreRoute;
     }
 }

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -932,7 +932,6 @@ public abstract class ConfigTransferFunctionalTest {
         Set<ExportConfigComponentType> componentTypes = Set.of(ExportConfigComponentType.APPLICATION, ExportConfigComponentType.APPLICATION_TYPE_SCHEMA);
         FullExportRequest request = new FullExportRequest();
         request.setExportFormat(ExportFormat.ADMIN);
-        request.setAddSecrets(true);
         request.setComponentTypes(componentTypes);
 
         // Routes
@@ -997,7 +996,7 @@ public abstract class ConfigTransferFunctionalTest {
                                     var upstream = upstreams.get(0);
                                     var expectedUpstream = route1.getUpstreams().get(0);
                                     Assertions.assertThat(upstream.getEndpoint()).isEqualTo(expectedUpstream.getEndpoint());
-                                    Assertions.assertThat(upstream.getKey()).isEqualTo(expectedUpstream.getKey());
+                                    Assertions.assertThat(upstream.getKey()).isNull();
                                     Assertions.assertThat(upstream.getExtraData()).isEqualTo(expectedUpstream.getExtraData());
                                 });
                     });
@@ -1584,7 +1583,6 @@ public abstract class ConfigTransferFunctionalTest {
         );
         FullExportRequest request = new FullExportRequest();
         request.setExportFormat(ExportFormat.CORE);
-        request.setAddSecrets(true);
         request.setComponentTypes(componentTypes);
 
         // When
@@ -1632,7 +1630,7 @@ public abstract class ConfigTransferFunctionalTest {
                                     Assertions.assertThat(upstreams).isNotEmpty();
                                     var upstream = upstreams.get(0);
                                     Assertions.assertThat(upstream.getEndpoint()).isEqualTo("http://upstream.com/api");
-                                    Assertions.assertThat(upstream.getKey()).isEqualTo("123");
+                                    Assertions.assertThat(upstream.getKey()).isEqualTo(null);
                                     Assertions.assertThat(upstream.getExtraData()).isEqualTo("{\"field1\":\"val1\"}");
                                 });
                     });

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -2855,6 +2855,56 @@ public abstract class ConfigTransferFunctionalTest {
         Assertions.assertThat(importConfigPreview).usingRecursiveAssertion().isEqualTo(expectedPreview);
     }
 
+    @Test
+    void testExport_CoreFormatDoesNotLeakSecrets() throws IOException {
+        ModelDto modelDto = createModelDto("1");
+        UpstreamDto upstream = new UpstreamDto();
+        upstream.setEndpoint("https://api.example.com");
+        upstream.setKey("secret-api-key-12345");
+        upstream.setSecretExtraData("{\"apiSecret\":\"super-secret-value\"}");
+        upstream.setExtraData("{\"timeout\":30}");
+        modelDto.setUpstreams(List.of(upstream));
+        modelFacade.createModel(modelDto);
+
+        RouteDto routeDto = createRouteDto("1");
+        UpstreamDto routeUpstream = new UpstreamDto();
+        routeUpstream.setEndpoint("https://route.example.com");
+        routeUpstream.setKey("route-secret-key");
+        routeUpstream.setSecretExtraData("{\"token\":\"route-secret-token\"}");
+        routeUpstream.setExtraData("{\"retries\":3}");
+        routeDto.setUpstreams(List.of(routeUpstream));
+        routeFacade.createRoute(routeDto);
+
+        FullExportRequest request = new FullExportRequest();
+        request.setExportFormat(ExportFormat.CORE);
+        request.setComponentTypes(Set.of(ExportConfigComponentType.MODEL, ExportConfigComponentType.ROUTE));
+
+        StreamingResponseBody streamingResponseBody = configTransfer.exportConfig(request);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        streamingResponseBody.writeTo(outputStream);
+        String exportedJson = outputStream.toString();
+
+        Config result = jsonMapper.readValue(exportedJson, Config.class);
+        Assertions.assertThat(result).isNotNull().satisfies(config -> {
+            Assertions.assertThat(config.getModels()).containsKey("model1");
+            Assertions.assertThat(config.getModels().get("model1").getUpstreams()).hasSize(1);
+            var modelUpstream = config.getModels().get("model1").getUpstreams().get(0);
+            Assertions.assertThat(modelUpstream.getKey()).isNull();
+            Assertions.assertThat(modelUpstream.getSecretExtraData()).isNull();
+            Assertions.assertThat(modelUpstream.getEndpoint()).isEqualTo("https://api.example.com");
+            Assertions.assertThat(modelUpstream.getExtraData()).isEqualTo("{\"timeout\":30}");
+
+            Assertions.assertThat(config.getRoutes()).containsKey("test_route1");
+            Assertions.assertThat(config.getRoutes().get("test_route1").getUpstreams()).hasSize(1);
+            var routeUpstreamResult = config.getRoutes().get("test_route1").getUpstreams().get(0);
+            Assertions.assertThat(routeUpstreamResult.getKey()).isNull();
+            Assertions.assertThat(routeUpstreamResult.getSecretExtraData()).isNull();
+            Assertions.assertThat(routeUpstreamResult.getEndpoint()).isEqualTo("https://route.example.com");
+            Assertions.assertThat(routeUpstreamResult.getExtraData()).isEqualTo("{\"retries\":3}");
+        });
+    }
+
     @SneakyThrows
     private InputStream getZipInputStreamWithAdminConfig() {
         byte[] data;

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -932,6 +932,7 @@ public abstract class ConfigTransferFunctionalTest {
         Set<ExportConfigComponentType> componentTypes = Set.of(ExportConfigComponentType.APPLICATION, ExportConfigComponentType.APPLICATION_TYPE_SCHEMA);
         FullExportRequest request = new FullExportRequest();
         request.setExportFormat(ExportFormat.ADMIN);
+        request.setAddSecrets(true);
         request.setComponentTypes(componentTypes);
 
         // Routes
@@ -1583,6 +1584,7 @@ public abstract class ConfigTransferFunctionalTest {
         );
         FullExportRequest request = new FullExportRequest();
         request.setExportFormat(ExportFormat.CORE);
+        request.setAddSecrets(true);
         request.setComponentTypes(componentTypes);
 
         // When
@@ -2895,9 +2897,9 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(modelUpstream.getEndpoint()).isEqualTo("https://api.example.com");
             Assertions.assertThat(modelUpstream.getExtraData()).isEqualTo("{\"timeout\":30}");
 
-            Assertions.assertThat(config.getRoutes()).containsKey("test_route1");
-            Assertions.assertThat(config.getRoutes().get("test_route1").getUpstreams()).hasSize(1);
-            var routeUpstreamResult = config.getRoutes().get("test_route1").getUpstreams().get(0);
+            Assertions.assertThat(config.getRoutes()).containsKey("route1");
+            Assertions.assertThat(config.getRoutes().get("route1").getUpstreams()).hasSize(1);
+            var routeUpstreamResult = config.getRoutes().get("route1").getUpstreams().get(0);
             Assertions.assertThat(routeUpstreamResult.getKey()).isNull();
             Assertions.assertThat(routeUpstreamResult.getSecretExtraData()).isNull();
             Assertions.assertThat(routeUpstreamResult.getEndpoint()).isEqualTo("https://route.example.com");

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ConfigTransferFunctionalTest.java
@@ -1718,7 +1718,21 @@ public abstract class ConfigTransferFunctionalTest {
             Assertions.assertThat(config.getModels()).isNotEmpty().containsOnlyKeys("testModel1")
                     .satisfies(models ->
                             Assertions.assertThat(models.get("testModel1").getInterceptors()).containsExactlyInAnyOrder("testInterceptor1"));
-            Assertions.assertThat(config.getRoutes()).isNotEmpty().containsOnlyKeys("test_route1");
+            Assertions.assertThat(config.getRoutes()).isNotEmpty().containsOnlyKeys("test_route1")
+                    .satisfies(routes -> {
+                        var route = routes.get("test_route1");
+                        Assertions.assertThat(route.getUpstreams()).isNotEmpty();
+                        route.getUpstreams().forEach(upstream -> {
+                            if (addSecrets) {
+                                Assertions.assertThat(upstream.getKey()).isNotNull();
+                                Assertions.assertThat(upstream.getSecretExtraData()).isNotNull();
+                            } else {
+                                Assertions.assertThat(upstream.getKey()).isNull();
+                                Assertions.assertThat(upstream.getSecretExtraData()).isNull();
+                            }
+                            Assertions.assertThat(upstream.getExtraData()).isNotNull();
+                        });
+                    });
             Assertions.assertThat(config.getInterceptors()).isNotEmpty().containsOnlyKeys("testInterceptor1");
             Assertions.assertThat(config.getApplicationTypeSchemas()).isNotEmpty().containsOnlyKeys("https://test-schema-id.example");
         });

--- a/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
@@ -71,10 +71,13 @@ class ConfigExportServiceSecuredImplTest {
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
         verify(configTransferLock).withWriteLock(any());
 
-        // Verify regular config has secrets removed
+        // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
+        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
+        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
+        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
+        assertNotNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getEndpoint());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
@@ -99,10 +102,13 @@ class ConfigExportServiceSecuredImplTest {
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
         verify(configTransferLock).withWriteLock(any());
 
-        // Verify regular config has secrets removed
+        // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
+        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
+        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
+        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
+        assertNotNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getEndpoint());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
@@ -157,12 +163,14 @@ class ConfigExportServiceSecuredImplTest {
         verify(configSource).writeConfig(configCaptor.capture(), eq(createResources));
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
 
-        // Verify regular config has secrets removed
+        // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
+        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
+        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
-        assertTrue(regularConfig.getModels().get("model2").getUpstreams().isEmpty());
+        assertEquals(1, regularConfig.getModels().get("model2").getUpstreams().size());
+        assertNull(regularConfig.getModels().get("model2").getUpstreams().get(0).getKey());
 
         // Verify secured config contains only secrets
         Config secretConfig = securedConfigCaptor.getValue();

--- a/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
@@ -71,7 +71,7 @@ class ConfigExportServiceSecuredImplTest {
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
         verify(configTransferLock).withWriteLock(any());
 
-        // Verify regular config has secrets removed but upstreams preserved
+        // Verify regular config has secrets removed
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
         assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
@@ -100,7 +100,7 @@ class ConfigExportServiceSecuredImplTest {
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
         verify(configTransferLock).withWriteLock(any());
 
-        // Verify regular config has secrets removed but upstreams preserved
+        // Verify regular config has secrets removed
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
         assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
@@ -159,7 +159,7 @@ class ConfigExportServiceSecuredImplTest {
         verify(configSource).writeConfig(configCaptor.capture(), eq(createResources));
         verify(securedConfigSource).writeConfig(securedConfigCaptor.capture(), eq(createResources));
 
-        // Verify regular config has secrets removed but upstreams preserved
+        // Verify regular config has secrets removed
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
         assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());

--- a/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
@@ -74,6 +74,7 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
+        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
@@ -102,6 +103,7 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
+        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
@@ -160,9 +162,11 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
+        assertTrue(regularConfig.getModels().get("model1").getUpstreams().isEmpty());
         assertEquals(1, regularConfig.getModels().get("model2").getUpstreams().size());
+        assertEquals("https://api2.example.com", regularConfig.getModels().get("model2").getUpstreams().get(0).getEndpoint());
         assertNull(regularConfig.getModels().get("model2").getUpstreams().get(0).getKey());
+        assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
         Config secretConfig = securedConfigCaptor.getValue();

--- a/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/export/ConfigExportServiceSecuredImplTest.java
@@ -74,16 +74,13 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
-        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
-        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
-        assertNotNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getEndpoint());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
         Config secretConfig = securedConfigCaptor.getValue();
         assertNotNull(secretConfig.getKeys().get("key1"));
         assertEquals("upstream-key-1", secretConfig.getModels().get("model1").getUpstreams().get(0).getKey());
+        assertEquals("secretExtraData", secretConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
         assertEquals("client-secret-1", secretConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
         assertTrue(secretConfig.getRoles().isEmpty());
     }
@@ -105,16 +102,13 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
-        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
-        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
-        assertNotNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getEndpoint());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
 
         // Verify secured config contains only secrets
         Config secretConfig = securedConfigCaptor.getValue();
         assertNotNull(secretConfig.getKeys().get("key1"));
         assertEquals("upstream-key-1", secretConfig.getModels().get("model1").getUpstreams().get(0).getKey());
+        assertEquals("secretExtraData", secretConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
         assertEquals("client-secret-1", secretConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
         assertTrue(secretConfig.getRoles().isEmpty());
     }
@@ -166,8 +160,6 @@ class ConfigExportServiceSecuredImplTest {
         // Verify regular config has secrets removed but upstreams preserved
         Config regularConfig = configCaptor.getValue();
         assertTrue(regularConfig.getKeys().isEmpty());
-        assertEquals(1, regularConfig.getModels().get("model1").getUpstreams().size());
-        assertNull(regularConfig.getModels().get("model1").getUpstreams().get(0).getKey());
         assertNull(regularConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
         assertEquals(1, regularConfig.getModels().get("model2").getUpstreams().size());
         assertNull(regularConfig.getModels().get("model2").getUpstreams().get(0).getKey());
@@ -176,8 +168,7 @@ class ConfigExportServiceSecuredImplTest {
         Config secretConfig = securedConfigCaptor.getValue();
         assertNotNull(secretConfig.getKeys().get("key1"));
         assertEquals("upstream-key-1", secretConfig.getModels().get("model1").getUpstreams().get(0).getKey());
-        assertEquals("upstream-key-2", secretConfig.getModels().get("model2").getUpstreams().get(0).getKey());
-        assertEquals("https://api2.example.com", secretConfig.getModels().get("model2").getUpstreams().get(0).getEndpoint());
+        assertEquals("secretExtraData", secretConfig.getModels().get("model1").getUpstreams().get(0).getSecretExtraData());
         assertEquals("client-secret-1", secretConfig.getToolsets().get("toolset1").getAuthSettings().getClientSecret());
         assertTrue(secretConfig.getRoles().isEmpty());
     }
@@ -243,6 +234,7 @@ class ConfigExportServiceSecuredImplTest {
         CoreUpstream upstream = new CoreUpstream();
         upstream.setEndpoint("https://api.example.com");
         upstream.setKey("upstream-key-1");
+        upstream.setSecretExtraData("secretExtraData");
         model.setUpstreams(List.of(upstream));
         
         models.put("model1", model);
@@ -273,7 +265,6 @@ class ConfigExportServiceSecuredImplTest {
         
         CoreUpstream upstream2 = new CoreUpstream();
         upstream2.setEndpoint("https://api2.example.com");
-        upstream2.setKey("upstream-key-2");
         model2.setUpstreams(List.of(upstream2));
         
         config.getModels().put("model2", model2);

--- a/src/test/java/com/epam/aidial/core/config/CoreObjectsEmptyMethodContractTest.java
+++ b/src/test/java/com/epam/aidial/core/config/CoreObjectsEmptyMethodContractTest.java
@@ -21,6 +21,16 @@ class CoreObjectsEmptyMethodContractTest {
     }
 
     @Test
+    void coreApplicationEmpty_shouldHaveAllFieldsNull() throws IllegalAccessException {
+        assertAllFieldsNull(CoreApplication.empty());
+    }
+
+    @Test
+    void coreRouteEmpty_shouldHaveAllFieldsNull() throws IllegalAccessException {
+        assertAllFieldsNull(CoreRoute.empty());
+    }
+
+    @Test
     void coreResourceAuthSettingsEmpty_shouldHaveAllFieldsNull() throws IllegalAccessException {
         assertAllFieldsNull(CoreResourceAuthSettings.empty());
     }

--- a/src/test/resources/import_for_export.json
+++ b/src/test/resources/import_for_export.json
@@ -206,6 +206,7 @@
           "endpoint": "http://upstream1.example.com",
           "key": "upstream-key-1",
           "extraData": "{\"custom\":\"data1\"}",
+          "secretExtraData": "{\"secret\":\"value1\"}",
           "weight": 1,
           "tier": 0
         },
@@ -213,6 +214,7 @@
           "endpoint": "http://upstream2.example.com",
           "key": "upstream-key-2",
           "extraData": "{\"custom\":\"data2\"}",
+          "secretExtraData": "{\"secret\":\"value2\"}",
           "weight": 2,
           "tier": 1
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1064

### Description of changes
Fixed an issue where secret extra data in Upstream was included in exported output even when the "Include secrets" option was disabled.
<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.