### PR TITLE
fix: distinct-on-tag queries returning values outside the requested time range on InfluxDB 2

### DIFF
--- a/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/FluxQueryBuilder.java
@@ -282,10 +282,18 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
         var rangePart = FluxConditionPartBuilder.createRangePart(query.getWhere(), true);
         var measurementPart = FluxConditionPartBuilder.createFilterPart(MEASUREMENT_COLUMN, tableDeclaration.getSource().getMeasurement());
         var filterPart = FluxConditionPartBuilder.createFilterPart(query.getWhere());
+        // group-by-(tag,_field) |> first() instead of keep|>group|>distinct: the distinct chain
+        // is rewritten by the InfluxDB 2 planner into an index-backed tag-values read that
+        // applies the time range only at shard granularity, returning tag values outside the
+        // requested range. Grouping reads actual points (time-accurate) and collapses each
+        // group to a single row; _field is part of the key because storage cannot group fields
+        // of different value types together. unique() then dedups the per-field rows.
+        var groupPart = SimpleFluxBuilder.createGroupPart(List.of(tagName, FIELD_COLUMN));
+        var firstPart = SimpleFluxBuilder.createFirstPart();
         var keepPart = SimpleFluxBuilder.createKeepPart(List.of(tagName));
         var ungroupPart = SimpleFluxBuilder.createUngroupPart();
-        var distinctPart = SimpleFluxBuilder.createDistinctPart(tagName);
-        var renamePart = SimpleFluxBuilder.createRenamePart(Map.of(VALUE_COLUMN, outerColumnName));
+        var uniquePart = SimpleFluxBuilder.createUniquePart(tagName);
+        var renamePart = SimpleFluxBuilder.createRenamePart(Map.of(tagName, outerColumnName));
         var sortPart = buildSortPart(query.getOrderBy());
         var limitPart = SimpleFluxBuilder.createLimitPart(query);
 
@@ -294,9 +302,11 @@ public class FluxQueryBuilder extends AbstractQueryBuilder<FluxQueryContext, Inf
                 .add(rangePart)
                 .add(measurementPart)
                 .add(filterPart)
+                .add(groupPart)
+                .add(firstPart)
                 .add(keepPart)
                 .add(ungroupPart)
-                .add(distinctPart)
+                .add(uniquePart)
                 .add(sortPart)
                 .add(renamePart)
                 .add(limitPart)

--- a/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
+++ b/src/main/java/com/epam/aidial/metric/service/influx/SimpleFluxBuilder.java
@@ -71,6 +71,14 @@ public class SimpleFluxBuilder {
         return "|> distinct(column: %s)".formatted(quote(columnName));
     }
 
