### PR TITLE
chore: bump jackson-databind from 2.21.2 to 2.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     testImplementation 'org.testcontainers:influxdb'
 
     constraints {
-        implementation ('com.fasterxml.jackson.core:jackson-databind:2.21.4') {
+        implementation ('com.fasterxml.jackson.core:jackson-databind:2.21.5') {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.22') {

--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,9 @@ dependencies {
     testImplementation 'org.testcontainers:influxdb'
 
     constraints {
+        implementation ('com.fasterxml.jackson.core:jackson-databind:2.21.4') {
+            because("previous versions have vulnerabilities")
+        }
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.22') {
             because("previous versions have vulnerabilities")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     testImplementation 'org.testcontainers:influxdb'
 
     constraints {
-        implementation ('com.fasterxml.jackson.core:jackson-databind:2.21.5') {
+        implementation ('com.fasterxml.jackson.core:jackson-databind:2.21.4') {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.22') {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Bumps `jackson-databind` from `2.21.2` to `2.21.4` to address two HIGH severity vulnerabilities:

- **CVE-2026-54512** — PolymorphicTypeValidator bypass via generic type parameters
- **CVE-2026-54513** — Array subtype allowlist bypass in BasicPolymorphicTypeValidator `allowIfSubTypeIsArray`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.