### PR TITLE
feat: allow text-classification inference container as toolset source (#1994, #2502)

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/client/dto/InferenceDeploymentInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/InferenceDeploymentInfoDto.java
@@ -1,11 +1,21 @@
 package com.epam.aidial.cfg.client.dto;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
+@Getter
+@Setter
 @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class InferenceDeploymentInfoDto extends DeploymentInfoDto {
-    public InferenceDeploymentInfoDto(String id, String name, String url) {
+    private InferenceTask inferenceTask;
+
+    public InferenceDeploymentInfoDto(String id, String name, String url, InferenceTask inferenceTask) {
         super(id, name, url);
+        this.inferenceTask = inferenceTask;
     }
 }
-

--- a/src/main/java/com/epam/aidial/cfg/client/dto/InferenceTask.java
+++ b/src/main/java/com/epam/aidial/cfg/client/dto/InferenceTask.java
@@ -1,0 +1,12 @@
+package com.epam.aidial.cfg.client.dto;
+
+/**
+ * System-detected inference task category reported by the deployment manager for an inference
+ * deployment. Deserialized case-insensitively from the lowercase wire values
+ * ({@code text_classification} / {@code text_generation} / {@code none}).
+ */
+public enum InferenceTask {
+    TEXT_CLASSIFICATION,
+    TEXT_GENERATION,
+    NONE
+}

--- a/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
+++ b/src/main/java/com/epam/aidial/cfg/domain/validator/ToolSetValidator.java
@@ -1,6 +1,8 @@
 package com.epam.aidial.cfg.domain.validator;
 
 import com.epam.aidial.cfg.client.dto.DeploymentInfoDto;
+import com.epam.aidial.cfg.client.dto.InferenceDeploymentInfoDto;
+import com.epam.aidial.cfg.client.dto.InferenceTask;
 import com.epam.aidial.cfg.client.dto.McpDeploymentInfoDto;
 import com.epam.aidial.cfg.domain.model.ToolSet;
 import com.epam.aidial.cfg.domain.model.source.ToolSetContainerSource;
@@ -106,8 +108,7 @@ public class ToolSetValidator {
     private void validateContainerSource(ToolSetContainerSource containerSource, String toolSetName) {
         String containerId = containerSource.getContainerId();
         DeploymentInfoDto deploymentInfo = deploymentManagerService.getById(containerId);
-        McpDeploymentInfoDto mcpDeploymentInfoDto = validateDeploymentType(deploymentInfo, toolSetName);
-        validateToolsetTransport(mcpDeploymentInfoDto, toolSetName);
+        validateDeploymentType(deploymentInfo, toolSetName);
         validateEndpointPath(containerSource.getCompletionEndpointPath(), toolSetName);
     }
 
@@ -119,12 +120,19 @@ public class ToolSetValidator {
         }
     }
 
-    private McpDeploymentInfoDto validateDeploymentType(DeploymentInfoDto deploymentInfo, String toolSetName) {
+    private void validateDeploymentType(DeploymentInfoDto deploymentInfo, String toolSetName) {
         if (deploymentInfo instanceof McpDeploymentInfoDto mcpDeploymentInfoDto) {
-            return mcpDeploymentInfoDto;
+            validateToolsetTransport(mcpDeploymentInfoDto, toolSetName);
+            return;
         }
-        log.warn("Toolset deployment type must be mcp. toolSetName: {}. deploymentInfo: {}", toolSetName, deploymentInfo);
-        throw new IllegalArgumentException("Toolset deployment type must be mcp. toolSetName: " + toolSetName);
+        if (deploymentInfo instanceof InferenceDeploymentInfoDto inferenceDeploymentInfoDto
+                && inferenceDeploymentInfoDto.getInferenceTask() == InferenceTask.TEXT_CLASSIFICATION) {
+            return;
+        }
+        log.warn("Toolset deployment must be an MCP container or a text-classification inference deployment. "
+                + "toolSetName: {}. deploymentInfo: {}", toolSetName, deploymentInfo);
+        throw new IllegalArgumentException("Toolset deployment must be an MCP container or a text-classification "
+                + "inference deployment. toolSetName: " + toolSetName);
     }
 
     private void validateEndpoint(String endpoint, String name) {

--- a/src/test/java/com/epam/aidial/cfg/domain/validator/ToolSetValidatorTest.java
+++ b/src/test/java/com/epam/aidial/cfg/domain/validator/ToolSetValidatorTest.java
@@ -1,5 +1,7 @@
 package com.epam.aidial.cfg.domain.validator;
 
+import com.epam.aidial.cfg.client.dto.InferenceDeploymentInfoDto;
+import com.epam.aidial.cfg.client.dto.InferenceTask;
 import com.epam.aidial.cfg.client.dto.InterceptorDeploymentInfoDto;
 import com.epam.aidial.cfg.client.dto.McpDeploymentInfoDto;
 import com.epam.aidial.cfg.domain.model.SecuredResource;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -223,7 +226,8 @@ public class ToolSetValidatorTest {
         // when/then
         assertThatThrownBy(() -> toolSetValidator.validateCreation(toolSet))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Toolset deployment type must be mcp. toolSetName: test-toolset");
+                .hasMessageStartingWith("Toolset deployment must be an MCP container or a text-classification "
+                        + "inference deployment. toolSetName: test-toolset");
     }
 
     @Test
@@ -241,7 +245,46 @@ public class ToolSetValidatorTest {
         // when/then
         assertThatThrownBy(() -> toolSetValidator.validateCreation(toolSet))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Toolset deployment type must be mcp. toolSetName: test-toolset");
+                .hasMessageStartingWith("Toolset deployment must be an MCP container or a text-classification "
+                        + "inference deployment. toolSetName: test-toolset");
+    }
+
+    @Test
+    void validateContainerSource_shouldNotThrowExceptionForTextClassificationInference() {
+        // given
+        SecuredResource deployment = new SecuredResource("test-toolset");
+        ToolSet toolSet = new ToolSet();
+        toolSet.setDeployment(deployment);
+        toolSet.setSource(new ToolSetContainerSource(TEST_CONTAINER_ID, TEST_CONTAINER_NAME, COMPLETION_PATH));
+
+        InferenceDeploymentInfoDto deploymentInfo = new InferenceDeploymentInfoDto();
+        deploymentInfo.setUrl("https://deployment.url");
+        deploymentInfo.setInferenceTask(InferenceTask.TEXT_CLASSIFICATION);
+        when(deploymentManagerService.getById(TEST_CONTAINER_ID)).thenReturn(deploymentInfo);
+
+        // when/then
+        assertThatNoException().isThrownBy(() -> toolSetValidator.validateCreation(toolSet));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = InferenceTask.class, names = {"TEXT_GENERATION", "NONE"})
+    void validateContainerSource_shouldThrowExceptionForNonClassificationInference(InferenceTask inferenceTask) {
+        // given
+        SecuredResource deployment = new SecuredResource("test-toolset");
+        ToolSet toolSet = new ToolSet();
+        toolSet.setDeployment(deployment);
+        toolSet.setSource(new ToolSetContainerSource(TEST_CONTAINER_ID, TEST_CONTAINER_NAME, COMPLETION_PATH));
+
+        InferenceDeploymentInfoDto deploymentInfo = new InferenceDeploymentInfoDto();
+        deploymentInfo.setUrl("https://deployment.url");
+        deploymentInfo.setInferenceTask(inferenceTask);
+        when(deploymentManagerService.getById(TEST_CONTAINER_ID)).thenReturn(deploymentInfo);
+
+        // when/then
+        assertThatThrownBy(() -> toolSetValidator.validateCreation(toolSet))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Toolset deployment must be an MCP container or a text-classification "
+                        + "inference deployment. toolSetName: test-toolset");
     }
 
     @Test


### PR DESCRIPTION
## What

`ToolSetValidator` rejected any container source whose backing deployment was not an MCP deployment (`Toolset deployment type must be mcp`). This blocked creating an MCP toolset from a **text-classification inference** container, which the frontend now offers (relates to #1994, #2502).

This change reads the `inferenceTask` reported by the deployment manager and accepts an inference deployment as a toolset container source **only** when its task is `text_classification`. MCP deployments keep their existing transport check; everything else (including inference `text_generation` / `none`) is still rejected.

## Changes

- Add `InferenceTask` enum (`text_classification` / `text_generation` / `none`) to the deployment-manager client DTOs. The primary Jackson mapper already enables `ACCEPT_CASE_INSENSITIVE_ENUMS`, so the lowercase wire values deserialize as-is (same as `McpTransport`).
- Add `inferenceTask` to `InferenceDeploymentInfoDto` (previously dropped via `ignoreUnknown`).
- Broaden `ToolSetValidator` container-source validation to accept MCP **or** text-classification inference deployments; update the error message accordingly.
- Tests: classification allowed; `text_generation` / `none` rejected; existing message assertions updated.

## Dependency

Requires the companion deployment-manager change that exposes `inferenceTask` on the internal `/api/internal/v1/deployments/{id}` endpoint (that endpoint currently omits it, so this validator would otherwise always read `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)