### PR TITLE
chore: bump netty-codec-http2 to 4.2.16.Final, netty-codec-compression to 4.2.16.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,10 @@ dependencies {
         implementation ('commons-fileupload:commons-fileupload:1.6.0') {
             because("previous versions have vulnerabilities")
         }
-        implementation ('io.netty:netty-codec-http2:4.2.15.Final') {
+        implementation('io.netty:netty-codec-http2:4.2.16.Final') {
+            because("previous versions have vulnerabilities")
+        }
+        implementation('io.netty:netty-codec-compression:4.2.16.Final') {
             because("previous versions have vulnerabilities")
         }
         implementation ('io.netty:netty-handler:4.2.15.Final') {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.