### PR TITLE
fix: pin libexpat to 2.8.2-r0 to patch CVE-2026-56131/56407/56408

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
 # TODO: remove explicit openssl pinning once eclipse-temurin:21-jre-alpine ships with libcrypto3>=3.5.7-r0 (CVE-2026-45447)
+# TODO: remove explicit libexpat pinning once eclipse-temurin:21-jre-alpine ships with libexpat>=2.8.2-r0 (CVE-2026-56131/56407/56408)
 RUN apk add --no-cache 'libcrypto3=3.5.7-r0' 'libssl3=3.5.7-r0' 'openssl=3.5.7-r0' && \
     apk add --no-cache 'p11-kit>=0.26.2-r0' 'p11-kit-trust>=0.26.2-r0' && \
+    apk add --no-cache 'libexpat>=2.8.2-r0' && \
     apk add --no-cache bash && \
     adduser -u 1001 -D appuser && \
     mkdir -p /app/data && \


### PR DESCRIPTION
### Description of changes

Trivy flags 3 HIGH `libexpat` CVEs in the `eclipse-temurin:21-jre-alpine` base image, failing the `docker_build` check on **every open PR** (and `development` builds) since the vuln DB was updated on 2026-07-08:

| CVE | Severity | Installed | Fixed |
|---|---|---|---|
| CVE-2026-56131 | HIGH | 2.8.1-r0 | 2.8.2-r0 |
| CVE-2026-56407 | HIGH | 2.8.1-r0 | 2.8.2-r0 |
| CVE-2026-56408 | HIGH | 2.8.1-r0 | 2.8.2-r0 |

Pin `libexpat>=2.8.2-r0` in the runtime stage, matching the existing `openssl`/`p11-kit` pinning pattern from #1055 and #1075. The application jar itself is clean (0 vulnerabilities).

Verified locally: the full runtime `apk add` line resolves cleanly against the base image and upgrades `libexpat 2.8.1-r0 -> 2.8.2-r0` from `alpine/v3.23/main`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)