### PR TITLE
chore: docker upgrade p11-kit and p11-kit-trust from 0.26.1-r0 to 0.26.2-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /app
 
 # TODO: remove explicit openssl pinning once eclipse-temurin:21-jre-alpine ships with libcrypto3>=3.5.7-r0 (CVE-2026-45447)
 RUN apk add --no-cache 'libcrypto3=3.5.7-r0' 'libssl3=3.5.7-r0' 'openssl=3.5.7-r0' && \
+    apk add --no-cache 'p11-kit>=0.26.2-r0' 'p11-kit-trust>=0.26.2-r0' && \
     apk add --no-cache bash && \
     adduser -u 1001 -D appuser && \
     mkdir -p /app/data && \


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes
* Resolved Trivy findings by updating vulnerable Alpine packages.
<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.