### PR TITLE
fix(VersionAwareFieldFilter): keep applications with routes when interfaces are stripped on export

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilter.java
+++ b/src/main/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilter.java
@@ -104,6 +104,7 @@ public class VersionAwareFieldFilter {
                 && !hasNonEmptyField(entity, "responses_endpoint")
                 && !hasNonEmptyField(entity, "applicationTypeSchemaId")
                 && !hasNonEmptyField(entity, "application_type_schema_id")
+                && !hasNonEmptyField(entity, "routes")
                 && (mcp == null || !hasNonEmptyField(mcp, "endpoint"));
     }
 

--- a/src/main/resources/core-config-schemas/schema-v0.46.0.json
+++ b/src/main/resources/core-config-schemas/schema-v0.46.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Core Config Schema v0.45.0",
+  "title": "Core Config Schema v0.46.0",
   "type": "object",
   "properties": {
     "models": {

--- a/src/main/resources/db/migration/H2/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
+++ b/src/main/resources/db/migration/H2/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
@@ -1,0 +1,23 @@
+--Drop constraint
+alter table application_entity
+drop constraint if exists CHK_APPLICATION_ENTITY_ENDPOINT_APPLICATION_TYPE_SCHEMA_ID_MCP_ENDPOINT;
+
+-- Add new constraint allowing interfaces as an alternative routing configuration
+alter table application_entity add constraint CHK_APPLICATION_ENTITY_ENDPOINT_APPLICATION_TYPE_SCHEMA_ID_MCP_ENDPOINT
+check (
+    (
+        nullif(application_type_schema_id,'') is not null
+        and nullif(endpoint,'') is null
+        and nullif(mcp_endpoint,'') is null
+        and nullif(nullif(interfaces,''),'{}') is null
+    )
+    or
+    (
+        nullif(application_type_schema_id,'') is null
+        and (
+            nullif(endpoint,'') is not null
+            or nullif(mcp_endpoint,'') is not null
+            or nullif(nullif(interfaces,''),'{}') is not null
+        )
+    )
+);

--- a/src/main/resources/db/migration/MS_SQL_SERVER/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
+++ b/src/main/resources/db/migration/MS_SQL_SERVER/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
@@ -1,0 +1,24 @@
+--Drop constraint
+alter table application_entity
+drop constraint if exists chk_application_entity_endpoint_schema_mcp;
+
+-- Add new constraint allowing interfaces as an alternative routing configuration
+alter table application_entity
+add constraint chk_application_entity_endpoint_schema_mcp
+check (
+    (
+        application_type_schema_id is not null
+        and nullif(endpoint,'') is null
+        and nullif(mcp_endpoint,'') is null
+        and nullif(nullif(interfaces,''),'{}') is null
+    )
+    or
+    (
+        application_type_schema_id is null
+        and (
+            nullif(endpoint,'') is not null
+            or nullif(mcp_endpoint,'') is not null
+            or nullif(nullif(interfaces,''),'{}') is not null
+        )
+    )
+);

--- a/src/main/resources/db/migration/POSTGRES/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
+++ b/src/main/resources/db/migration/POSTGRES/V1.113__UpdateApplicationEndpointCheckConstraintForInterfaces.sql
@@ -1,0 +1,24 @@
+--Drop constraint
+alter table application_entity
+drop constraint if exists chk_application_entity_endpoint_schema_mcp;
+
+--Add new constraint allowing interfaces as an alternative routing configuration
+alter table application_entity
+add constraint chk_application_entity_endpoint_schema_mcp
+check (
+    (
+        application_type_schema_id is not null
+        and nullif(endpoint,'') is null
+        and nullif(mcp_endpoint,'') is null
+        and nullif(nullif(interfaces,''),'{}') is null
+    )
+    or
+    (
+        application_type_schema_id is null
+        and (
+            nullif(endpoint,'') is not null
+            or nullif(mcp_endpoint,'') is not null
+            or nullif(nullif(interfaces,''),'{}') is not null
+        )
+    )
+);

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/ApplicationFunctionalTest.java
@@ -8,6 +8,7 @@ import com.epam.aidial.cfg.domain.model.ToolSet;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationInfoDto;
+import com.epam.aidial.cfg.dto.DeploymentInterfaceDto;
 import com.epam.aidial.cfg.dto.EntitySyncStateDto;
 import com.epam.aidial.cfg.dto.EntitySyncStateStatusDto;
 import com.epam.aidial.cfg.dto.InterceptorDto;
@@ -98,6 +99,21 @@ public abstract class ApplicationFunctionalTest {
         Collection<ApplicationInfoDto> actualApplications = applicationFacade.getAllApplications();
 
         assertApp(actualApplications, List.of(createApplicationDtoWithEndpointAndLimits("1"), createApplicationDtoWithEndpointAndLimits("2")));
+    }
+
+    @Test
+    public void shouldSuccessfullyCreateAndGetApplicationWithInterfacesOnly() {
+        initRoles();
+
+        ApplicationDto applicationDto = createBaseApplicationDto("1");
+        DeploymentInterfaceDto chatInterface = new DeploymentInterfaceDto();
+        chatInterface.setBaseUrl("https://app.adapter.test.com");
+        applicationDto.setInterfaces(Map.of("openaiChatCompletions", chatInterface));
+        applicationFacade.createApplication(applicationDto);
+
+        ApplicationDto actual = applicationFacade.getApplication(applicationDto.getName());
+        Assertions.assertNull(actual.getEndpoint());
+        Assertions.assertEquals(applicationDto.getInterfaces(), actual.getInterfaces());
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
+++ b/src/test/java/com/epam/aidial/cfg/functional/tests/InterceptorFunctionalTest.java
@@ -7,6 +7,7 @@ import com.epam.aidial.cfg.configuration.JsonMapperConfiguration;
 import com.epam.aidial.cfg.domain.service.DeploymentManagerService;
 import com.epam.aidial.cfg.dto.ApplicationDto;
 import com.epam.aidial.cfg.dto.ApplicationTypeSchemaDto;
+import com.epam.aidial.cfg.dto.DeploymentInterfaceDto;
 import com.epam.aidial.cfg.dto.EntitySyncStateDto;
 import com.epam.aidial.cfg.dto.EntitySyncStateStatusDto;
 import com.epam.aidial.cfg.dto.FeaturesDto;
@@ -101,6 +102,20 @@ public abstract class InterceptorFunctionalTest {
 
         Collection<InterceptorDto> actualInterceptors = interceptorFacade.getAllInterceptors();
         assertInterceptors(actualInterceptors, List.of(expected1, expected2));
+    }
+
+    @Test
+    public void shouldSuccessfullyCreateAndGetInterceptorWithInterfacesOnly() {
+        InterceptorDto interceptorDto = createInterceptorDto("1");
+        interceptorDto.setEndpoint(null);
+        DeploymentInterfaceDto chatInterface = new DeploymentInterfaceDto();
+        chatInterface.setBaseUrl("https://interceptor.adapter.test.com");
+        interceptorDto.setInterfaces(Map.of("openaiChatCompletions", chatInterface));
+        interceptorFacade.createInterceptor(interceptorDto);
+
+        InterceptorDto actual = interceptorFacade.getInterceptor(interceptorDto.getName());
+        Assertions.assertNull(actual.getEndpoint());
+        Assertions.assertEquals(interceptorDto.getInterfaces(), actual.getInterfaces());
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
+++ b/src/test/java/com/epam/aidial/cfg/service/config/transfer/VersionAwareFieldFilterTest.java
@@ -388,6 +388,35 @@ class VersionAwareFieldFilterTest {
         assertThat(result.get("models").has("m2")).isTrue();
     }
 
+    @Test
+    void filterForTargetVersion_applicationWithRoutesKeptWhenInterfacesStripped() throws IOException {
+        // given
+        mockRealSchema("0.45.0");
+        Config config = MAPPER.readValue("""
+                {
+                  "applications": {
+                    "app1": {
+                      "interfaces": {
+                        "openaiChatCompletions": {"base_url": "http://app.adapter"}
+                      },
+                      "routes": {
+                        "route1": {"paths": ["/v1/route"]}
+                      }
+                    }
+                  }
+                }
+                """, Config.class);
+
+        // when
+        JsonNode result = filter.filterForTargetVersion(config);
+
+        // then
+        JsonNode application = result.get("applications").get("app1");
+        assertThat(application).isNotNull();
+        assertThat(application.has("interfaces")).isFalse();
+        assertThat(application.get("routes").has("route1")).isTrue();
+    }
+
     private void mockRealSchema(String version) throws IOException {
         JsonNode schema = loadRealSchema(version);
         when(coreConfigVersionService.getVersionForExport()).thenReturn(version);

--- a/src/test/resources/import/import_configWithoutAssistants.json
+++ b/src/test/resources/import/import_configWithoutAssistants.json
@@ -26,6 +26,10 @@
         "system"
       ],
       "endpoint": "https://endpoint1/embeddings",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "https://model.adapter.test.com"},
+        "anthropicMessages": {"base_url": "https://model.adapter.test.com"}
+      },
       "responsesEndpoint": "http://model1/responses",
       "responsesDefaults": {
         "field": "skipped-value"
@@ -83,6 +87,9 @@
         "testRole1"
       ],
       "endpoint": "endpoint",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "https://app.adapter.test.com"}
+      },
       "responsesEndpoint": "http://application2/responses",
       "responsesDefaults": {
         "field": "skipped-value"
@@ -194,6 +201,9 @@
       "name": "testInterceptor1",
       "displayName": "Test Interceptor1",
       "endpoint": "https://endpoint.test.com/interceptor",
+      "interfaces": {
+        "openaiChatCompletions": {"base_url": "https://interceptor.adapter.test.com"}
+      },
       "userRoles": [
         "testRole1"
       ],

--- a/src/test/resources/import/import_preview.json
+++ b/src/test/resources/import/import_preview.json
@@ -348,6 +348,9 @@
         "name": "testInterceptor1",
         "displayName": "Test Interceptor1",
         "endpoint": "https://endpoint.test.com/interceptor",
+        "interfaces": {
+          "openaiChatCompletions": {"baseUrl": "https://interceptor.adapter.test.com"}
+        },
         "forwardAuthToken": false,
         "author": "test-author",
         "dependencies": [],
@@ -640,6 +643,10 @@
         "defaults": {
           "max_tokens": 8000
         },
+        "interfaces": {
+          "openaiChatCompletions": {"baseUrl": "https://model.adapter.test.com"},
+          "anthropicMessages": {"baseUrl": "https://model.adapter.test.com"}
+        },
         "interceptors": [
           "testInterceptor1"
         ],
@@ -930,6 +937,9 @@
         "endpoint": "endpoint",
         "source": {
           "$type": "endpoints"
+        },
+        "interfaces": {
+          "openaiChatCompletions": {"baseUrl": "https://app.adapter.test.com"}
         },
         "responsesEndpoint": "http://application2/responses",
         "responsesDefaults": {


### PR DESCRIPTION
### Applicable issues

<!-- Follow-up to #1085 (no standalone issue) -->
- follow-up to #1085

### Description of changes

Follow-up fixes and test improvements for the `interfaces` property support merged in #1085:

1. **`VersionAwareFieldFilter.hasNoRouting()` now checks the application-level `routes` field.** When exporting to Core < 0.46.0, the filter strips the unsupported `interfaces` map and drops deployments left without any routing. The check missed `routes`, so an application configured with `interfaces` + `routes` (and no `endpoint`/MCP — valid since #1085) was removed from the export entirely, even though its `routes` still provided valid routing. Added a regression test (`filterForTargetVersion_applicationWithRoutesKeptWhenInterfacesStripped`) that fails without the fix.

2. **Fixed `application_entity` check constraint for interfaces-only applications (V1.113 for H2/Postgres/MSSQL).** The constraint required `endpoint`, `application_type_schema_id` or `mcp_endpoint`, so an interfaces-only application accepted by `ApplicationValidator` failed on insert with `DataIntegrityViolationException` (uncovered by the new functional test below). `interfaces` is now an accepted alternative for endpoints-based applications; empty values (`''`/`'{}'`) are treated as absent.

3. **Test data & coverage parity** (per reviewer checklist from #1081):
   - `import_configWithoutAssistants.json` / `import_preview.json` now include `interfaces` for a model, an endpoints-based application, and an interceptor, exercising the import-preview pipeline with the new field.
   - Added interfaces-only create+get functional tests for Application and Interceptor, mirroring the existing Model test — verified on H2, Postgres and MSSQL (testcontainers).

4. **`schema-v0.46.0.json` title corrected** from "Core Config Schema v0.45.0" (copy-paste leftover) to "Core Config Schema v0.46.0", matching the convention of all other schema files. Cosmetic only — version resolution is filename-based.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)