### PR TITLE
chore: bump postgresql from 42.7.11 to 42.7.12 and jackson-core to 2.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation 'info.picocli:picocli-spring-boot-starter:4.7.6'
 
     implementation 'com.h2database:h2'
-    implementation 'org.postgresql:postgresql:42.7.11'
+    implementation 'org.postgresql:postgresql:42.7.12'
     implementation 'com.microsoft.sqlserver:mssql-jdbc:12.10.2.jre11'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'
@@ -166,6 +166,9 @@ dependencies {
 
     constraints {
         implementation ('com.fasterxml.jackson.core:jackson-databind:2.22.0') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation ('com.fasterxml.jackson.core:jackson-core:2.22.1') {
             because("previous versions have vulnerabilities")
         }
         implementation ('org.apache.tomcat.embed:tomcat-embed-core:11.0.22') {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Fixes Trivy-reported HIGH vulnerabilities found during the release build's docker image scan ([run](https://github.com/epam/ai-dial-admin-backend/actions/runs/29921380637/job/88929205358)):

| Library | Installed | Advisory | Fixed in |
|---|---|---|---|
| `org.postgresql:postgresql` | 42.7.11 | [CVE-2026-54291](https://avd.aquasec.com/nvd/cve-2026-54291) — SCRAM-SHA-256-PLUS MITM downgrade | 42.7.12 |
| `com.fasterxml.jackson.core:jackson-core` (transitive via `jackson-databind`) | 2.22.0 | [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) — async parser `maxNumberLength` bypass | 2.22.1 |

Changes:
- Bumped `org.postgresql:postgresql` from `42.7.11` to `42.7.12`.
- Added a `jackson-core:2.22.1` constraint alongside the existing `jackson-databind` constraint, since `jackson-core` is pulled in transitively.

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.