### PR TITLE
chore: bump openssl/libcrypto3/libssl3 from 3.5.7-r0 to 3.5.8-r0 (#1134)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN gradle --no-daemon clean bootJar
 FROM eclipse-temurin:21-jre-alpine AS runtime
 WORKDIR /app
 
-# TODO: remove explicit openssl pinning once eclipse-temurin:21-jre-alpine ships with libcrypto3>=3.5.7-r0 (CVE-2026-45447)
+# TODO: remove explicit openssl pinning once eclipse-temurin:21-jre-alpine ships with libcrypto3>=3.5.8-r0 (CVE-2026-14456)
 # TODO: remove explicit libexpat pinning once eclipse-temurin:21-jre-alpine ships with libexpat>=2.8.2-r0 (CVE-2026-56131/56407/56408)
-RUN apk add --no-cache 'libcrypto3=3.5.7-r0' 'libssl3=3.5.7-r0' 'openssl=3.5.7-r0' && \
+RUN apk add --no-cache 'libcrypto3=3.5.8-r0' 'libssl3=3.5.8-r0' 'openssl=3.5.8-r0' && \
     apk add --no-cache 'p11-kit>=0.26.2-r0' 'p11-kit-trust>=0.26.2-r0' && \
     apk add --no-cache 'libexpat>=2.8.2-r0' && \
     apk add --no-cache bash && \


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.