+    public static String createFirstPart() {
+        return "|> first()";
+    }
+
+    public static String createUniquePart(String columnName) {
+        return "|> unique(column: %s)".formatted(quote(columnName));
+    }
+
     public static String createRenamePart(Map<String, String> mapping) {
         if (MapUtils.isEmpty(mapping)) {
             return "";

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxContainerTest.java
@@ -74,10 +74,7 @@ public abstract class AbstractInfluxContainerTest {
     // mcp_analytics record with a UUID-shaped project_id, timestamped outside
     // every other test's time range. Used by UuidLiteralFilterTests to verify
     // that a UUID-shaped string literal is accepted as a filter value against a
-    // STRING tag column. Lives on mcp_analytics (not analytics) because Flux's
-    // distinct(column:) doesn't always respect the upstream range() filter — a
-    // UUID project_id added to analytics would leak into pre-existing distinct
-    // tests like distinctWithContainsFilter.
+    // STRING tag column.
     private static final String UUID_PROJECT_ID = "a36d8a75-aa7d-4185-a84d-566066cf91f2";
     private static final List<String> UUID_PROJECT_RECORDS = List.of(
             // 2026-03-15T10:00:00Z
@@ -118,7 +115,16 @@ public abstract class AbstractInfluxContainerTest {
             "analytics,deployment=gpt-4,model=gpt-4,project_id=proj1 "
             + "user_hash=\"user3\",price=0.15,deployment_price=0.12,"
             + "prompt_tokens=400i,completion_tokens=200i "
-            + "1773410400000000000"
+            + "1773410400000000000",
+            // OUTSIDE (after range): 2026-03-13T15:00:00Z. The only record with this
+            // deployment/project_id — guards against distinct-on-tag returning values
+            // outside the requested time range (InfluxDB 2 rewrote keep|>group|>distinct
+            // into an index read with shard-granularity time bounds; FluxQueryBuilder
+            // uses group-by-tag|>first() instead of distinct() to avoid that).
+            "analytics,deployment=leak-probe,model=leak-probe,project_id=proj9 "
+            + "user_hash=\"user9\",price=0.01,deployment_price=0.01,"
+            + "prompt_tokens=10i,completion_tokens=5i "
+            + "1773414000000000000"
     );
 
     protected static final List<String> TEST_RECORDS;
@@ -198,6 +204,23 @@ public abstract class AbstractInfluxContainerTest {
             assertThat(columnNames(data)).containsExactly("deployment", "project_id", "price");
             assertThat(data.getData()).containsExactly(
                     List.of("gpt-3.5", "proj1", 0.02)
+            );
+        }
+
+        @Test
+        void distinctDeployments() throws Exception {
+            var data = queryFromJson("""
+                    {
+                      "distinct": true,
+                      "expressions": ["deployment"],
+                      "from": "analytics",
+                      "where": {%s}
+                    }""".formatted(TIME_FILTER));
+
+            assertThat(columnNames(data)).containsExactly("deployment");
+            assertThat(data.getData()).containsExactlyInAnyOrder(
+                    List.of("gpt-3.5"),
+                    List.of("gpt-4")
             );
         }
 

--- a/src/test/java/com/epam/aidial/metric/service/AbstractInfluxPerformanceTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/AbstractInfluxPerformanceTest.java
@@ -93,6 +93,9 @@ public abstract class AbstractInfluxPerformanceTest {
     private static final String Q_DISTINCT_USER_COUNT = """
             {"$type":"json","query":{"expressions":["count()"],"from":{"distinct":"true","expressions":["user_hash"],"from":"analytics","where":{"$and":[{"$gte":{"left":"_time","right":"'2026-04-13T12:40:00.403Z'"}},{"$lt":{"left":"_time","right":"'2026-04-15T12:40:00.403Z'"}}]}}}}""";
 
+    private static final String Q_DISTINCT_DEPLOYMENTS = """
+            {"$type":"json","query":{"distinct":"true","expressions":["deployment"],"from":"analytics","where":{"$and":[{"$gte":{"left":"_time","right":"'2026-04-13T12:40:00.403Z'"}},{"$lt":{"left":"_time","right":"'2026-04-15T12:40:00.403Z'"}}]}}}""";
+
     private static final String Q_TOTAL_COUNT = """
             {"$type":"json","query":{"expressions":["count()"],"from":"analytics","where":{"$and":[{"$gte":{"left":"_time","right":"'2026-04-13T12:40:00.404Z'"}},{"$lt":{"left":"_time","right":"'2026-04-15T12:40:00.404Z'"}}]}}}""";
 
@@ -120,6 +123,11 @@ public abstract class AbstractInfluxPerformanceTest {
     @Test
     void distinctUserCount() throws Exception {
         measure("distinct_user_count", Q_DISTINCT_USER_COUNT);
+    }
+
+    @Test
+    void distinctDeployments() throws Exception {
+        measure("distinct_deployments", Q_DISTINCT_DEPLOYMENTS);
     }
 
     @Test

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryBuilderTest.java
@@ -293,10 +293,11 @@ class FluxQueryBuilderTest {
                 from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 
@@ -327,10 +328,11 @@ class FluxQueryBuilderTest {
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["deployment"] == "dep_value")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 
@@ -360,10 +362,12 @@ class FluxQueryBuilderTest {
                 from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "a"})""");
+                |> unique(column: "deployment")
+                |> rename(columns: {deployment: "a"})""");
         assertThat(actual.getColumnNames()).isEqualTo(List.of("a"));
     }
 

--- a/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
+++ b/src/test/java/com/epam/aidial/metric/service/influx/FluxQueryIntegrationTest.java
@@ -319,10 +319,11 @@ class FluxQueryIntegrationTest {
                 from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 
@@ -341,10 +342,11 @@ class FluxQueryIntegrationTest {
                 from(bucket: "analytics-realtime")
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 
@@ -363,10 +365,11 @@ class FluxQueryIntegrationTest {
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["deployment"] == "dep_value")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 
@@ -388,10 +391,11 @@ class FluxQueryIntegrationTest {
                 |> range(start: 2025-02-11T15:12:00Z, stop: 2025-02-11T16:20:00Z)
                 |> filter(fn: (r) => r["_measurement"] == "analytics")
                 |> filter(fn: (r) => r["deployment"] == "dep_value")
+                |> group(columns: ["deployment", "_field"])
+                |> first()
                 |> keep(columns: ["deployment"])
                 |> group()
-                |> distinct(column: "deployment")
-                |> rename(columns: {_value: "deployment"})""");
+                |> unique(column: "deployment")""");
         assertThat(result.getColumnNames()).isEqualTo(List.of("deployment"));
     }
 


### PR DESCRIPTION
### Applicable issues
<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #1102

### Description of changes

**Bug:** distinct queries on a tag column (e.g. `SELECT DISTINCT deployment FROM analytics WHERE _time >= ... AND _time < ...`) returned tag values from records **outside the requested time range** on InfluxDB 2. The generated Flux chain `keep |> group |> distinct(column: <tag>)` is the same pattern `schema.tagValues()` uses, and the InfluxDB 2 planner rewrites it into an index-backed tag-values read that applies time bounds only at shard granularity. InfluxDB 3 (SQL) was not affected; distinct on *field* columns was not affected.

**Fix:** `FluxQueryBuilder.buildDistinctQueryForTag` now generates `group(columns: [<tag>, "_field"]) |> first() |> keep |> group() |> unique`. Grouping reads actual points, so the time range is exact; `first()` collapses each group to one row before flattening; the final `unique` dedups only one row per tag-value × field. `_field` must be in the group key because storage cannot group int and float field types together.

**Performance** (influx2 container, 100k records / 48h, 10 measured runs): 9.1s mean — vs 34s for a naive `unique()` over the flattened stream, and 70s for the pre-existing group-by-deployment rollup on the same data. The old index read was faster only because it ignored the time range; correct results must touch each in-range series since the analytics schema has per-request tags (`trace_id`, `response_id`).

**Tests:**
- New out-of-range `leak-probe` fixture record in `AbstractInfluxContainerTest` — regression guard; `distinctDeployments` and `notContainsFilterCaseInsensitive` failed on influx2 before the fix, pass after, on both engines.
- New `distinctDeployments` container test (plain distinct tag + time range only).
- New `distinct_deployments` query in the performance suite.
- Flux string expectations updated in `FluxQueryBuilderTest` / `FluxQueryIntegrationTest`.

Both container suites (`InfluxContainerTest`, `Influx3ContainerTest`) pass.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)