### PR TITLE
chore: add `iconUrl` to applications listing

### DIFF
--- a/src/main/java/com/epam/aidial/cfg/dto/ApplicationInfoDto.java
+++ b/src/main/java/com/epam/aidial/cfg/dto/ApplicationInfoDto.java
@@ -14,6 +14,7 @@ public class ApplicationInfoDto {
     private String endpoint;
     private String displayName;
     private String displayVersion;
+    private String iconUrl;
     private String description;
     private Boolean forwardAuthToken;
     private List<String> inputAttachmentTypes;


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Added the `iconUrl` field to `ApplicationInfoDto` so it is returned in the applications listing endpoint, consistent with other deployment DTOs (`ModelDto`, `AddonDto`, `AssistantDto`, etc.) that already expose `iconUrl`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
